### PR TITLE
🐛Bug fix [iOS] - No margin for text watermark when using BottomCenter position

### DIFF
--- a/ios/RCTImageMarker/RCTImageMarker.m
+++ b/ios/RCTImageMarker/RCTImageMarker.m
@@ -244,7 +244,7 @@ UIImage * markerImgWithTextByPostion    (UIImage *image, NSString* text, MarkerP
             break;
         case BottomCenter:
             posX = (w-(size.width))/2;
-            posY = h-size.height;
+            posY = h-size.height - margin;
             break;
         case BottomRight:
             posX = w-(size.width) - margin;


### PR DESCRIPTION
Subtracting the `margin` value when calculating the y-position for `BottomCenter`.

All other position values add a margin so `BottomCenter` should be no different 🤷‍♂️.

Thanks for the great lib btw! 🤗