### PR TITLE
fix(android): remove deprecated jcenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,6 @@ android {
 repositories {
   mavenCentral()
   google()
-  jcenter()
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")


### PR DESCRIPTION
The latest version of this library does not build on Android with react-native version `0.82.1`
This PR is addressing the issue by removing JCenter from repository declaration.

JCenter has been sunset since February 2021 and is no longer recommended. The project already uses mavenCentral() and google() which provide all necessary dependencies.