### PR TITLE
fix: propagate image loading errors via rejecter on iOS

### DIFF
--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -396,6 +396,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 print("Loaded images: \(images)")
             } catch {
                 print("Failed to load images, error: \(error).")
+                rejecter("error", error.localizedDescription, error)
             }
         }
     }
@@ -416,6 +417,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 print("Loaded images: \(images), waterImages: \(String(describing: waterImages))")
             } catch {
                 print("Failed to load images, error: \(error).")
+                rejecter("error", error.localizedDescription, error)
             }
         }
     }


### PR DESCRIPTION
fix #258