### PR TITLE
fix(ios): guard against nil markOpts and request to prevent EXC_BREAKPOINT crashes

### DIFF
--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -34,8 +34,12 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                                 continuation.resume(throwing: error)
                             }
                         } else {
-                            let request = RCTConvert.nsurlRequest(img.src)
-                            imageLoader.loadImage(with: request!, size: CGSizeMake(img.rnSrc.width, img.rnSrc.height), scale: img.rnSrc.scale, clipped: false, resizeMode: RCTResizeMode.cover) { progress, total in
+                            guard let request = RCTConvert.nsurlRequest(img.src) else {
+                                let error = NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create URL request for image: \(img.uri)"])
+                                continuation.resume(throwing: error)
+                                return
+                            }
+                            imageLoader.loadImage(with: request, size: CGSizeMake(img.rnSrc.width, img.rnSrc.height), scale: img.rnSrc.scale, clipped: false, resizeMode: RCTResizeMode.cover) { progress, total in
                                 print("Loading image: \(img.uri) progress: \(progress) total\(total)")
                             } partialLoad: { loadedImage in
                                 //
@@ -383,15 +387,18 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     
     @objc(markWithText:resolver:rejecter:)
     func mark(withText opts: [AnyHashable: Any], resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-        let markOpts = MarkTextOptions.checkTextParams(opts, rejecter: rejecter)
-        if markOpts === nil {
+        guard let markOpts = MarkTextOptions.checkTextParams(opts, rejecter: rejecter) else {
             rejecter(ErrorDomainEnum.PARAMS_INVALID.rawValue, "opts invalid", nil)
+            return
         }
         Task(priority: .userInitiated) {
             do {
-                let images = try await loadImages(with: [(markOpts?.backgroundImage)!])
-                let scaledImage = self.markImgWithText(images[0], markOpts!)
-                let res = self.saveImageForMarker(scaledImage!, with: markOpts!)
+                let images = try await self.loadImages(with: [markOpts.backgroundImage])
+                guard let scaledImage = self.markImgWithText(images[0], markOpts) else {
+                    rejecter("error", "Failed to render watermarked image", nil)
+                    return
+                }
+                let res = self.saveImageForMarker(scaledImage, with: markOpts)
                 resolver(res)
                 print("Loaded images: \(images)")
             } catch {
@@ -403,18 +410,21 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     
     @objc(markWithImage:resolver:rejecter:)
     func mark(withImage opts: [AnyHashable: Any], resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-        let markOpts = MarkImageOptions.checkImageParams(opts, rejecter: rejecter)
-        if markOpts === nil {
+        guard let markOpts = MarkImageOptions.checkImageParams(opts, rejecter: rejecter) else {
             rejecter(ErrorDomainEnum.PARAMS_INVALID.rawValue, "opts invalid", nil)
+            return
         }
         Task(priority: .userInitiated) {
             do {
-                let waterImages = markOpts?.watermarkImages.map { $0.imageOption }
-                var images = try await loadImages(with: [(markOpts?.backgroundImage)!] + waterImages!)
-                let scaledImage = self.markImage(with: images.remove(at: 0), waterImages: images, options: markOpts!)
-                let res = self.saveImageForMarker(scaledImage!, with: markOpts!)
+                let waterImages = markOpts.watermarkImages.map { $0.imageOption }
+                var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages)
+                guard let scaledImage = self.markImage(with: images.remove(at: 0), waterImages: images, options: markOpts) else {
+                    rejecter("error", "Failed to render watermarked image", nil)
+                    return
+                }
+                let res = self.saveImageForMarker(scaledImage, with: markOpts)
                 resolver(res)
-                print("Loaded images: \(images), waterImages: \(String(describing: waterImages))")
+                print("Loaded images: \(images), waterImages: \(waterImages)")
             } catch {
                 print("Failed to load images, error: \(error).")
                 rejecter("error", error.localizedDescription, error)


### PR DESCRIPTION
## Problem

Three force-unwrap sites in `ImageMarker.swift` cause `EXC_BREAKPOINT` (trap) crashes in production:

### 1 & 2 — Missing `return` after nil check in `mark(withText:)` and `mark(withImage:)`

Both methods check `checkTextParams`/`checkImageParams` for nil but **don't `return`** afterwards, so execution falls through into the `Task` block. Inside the task, `markOpts` is force-unwrapped:

```swift
// mark(withText:)
let images = try await loadImages(with: [(markOpts?.backgroundImage)!])  // 💥 EXC_BREAKPOINT
let scaledImage = self.markImgWithText(images[0], markOpts!)              // 💥 EXC_BREAKPOINT

// mark(withImage:)
var images = try await loadImages(with: [(markOpts?.backgroundImage)!] + waterImages!)  // 💥
let scaledImage = self.markImage(with: ..., options: markOpts!)                          // 💥
```

### 3 — Force-unwrap of `request` in `loadImages`

`RCTConvert.nsurlRequest(img.src)` returns an optional and can be `nil` for malformed URLs. It is immediately force-unwrapped:

```swift
let request = RCTConvert.nsurlRequest(img.src)
imageLoader.loadImage(with: request!, ...)  // 💥 EXC_BREAKPOINT if request is nil
```

These crashes are observed in production on iOS 17+ with React Native 0.73+ (both old and new architecture).

## Fix

Replace all three force-unwrap patterns with `guard let` bindings that properly reject the JS promise with descriptive error messages instead of crashing:

- `mark(withText:)` / `mark(withImage:)`: use `guard let markOpts = ... else { rejecter(...); return }` before the `Task` block
- `loadImages`: use `guard let request = ... else { continuation.resume(throwing: error); return }`
- Remove `!` force-unwraps on `scaledImage`, `waterImages`, and `markOpts` throughout both mark methods

## Testing

- Pass invalid/nil `opts` to `markText` or `markImage` — the JS `catch` block now receives a proper error instead of crashing
- Pass a malformed image URL to either mark method — handled gracefully
- Normal watermarking flow is unaffected