### PR TITLE
fix: move patch tooling to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "husky": "^8.0.3",
     "jest": "^28.1.1",
     "metro-react-native-babel-preset": "^0.77.0",
+    "patch-package": "^8.0.0",
     "pod-install": "^0.1.0",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.0.5",
     "react": "18.2.0",
     "react-native": "0.73.3",
@@ -175,9 +177,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "patch-package": "^8.0.0",
-    "postinstall-postinstall": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary

- Move `patch-package` and `postinstall-postinstall` from runtime `dependencies` to `devDependencies`.
- Remove the published package runtime dependency on `postinstall-postinstall`, which can re-run consumer postinstall scripts.

Fixes #272.

## Validation

- `node -e "const p=require(\047./package.json\047); console.log(JSON.stringify({dependencies:p.dependencies||null, patchPackageInDev:!!p.devDependencies[\047patch-package\047], postinstallInDev:!!p.devDependencies[\047postinstall-postinstall\047]}, null, 2))"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

Note: `npm pack --dry-run` without `--ignore-scripts` currently requires local dev dependencies because it runs `prepack` (`bob build`); this checkout has no `node_modules` installed.
