### PR TITLE
fix: preserve android named colors

### DIFF
--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/Utils.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/Utils.kt
@@ -78,7 +78,10 @@ class Utils {
     }
 
     fun transRGBColor(color: String?): String {
-      val colorStr = color!!.substring(1)
+      if (color == null || !color.startsWith("#")) {
+        return color ?: ""
+      }
+      val colorStr = color.substring(1)
       if (colorStr.length == 3) {
         var fullColor = ""
         for (i in colorStr.indices) {

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/UtilsTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/UtilsTest.kt
@@ -1,0 +1,24 @@
+package com.jimmydaddy.imagemarker.base
+
+import org.junit.Assert
+import org.junit.Test
+
+class UtilsTest {
+
+  @Test
+  fun transRGBColorReturnsNamedColorsUnchanged() {
+    Assert.assertEquals("white", Utils.transRGBColor("white"))
+    Assert.assertEquals("transparent", Utils.transRGBColor("transparent"))
+  }
+
+  @Test
+  fun transRGBColorExpandsShortHexColors() {
+    Assert.assertEquals("#ffffff", Utils.transRGBColor("#fff"))
+    Assert.assertEquals("#ffffffff", Utils.transRGBColor("#ffff"))
+  }
+
+  @Test
+  fun transRGBColorConvertsTrailingAlphaToAndroidAlpha() {
+    Assert.assertEquals("#44112233", Utils.transRGBColor("#11223344"))
+  }
+}


### PR DESCRIPTION
## Summary

- Preserve Android named colors such as `white` and `transparent` instead of treating them as shortened hex strings.
- Add unit coverage for named colors and the existing short hex / trailing alpha conversions.

Fixes #236.

## Validation

- `npm install --prefix example --no-package-lock --ignore-scripts`
- `./gradlew :react-native-image-marker:testDebugUnitTest --tests com.jimmydaddy.imagemarker.base.UtilsTest` from `example/android`
- `git diff --check`

Notes: the first `yarn --cwd example install --no-lockfile` attempt failed with a malformed registry response for `@jest/fake-timers`, so npm was used to install the example dependencies without writing a lockfile. Gradle completed successfully with existing Kotlin/manifest/deprecation warnings only.
