### PR TITLE
fix: support responsive watermark font sizing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,7 @@
 * <details>
   <summary><a href="#usage">Usage</a></summary>
 
+    * [Responsive watermark size](#responsive-watermark-size)
     * [Text background fit](#text-background-fit)
     * [Text background stretchX](#text-background-stretchx)
     * [Text background stretchY](#text-background-stretchy)
@@ -139,6 +140,36 @@ eas build
 For custom fonts, first confirm the font renders in your React Native app, then pass the same native font family or PostScript name to `fontName`.
 
 ## Usage
+
+### Responsive watermark size
+
+`fontSize` is applied to the output bitmap. If two background images have different pixel dimensions, the same `fontSize` will occupy a different percentage of each image.
+
+To keep the visual size consistent across different image resolutions, set `fontSizeRatio`. The native renderer calculates the actual font size from the background image width before drawing the text:
+
+```typescript
+await Marker.markText({
+  backgroundImage: {
+    src: imageUri,
+    scale: 1,
+  },
+  watermarkTexts: [
+    {
+      text: 'watermark',
+      positionOptions: {
+        position: Position.center,
+      },
+      style: {
+        color: '#ffffff',
+        fontName: 'Arial',
+        fontSizeRatio: 0.03,
+      },
+    },
+  ],
+});
+```
+
+Choose the multiplier for your design. For example, `0.03` means the text size is about 3% of the background image width. If both `fontSizeRatio` and `fontSize` are set, `fontSizeRatio` is used.
 
 ### Text background fit
 

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
@@ -74,7 +74,7 @@ data class TextOptions(val options: ReadableMap) {
 //      style.fontSize,
 //      context.resources.displayMetrics
 //    )
-    val textSize = style.fontSize
+    val textSize = style.resolveFontSize(maxWidth)
     textPaint.isAntiAlias = true
     textPaint.textSize = textSize
     Log.i(Constants.IMAGE_MARKER_TAG, "textSize: " + textSize + " fontSize: " + style.fontSize + " displayMetrics: " + context.resources.displayMetrics)

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStyle.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStyle.kt
@@ -8,6 +8,12 @@ data class TextStyle(val options: ReadableMap?) {
   var color: String? = if (null != options!!.getString("color")) options.getString("color") else null
   var fontName: String? = if (null != options?.getString("fontName")) options.getString("fontName") else null
   var fontSize: Float = if (options?.hasKey("fontSize") == true) options.getDouble("fontSize").toFloat() else DEFAULT_FONT_SIZE
+  var fontSizeRatio: Float? =
+    if (options?.hasKey("fontSizeRatio") == true && !options.isNull("fontSizeRatio")) {
+      options.getDouble("fontSizeRatio").toFloat()
+    } else {
+      null
+    }
   var shadowLayerStyle: ShadowLayerStyle?
   var textBackgroundStyle: TextBackgroundStyle?
   var underline: Boolean = if (options?.hasKey("underline") == true) options.getBoolean("underline") else false
@@ -31,5 +37,9 @@ data class TextStyle(val options: ReadableMap?) {
         else -> Align.LEFT
       }
     }
+  }
+
+  fun resolveFontSize(backgroundWidth: Int): Float {
+    return fontSizeRatio?.let { backgroundWidth * it } ?: fontSize
   }
 }

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/TextStyleTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/TextStyleTest.kt
@@ -1,0 +1,31 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+
+class TextStyleTest {
+  @Test
+  fun resolveFontSizeUsesRatioWhenProvided() {
+    val options = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(options.hasKey("fontSizeRatio")).thenReturn(true)
+    Mockito.`when`(options.isNull("fontSizeRatio")).thenReturn(false)
+    Mockito.`when`(options.getDouble("fontSizeRatio")).thenReturn(0.03)
+
+    val style = TextStyle(options)
+
+    assertEquals(30f, style.resolveFontSize(1000), 0.001f)
+  }
+
+  @Test
+  fun resolveFontSizeFallsBackToFontSize() {
+    val options = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(options.hasKey("fontSize")).thenReturn(true)
+    Mockito.`when`(options.getDouble("fontSize")).thenReturn(24.0)
+
+    val style = TextStyle(options)
+
+    assertEquals(24f, style.resolveFontSize(1000), 0.001f)
+  }
+}

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -148,16 +148,16 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         
         for textOpts in opts.watermarkTexts {
             context.saveGState()
-            var font = textOpts.style!.font
+            var font = textOpts.style!.resolvedFont(backgroundWidth: w)
             if textOpts.style!.italic && textOpts.style!.bold {
-                let boldItalicFontDescriptor = textOpts.style!.font!.fontDescriptor.withSymbolicTraits([.traitBold, .traitItalic])
-                font = UIFont(descriptor: boldItalicFontDescriptor!, size: font!.pointSize)
+                let boldItalicFontDescriptor = font.fontDescriptor.withSymbolicTraits([.traitBold, .traitItalic])
+                font = UIFont(descriptor: boldItalicFontDescriptor!, size: font.pointSize)
             } else if textOpts.style!.italic {
-                let italicFontDescriptor = textOpts.style!.font!.fontDescriptor.withSymbolicTraits(.traitItalic)
-                font = UIFont(descriptor: italicFontDescriptor!, size: font!.pointSize)
+                let italicFontDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic)
+                font = UIFont(descriptor: italicFontDescriptor!, size: font.pointSize)
             } else if textOpts.style!.bold {
-                let boldFontDescriptor = textOpts.style!.font!.fontDescriptor.withSymbolicTraits(.traitBold)
-                font = UIFont(descriptor: boldFontDescriptor!, size: font!.pointSize)
+                let boldFontDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold)
+                font = UIFont(descriptor: boldFontDescriptor!, size: font.pointSize)
             }
             
             var attributes: [NSAttributedString.Key: Any] = [

--- a/ios/RCTImageMarker/TextStyle.swift
+++ b/ios/RCTImageMarker/TextStyle.swift
@@ -13,7 +13,9 @@ class TextStyle: NSObject {
     var color: UIColor?
     var shadow: NSShadow?
     var textBackground: TextBackground?
-    var font: UIFont?
+    var fontName: String?
+    var fontSize: CGFloat = 14.0
+    var fontSizeRatio: CGFloat?
     var skewX: CGFloat = 0.0
     var underline: Bool = false
     var strikeThrough: Bool = false
@@ -30,11 +32,9 @@ class TextStyle: NSObject {
             self.shadow = nil
         }
         self.textBackground = try TextBackground(textBackgroundStyle: (opts["textBackgroundStyle"] as? [AnyHashable : Any]))
-        let fontSize = opts["fontSize"] != nil ? RCTConvert.cgFloat(opts["fontSize"]) : 14.0
-        self.font = UIFont(name: opts["fontName"] as? String ?? "", size: fontSize)
-        if self.font == nil {
-            self.font = UIFont.systemFont(ofSize: fontSize)
-        }
+        self.fontName = opts["fontName"] as? String
+        self.fontSize = opts["fontSize"] != nil ? RCTConvert.cgFloat(opts["fontSize"]) : 14.0
+        self.fontSizeRatio = opts["fontSizeRatio"] != nil ? RCTConvert.cgFloat(opts["fontSizeRatio"]) : nil
         self.skewX = RCTConvert.cgFloat(opts["skewX"])
         self.underline = RCTConvert.bool(opts["underline"])
         self.strikeThrough = RCTConvert.bool(opts["strikeThrough"])
@@ -44,5 +44,10 @@ class TextStyle: NSObject {
         self.textAlign = opts["textAlign"] as? String
 
         super.init()
+    }
+
+    func resolvedFont(backgroundWidth: CGFloat) -> UIFont {
+        let resolvedSize = fontSizeRatio != nil ? backgroundWidth * fontSizeRatio! : fontSize
+        return UIFont(name: fontName ?? "", size: resolvedSize) ?? UIFont.systemFont(ofSize: resolvedSize)
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,11 +211,17 @@ export interface TextStyle {
    */
   fontName?: string;
   /**
-   * @description font size, Android use `sp`, iOS use `pt`
+   * @description font size used when rendering text onto the output image
    * @example
    *  fontSize: 12
    */
   fontSize?: number;
+  /**
+   * @description font size ratio relative to the background image width
+   * @example
+   *  fontSizeRatio: 0.03
+   */
+  fontSizeRatio?: number;
   /**
    * @description text shadow style
    * @example


### PR DESCRIPTION
## Summary

- Add optional `style.fontSizeRatio` for text watermarks.
- Resolve responsive font size natively from the background image width on Android and iOS.
- Document the new API and cover Android ratio/fallback behavior with unit tests.

Fixes #225.

## Validation

- `./gradlew :react-native-image-marker:testDebugUnitTest --tests com.jimmydaddy.imagemarker.base.TextStyleTest`
- `git diff --check HEAD~1..HEAD`

Notes: full TypeScript checking was not completed in this local checkout because root dependencies are not installed; using `typescript@5.9.3` still stops on missing example/expo-example dependencies. GitHub CI should provide the authoritative cross-platform build signal for this native change.
