### PR TITLE
fix(ios): reject malformed marker inputs

### DIFF
--- a/ios/RCTImageMarker/CornerRadius.swift
+++ b/ios/RCTImageMarker/CornerRadius.swift
@@ -21,19 +21,34 @@ class CornerRadius: NSObject {
             switch key {
             case "topLeft" as String:
                 if Utils.isNULL(cornerRadius) { break; }
-                self.topLeft = try Radius(dicOpts: cornerRadius as! [AnyHashable : Any])
+                guard let cornerRadius = cornerRadius as? [AnyHashable: Any] else {
+                    throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius.topLeft is invalid"])
+                }
+                self.topLeft = try Radius(dicOpts: cornerRadius)
             case "topRight" as String:
                 if Utils.isNULL(cornerRadius) { break; }
-                self.topRight = try Radius(dicOpts: cornerRadius as! [AnyHashable : Any])
+                guard let cornerRadius = cornerRadius as? [AnyHashable: Any] else {
+                    throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius.topRight is invalid"])
+                }
+                self.topRight = try Radius(dicOpts: cornerRadius)
             case "bottomLeft" as String:
                 if Utils.isNULL(cornerRadius) { break; }
-                self.bottomLeft = try Radius(dicOpts: cornerRadius as! [AnyHashable : Any])
+                guard let cornerRadius = cornerRadius as? [AnyHashable: Any] else {
+                    throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius.bottomLeft is invalid"])
+                }
+                self.bottomLeft = try Radius(dicOpts: cornerRadius)
             case "bottomRight" as String:
                 if Utils.isNULL(cornerRadius) { break; }
-                self.bottomRight = try Radius(dicOpts: cornerRadius as! [AnyHashable : Any])
+                guard let cornerRadius = cornerRadius as? [AnyHashable: Any] else {
+                    throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius.bottomRight is invalid"])
+                }
+                self.bottomRight = try Radius(dicOpts: cornerRadius)
             default:
                 if Utils.isNULL(cornerRadius) { break; }
-                all = try Radius(dicOpts: cornerRadius as! [AnyHashable : Any])
+                guard let cornerRadius = cornerRadius as? [AnyHashable: Any] else {
+                    throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius is invalid"])
+                }
+                all = try Radius(dicOpts: cornerRadius)
             }
         }
     }

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -152,33 +152,33 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         
         for textOpts in opts.watermarkTexts {
             context.saveGState()
-            var font = textOpts.style!.resolvedFont(backgroundWidth: w)
-            if textOpts.style!.italic && textOpts.style!.bold {
+            var font = textOpts.style.resolvedFont(backgroundWidth: w)
+            if textOpts.style.italic && textOpts.style.bold {
                 let boldItalicFontDescriptor = font.fontDescriptor.withSymbolicTraits([.traitBold, .traitItalic])
                 font = UIFont(descriptor: boldItalicFontDescriptor!, size: font.pointSize)
-            } else if textOpts.style!.italic {
+            } else if textOpts.style.italic {
                 let italicFontDescriptor = font.fontDescriptor.withSymbolicTraits(.traitItalic)
                 font = UIFont(descriptor: italicFontDescriptor!, size: font.pointSize)
-            } else if textOpts.style!.bold {
+            } else if textOpts.style.bold {
                 let boldFontDescriptor = font.fontDescriptor.withSymbolicTraits(.traitBold)
                 font = UIFont(descriptor: boldFontDescriptor!, size: font.pointSize)
             }
             
             var attributes: [NSAttributedString.Key: Any] = [
                 .font: font as Any,   //设置字体
-                .foregroundColor: textOpts.style!.color as Any,      //设置字体颜色
+                .foregroundColor: textOpts.style.color as Any,      //设置字体颜色
             ]
             
-            if let shadow = textOpts.style!.shadow {
+            if let shadow = textOpts.style.shadow {
                 attributes[.shadow] = shadow
             }
-            if textOpts.style!.underline {
+            if textOpts.style.underline {
                 attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
             }
-            if textOpts.style!.strikeThrough {
+            if textOpts.style.strikeThrough {
                 attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
             }
-            if let textAlign = textOpts.style!.textAlign {
+            if let textAlign = textOpts.style.textAlign {
                 let paragraphStyle = NSMutableParagraphStyle()
                 switch textAlign {
                 case "right":
@@ -190,8 +190,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 }
                 attributes[.paragraphStyle] = paragraphStyle
             }
-            if textOpts.style!.skewX != 0 {
-                attributes[.obliqueness] = textOpts.style!.skewX
+            if textOpts.style.skewX != 0 {
+                attributes[.obliqueness] = textOpts.style.skewX
             }
             
             let attributedText = NSAttributedString(string: textOpts.text, attributes: attributes)
@@ -232,28 +232,28 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 posY = Utils.parseSpreadValue(v: textOpts.Y, relativeTo: CGFloat(h)) ?? margin
             }
             
-            if textOpts.style!.rotate != 0 {
+            if textOpts.style.rotate != 0 {
                 context.saveGState()
-                let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style!.rotate) * .pi / 180)
+                let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style.rotate) * .pi / 180)
                 let textRectWithPos = CGRect(x: CGFloat(posX), y: CGFloat(posY), width: size.width, height: size.height)
                 context.translateBy(x: textRectWithPos.midX, y: textRectWithPos.midY)
                 context.concatenate(rotation)
                 context.translateBy(x: -( textRectWithPos.midX), y: -(textRectWithPos.midY))
             }
             
-            if let textBackground = textOpts.style!.textBackground {
-                let bgEdgeInsets = textOpts.style?.textBackground?.toEdgeInsets(width: CGFloat(w), height: CGFloat(h))
+            if let textBackground = textOpts.style.textBackground {
+                let bgEdgeInsets = textBackground.toEdgeInsets(width: CGFloat(w), height: CGFloat(h))
                 context.setFillColor(textBackground.colorBg!.cgColor)
-                let stretchX = (bgEdgeInsets?.left ?? 0) + (bgEdgeInsets?.right ?? 0);
-                let stretchY = (bgEdgeInsets?.top ?? 0) + (bgEdgeInsets?.bottom ?? 0);
-                var bgRect = CGRect(x: CGFloat(CGFloat(posX) - (bgEdgeInsets?.left ?? 0)), y: CGFloat(CGFloat(posY) - (bgEdgeInsets?.top ?? 0)), width: size.width + stretchX, height: size.height + stretchY)
+                let stretchX = bgEdgeInsets.left + bgEdgeInsets.right;
+                let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom;
+                var bgRect = CGRect(x: CGFloat(CGFloat(posX) - bgEdgeInsets.left), y: CGFloat(CGFloat(posY) - bgEdgeInsets.top), width: size.width + stretchX, height: size.height + stretchY)
                 if textBackground.typeBg == "stretchX" {
-                    bgRect = CGRect(x: 0, y: CGFloat(posY) - (bgEdgeInsets?.top ?? 0), width: CGFloat(w), height: size.height + stretchY)
+                    bgRect = CGRect(x: 0, y: CGFloat(posY) - bgEdgeInsets.top, width: CGFloat(w), height: size.height + stretchY)
                 } else if textBackground.typeBg == "stretchY" {
-                    bgRect = CGRect(x: CGFloat(CGFloat(posX) - (bgEdgeInsets?.left ?? 0)), y: 0, width: size.width + stretchX, height: CGFloat(h))
+                    bgRect = CGRect(x: CGFloat(CGFloat(posX) - bgEdgeInsets.left), y: 0, width: size.width + stretchX, height: CGFloat(h))
                 }
                 
-                bgRect.inset(by: bgEdgeInsets!)
+                bgRect.inset(by: bgEdgeInsets)
                 
                 if !Utils.isNULL(textBackground.cornerRadius) {
                     let path = textBackground.cornerRadius!.radiusPath(rect: bgRect)
@@ -388,7 +388,6 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     @objc(markWithText:resolver:rejecter:)
     func mark(withText opts: [AnyHashable: Any], resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) -> Void {
         guard let markOpts = MarkTextOptions.checkTextParams(opts, rejecter: rejecter) else {
-            rejecter(ErrorDomainEnum.PARAMS_INVALID.rawValue, "opts invalid", nil)
             return
         }
         Task(priority: .userInitiated) {
@@ -411,7 +410,6 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     @objc(markWithImage:resolver:rejecter:)
     func mark(withImage opts: [AnyHashable: Any], resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) -> Void {
         guard let markOpts = MarkImageOptions.checkImageParams(opts, rejecter: rejecter) else {
-            rejecter(ErrorDomainEnum.PARAMS_INVALID.rawValue, "opts invalid", nil)
             return
         }
         Task(priority: .userInitiated) {

--- a/ios/RCTImageMarker/ImageOptions.swift
+++ b/ios/RCTImageMarker/ImageOptions.swift
@@ -22,7 +22,10 @@ class ImageOptions: NSObject {
         }
         self.src = src
         self.rnSrc = RNImageSRC(dicOpts: src)
-        self.uri = src["uri"] as! String
+        guard let uri = src["uri"] as? String, !uri.isEmpty else {
+            throw NSError(domain: ErrorDomainEnum.PARAMS_REQUIRED.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "image uri is required"])
+        }
+        self.uri = uri
         self.scale = opts["scale"] as? CGFloat ?? 1.0
         self.rotate = opts["rotate"] as? CGFloat ?? 0
         self.alpha = opts["alpha"] as? CGFloat ?? 1.0

--- a/ios/RCTImageMarker/MarkImageOptions.swift
+++ b/ios/RCTImageMarker/MarkImageOptions.swift
@@ -15,15 +15,18 @@ class MarkImageOptions: Options {
     override init(dicOpts opts: [AnyHashable: Any]) throws {
         try super.init(dicOpts: opts)
         let watermarkImageOpts = opts["watermarkImage"]
-        let watermarkImagesOpts = opts["watermarkImages"] as? [[AnyHashable: Any]]
-        if Utils.isNULL(watermarkImageOpts) && (Utils.isNULL(watermarkImagesOpts) || watermarkImagesOpts!.count <= 0)  {
+        let watermarkImagesOpts = opts["watermarkImages"] as? [[AnyHashable: Any]] ?? []
+        if Utils.isNULL(watermarkImageOpts) && watermarkImagesOpts.isEmpty  {
             throw NSError(domain: ErrorDomainEnum.PARAMS_REQUIRED.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "marker image is required"])
         }
-        if watermarkImagesOpts!.count > 0 {
-            self.watermarkImages = try watermarkImagesOpts!.map { try WatermarkImageOptions(dicOpts: $0) }
+        if !watermarkImagesOpts.isEmpty {
+            self.watermarkImages = try watermarkImagesOpts.map { try WatermarkImageOptions(dicOpts: $0) }
         }
         if (!Utils.isNULL(watermarkImageOpts)){
-            let singleImageOptions = try ImageOptions(dicOpts: watermarkImageOpts as! [AnyHashable : Any])
+            guard let watermarkImageOpts = watermarkImageOpts as? [AnyHashable: Any] else {
+                throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "watermarkImage is invalid"])
+            }
+            let singleImageOptions = try ImageOptions(dicOpts: watermarkImageOpts)
             var singleX = "20.0"
             var singleY = "20.0"
             var singlePosition: MarkerPositionEnum = .none

--- a/ios/RCTImageMarker/TextBackground.swift
+++ b/ios/RCTImageMarker/TextBackground.swift
@@ -21,9 +21,15 @@ class TextBackground: Padding {
         }
         try super.init(paddingData: textBackground)
         self.typeBg = textBackground["type"] as? String
-        self.colorBg = UIColor(hex: textBackground["color"] as! String) ?? UIColor.clear
+        guard let color = textBackground["color"] as? String else {
+            throw NSError(domain: ErrorDomainEnum.PARAMS_REQUIRED.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "text background color is required"])
+        }
+        self.colorBg = UIColor(hex: color) ?? UIColor.clear
         if textBackground.keys.contains("cornerRadius") {
-            self.cornerRadius = try CornerRadius(dicOpts: textBackground["cornerRadius"] as! [AnyHashable : Any])
+            guard let cornerRadius = textBackground["cornerRadius"] as? [AnyHashable: Any] else {
+                throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "cornerRadius is invalid"])
+            }
+            self.cornerRadius = try CornerRadius(dicOpts: cornerRadius)
         }
     }
 }

--- a/ios/RCTImageMarker/TextOptions.swift
+++ b/ios/RCTImageMarker/TextOptions.swift
@@ -14,7 +14,7 @@ class TextOptions: NSObject {
     var Y: String?
     var position: MarkerPositionEnum = .none
     var text: String
-    var style: TextStyle?
+    var style: TextStyle
 
     init(dicOpts opts: [AnyHashable: Any]) throws {
         guard let text = opts["text"] as? String else {
@@ -28,6 +28,7 @@ class TextOptions: NSObject {
         }
 
         self.text = text
-        self.style = try? TextStyle(dicOpts: (opts["style"] as? [AnyHashable: Any])!)
+        let styleOpts = opts["style"] as? [AnyHashable: Any] ?? [:]
+        self.style = try TextStyle(dicOpts: styleOpts)
     }
 }

--- a/ios/RCTImageMarker/TextStyle.swift
+++ b/ios/RCTImageMarker/TextStyle.swift
@@ -25,7 +25,11 @@ class TextStyle: NSObject {
     var textAlign: String?
 
     init(dicOpts opts: [AnyHashable: Any]) throws {
-        self.color = UIColor(hex: opts["color"] as! String) ?? UIColor.clear
+        if let color = opts["color"] as? String {
+            self.color = UIColor(hex: color) ?? UIColor.clear
+        } else {
+            self.color = UIColor.clear
+        }
         if let shadowStyle = opts["shadowStyle"] as? [AnyHashable: Any] {
             self.shadow = Utils.getShadowStyle(shadowStyle)
         } else {
@@ -47,7 +51,7 @@ class TextStyle: NSObject {
     }
 
     func resolvedFont(backgroundWidth: CGFloat) -> UIFont {
-        let resolvedSize = fontSizeRatio != nil ? backgroundWidth * fontSizeRatio! : fontSize
+        let resolvedSize = fontSizeRatio.map { backgroundWidth * $0 } ?? fontSize
         return UIFont(name: fontName ?? "", size: resolvedSize) ?? UIFont.systemFont(ofSize: resolvedSize)
     }
 }


### PR DESCRIPTION
## Summary

- Convert remaining iOS marker input force unwraps into validation errors after #271.
- Avoid duplicate promise rejection when option parsing already rejected.
- Default missing text style to a safe TextStyle object and reject malformed nested image/background/corner-radius inputs instead of trapping.

## Why

#271 fixed the immediate nil markOpts/request crash paths, but several parameter parsing paths could still trap before the promise was rejected. This follow-up keeps malformed JS inputs on the promise rejection path instead of causing EXC_BREAKPOINT crashes.

## Validation

- `git diff --check`
- Static scan for the targeted force unwrap patterns in iOS marker input parsing
- `xcodebuild -project ios/RCTImageMarker.xcodeproj -scheme RCTImageMarker -configuration Release -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` (blocked by existing project references to missing `RCTImageMarker.swift` and `RCTImageMarker-Bridging-Header.h`)
- `xcodebuild -workspace example/ios/ImageMarkerExample.xcworkspace -scheme ImageMarkerExample -configuration Release -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` (blocked locally because `example/ios/Pods` is not installed)
