### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0 (2026-07-01)
+
+* feat: add new architecture codegen support (#291) ([26011b6](https://github.com/JimmyDaddy/react-native-image-marker/commit/26011b6)), closes [#291](https://github.com/JimmyDaddy/react-native-image-marker/issues/291)
+* ci: enable npm trusted publishing ([ac889c7](https://github.com/JimmyDaddy/react-native-image-marker/commit/ac889c7))
+* ci: fix pages deployment trigger ([0f4df9c](https://github.com/JimmyDaddy/react-native-image-marker/commit/0f4df9c))
+
 ## <small>1.2.12 (2026-06-30)</small>
 
 * test: add native functional coverage (#290) ([90dbfa4](https://github.com/JimmyDaddy/react-native-image-marker/commit/90dbfa4)), closes [#290](https://github.com/JimmyDaddy/react-native-image-marker/issues/290)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.2.12",
+  "version": "1.3.0",
   "description": "Add text or icon watermark to your images",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

Prepare the `1.3.0` release after the New Architecture support PR landed on `master`.

## Changes

- Bump `package.json` from `1.2.12` to `1.3.0`
- Add the `1.3.0` section to `CHANGELOG.md`

## Release Notes

- New Architecture codegen support for Android and iOS
- npm trusted publishing workflow support
- GitHub Pages deployment trigger fix

## Validation

- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run prepack`
- `npm pack --dry-run`

## Publish

After this PR is merged, publish a GitHub Release for `v1.3.0` from `master`; the `publish npm Package` workflow is configured to publish to npm on `release.published` with provenance.
