### PR TITLE
chore: release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0 (2026-07-01)
+
+* feat: add native layered watermark renderer (#293) ([50fc255](https://github.com/JimmyDaddy/react-native-image-marker/commit/50fc255)), closes [#293](https://github.com/JimmyDaddy/react-native-image-marker/issues/293)
+
 ## 1.3.0 (2026-07-01)
 
 * feat: add new architecture codegen support (#291) ([26011b6](https://github.com/JimmyDaddy/react-native-image-marker/commit/26011b6)), closes [#291](https://github.com/JimmyDaddy/react-native-image-marker/issues/291)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Add text or icon watermark to your images",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- bump package version to 1.4.0
- update CHANGELOG.md for the native layered watermark renderer from #293

## Version
This is a minor release because #293 adds a new backwards-compatible `mark()` layered watermark API and native renderer support.

## Validation
- `git diff --check HEAD~1..HEAD`
- verified package version with `node -p "require('./package.json').version"`
