### PR TITLE
refactor: improve marker pipeline maintainability

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ lib
 docs
 
 base64.js
+example/src/bas64bg.js
+expo-example/assets/bas64bg.js

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g npm@latest
       - run: npm install
       - run: npm run prepack
-      - run: npm publish --provenance
+      - run: npm publish

--- a/android/src/main/java/com/jimmydaddy/imagemarker/ImageMarkerManager.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/ImageMarkerManager.kt
@@ -16,12 +16,17 @@ import com.jimmydaddy.imagemarker.base.Constants.IMAGE_MARKER_TAG
 import com.jimmydaddy.imagemarker.base.MarkImageOptions
 import com.jimmydaddy.imagemarker.base.MarkTextOptions
 import com.jimmydaddy.imagemarker.base.MarkWatermarkOptions
+import com.jimmydaddy.imagemarker.base.MarkerError
+import com.jimmydaddy.imagemarker.base.Options
 import com.jimmydaddy.imagemarker.base.SaveFormat
 import com.jimmydaddy.imagemarker.base.Utils.Companion.getBlankBitmap
-import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.FileOutputStream
@@ -34,191 +39,182 @@ import java.util.UUID
 class ImageMarkerManager(private val context: ReactApplicationContext) : NativeImageMarkerSpec(
   context
 ) {
-  private fun getSaveFormat(saveFormat: SaveFormat?): CompressFormat {
-    return if (saveFormat != null && saveFormat === SaveFormat.PNG) CompressFormat.PNG else CompressFormat.JPEG
+  private val moduleScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+  override fun invalidate() {
+    moduleScope.cancel()
+    super.invalidate()
   }
 
-  private fun markImageByBitmap(
-    bg: Bitmap?,
-    markers: List<Bitmap?>,
-    dest: String,
-    opts: MarkImageOptions,
-    promise: Promise
+  private fun getSaveFormat(saveFormat: SaveFormat?): CompressFormat {
+    return if (saveFormat == SaveFormat.PNG) CompressFormat.PNG else CompressFormat.JPEG
+  }
+
+  private fun launchMarkerJob(
+    promise: Promise,
+    block: suspend () -> String
   ) {
-    var bos: BufferedOutputStream? = null
-    var icon: Bitmap? = null
-    try {
-      icon = ImageMarkerRenderer.renderImageWatermarks(
-        bg!!,
-        markers,
-        opts,
-        recycleMarkerBitmaps = true
-      )
-
-      // 保存
-      // canvas.save(Canvas.ALL_SAVE_FLAG);
-      if (!bg.isRecycled) {
-        bg.recycle()
-        System.gc()
-      }
-
-      // export base64
-      if (dest == BASE64) {
-        val base64Stream = ByteArrayOutputStream()
-        icon.compress(CompressFormat.PNG, opts.quality, base64Stream)
-        base64Stream.flush()
-        base64Stream.close()
-        val bitmapBytes = base64Stream.toByteArray()
-        val result = Base64.encodeToString(bitmapBytes, Base64.DEFAULT)
-        promise.resolve("data:image/png;base64,$result")
-      } else {
-        bos = BufferedOutputStream(FileOutputStream(dest))
-        icon.compress(getSaveFormat(opts.saveFormat), opts.quality, bos)
-        bos.flush()
-        bos.close()
-        //保存成功的
-        promise.resolve(dest)
-      }
-    } catch (e: Exception) {
-      e.printStackTrace()
-      promise.reject("error", e.message, e)
-    } finally {
-      if (bos != null) {
-        try {
-          bos.close()
-        } catch (e: IOException) {
-          e.printStackTrace()
-        }
-      }
-      if (icon != null && !icon.isRecycled) {
-        icon.recycle()
-        System.gc()
+    moduleScope.launch {
+      try {
+        promise.resolve(block())
+      } catch (e: CancellationException) {
+        Log.d(IMAGE_MARKER_TAG, "marker job cancelled")
+      } catch (e: Exception) {
+        Log.d(IMAGE_MARKER_TAG, "error: " + e.message)
+        promise.rejectMarkerError(e)
       }
     }
   }
 
-  /**
-   * @param bg
-   * @param dest
-   * @param opts
-   * @param promise
-   */
-  private fun markImageByText(
-    bg: Bitmap?,
+  private fun Promise.rejectMarkerError(error: Exception) {
+    error.printStackTrace()
+    if (error is MarkerError) {
+      reject(error.getErrorCode(), error.getErrMsg(), error)
+    } else {
+      reject("error", error.message, error)
+    }
+  }
+
+  private suspend fun markImageByBitmap(
+    bg: Bitmap,
+    markers: List<Bitmap>,
     dest: String,
-    opts: MarkTextOptions,
-    promise: Promise
-  ) {
-    var bos: BufferedOutputStream? = null
+    opts: MarkImageOptions
+  ): String {
     var icon: Bitmap? = null
     try {
-      val height = bg!!.height
+      icon = withContext(Dispatchers.Default) {
+        ImageMarkerRenderer.renderImageWatermarks(
+          bg,
+          markers,
+          opts,
+          recycleMarkerBitmaps = false
+        )
+      }
+      return writeResult(icon, dest, opts)
+    } finally {
+      recycleBitmap(icon)
+      recycleBitmap(bg)
+      recycleBitmaps(markers)
+    }
+  }
+
+  private suspend fun markImageByText(
+    bg: Bitmap,
+    dest: String,
+    opts: MarkTextOptions
+  ): String {
+    var icon: Bitmap? = null
+    try {
+      icon = withContext(Dispatchers.Default) {
+        renderTextWatermarks(bg, opts)
+      }
+      return writeResult(icon, dest, opts)
+    } finally {
+      recycleBitmap(icon)
+      recycleBitmap(bg)
+    }
+  }
+
+  private fun renderTextWatermarks(
+    bg: Bitmap,
+    opts: MarkTextOptions
+  ): Bitmap {
+    var icon: Bitmap? = null
+    try {
+      val height = bg.height
       val width = bg.width
       icon = getBlankBitmap(width, height)
-      //初始化画布 绘制的图像到icon上
-      val canvas = Canvas(icon!!)
+        ?: throw IllegalStateException("Failed to create output bitmap")
+      val canvas = Canvas(icon)
       canvas.save()
       canvas.drawBitmap(bg, 0f, 0f, opts.backgroundImage.applyStyle())
       canvas.restore()
-      if (!bg.isRecycled) {
-        bg.recycle()
-        System.gc()
-      }
+
       for (text in opts.watermarkTexts) {
-        //建立画笔
-        text!!.applyStyle(this.reactApplicationContext, canvas, width, height)
+        text.applyStyle(this.reactApplicationContext, canvas, width, height)
       }
 
       if (opts.backgroundImage.rotate != 0f) {
-        icon = ImageProcess.rotate(icon, opts.backgroundImage.rotate)
+        val rotatedIcon = ImageProcess.rotate(icon, opts.backgroundImage.rotate)
+        recycleBitmap(icon)
+        icon = rotatedIcon
       }
-      if (dest == BASE64) {
-        val base64Stream = ByteArrayOutputStream()
-        icon.compress(CompressFormat.PNG, opts.quality, base64Stream)
-        base64Stream.flush()
-        base64Stream.close()
-        val bitmapBytes = base64Stream.toByteArray()
-        val result = Base64.encodeToString(bitmapBytes, Base64.DEFAULT)
-        promise.resolve("data:image/png;base64,$result")
-      } else {
-        bos = BufferedOutputStream(FileOutputStream(dest))
-        icon.compress(getSaveFormat(opts.saveFormat), opts.quality, bos)
-        bos.flush()
-        bos.close()
-        //保存成功的
-        promise.resolve(dest)
-      }
+
+      return icon
     } catch (e: Exception) {
-      e.printStackTrace()
-      promise.reject("error", e.message, e)
-    } finally {
-      if (bos != null) {
-        try {
-          bos.close()
-        } catch (e: IOException) {
-          e.printStackTrace()
-        }
-      }
-      if (icon != null && !icon.isRecycled) {
-        icon.recycle()
-        System.gc()
-      }
+      recycleBitmap(icon)
+      throw e
     }
   }
 
-  private fun markImageByWatermarks(
-    bg: Bitmap?,
-    markers: List<Bitmap?>,
+  private suspend fun markImageByWatermarks(
+    bg: Bitmap,
+    markers: List<Bitmap>,
     dest: String,
-    opts: MarkWatermarkOptions,
-    promise: Promise
-  ) {
-    var bos: BufferedOutputStream? = null
+    opts: MarkWatermarkOptions
+  ): String {
     var icon: Bitmap? = null
     try {
-      icon = ImageMarkerRenderer.renderWatermarks(
-        bg!!,
-        markers,
-        opts,
-        this.reactApplicationContext,
-        recycleMarkerBitmaps = true
-      )
-
-      if (!bg.isRecycled) {
-        bg.recycle()
-        System.gc()
+      icon = withContext(Dispatchers.Default) {
+        ImageMarkerRenderer.renderWatermarks(
+          bg,
+          markers,
+          opts,
+          context,
+          recycleMarkerBitmaps = false
+        )
       }
-
-      if (dest == BASE64) {
-        val base64Stream = ByteArrayOutputStream()
-        icon.compress(CompressFormat.PNG, opts.quality, base64Stream)
-        base64Stream.flush()
-        base64Stream.close()
-        val bitmapBytes = base64Stream.toByteArray()
-        val result = Base64.encodeToString(bitmapBytes, Base64.DEFAULT)
-        promise.resolve("data:image/png;base64,$result")
-      } else {
-        bos = BufferedOutputStream(FileOutputStream(dest))
-        icon.compress(getSaveFormat(opts.saveFormat), opts.quality, bos)
-        bos.flush()
-        bos.close()
-        promise.resolve(dest)
-      }
-    } catch (e: Exception) {
-      e.printStackTrace()
-      promise.reject("error", e.message, e)
+      return writeResult(icon, dest, opts)
     } finally {
-      if (bos != null) {
-        try {
-          bos.close()
-        } catch (e: IOException) {
-          e.printStackTrace()
-        }
+      recycleBitmap(icon)
+      recycleBitmap(bg)
+      recycleBitmaps(markers)
+    }
+  }
+
+  private suspend fun writeResult(
+    icon: Bitmap,
+    dest: String,
+    opts: Options
+  ): String = withContext(Dispatchers.IO) {
+    if (dest == BASE64) {
+      return@withContext encodeBase64(icon, opts)
+    }
+
+    BufferedOutputStream(FileOutputStream(dest)).use { stream ->
+      if (!icon.compress(getSaveFormat(opts.saveFormat), opts.quality, stream)) {
+        throw IOException("Failed to encode marker image")
       }
-      if (icon != null && !icon.isRecycled) {
-        icon.recycle()
-        System.gc()
+      stream.flush()
+    }
+    dest
+  }
+
+  private fun encodeBase64(
+    icon: Bitmap,
+    opts: Options
+  ): String {
+    val bitmapBytes = ByteArrayOutputStream().use { stream ->
+      if (!icon.compress(CompressFormat.PNG, opts.quality, stream)) {
+        throw IOException("Failed to encode marker image")
       }
+      stream.flush()
+      stream.toByteArray()
+    }
+    val result = Base64.encodeToString(bitmapBytes, Base64.DEFAULT)
+    return "data:image/png;base64,$result"
+  }
+
+  private fun recycleBitmaps(bitmaps: List<Bitmap>) {
+    for (bitmap in bitmaps) {
+      recycleBitmap(bitmap)
+    }
+  }
+
+  private fun recycleBitmap(bitmap: Bitmap?) {
+    if (bitmap != null && !bitmap.isRecycled) {
+      bitmap.recycle()
     }
   }
 
@@ -226,7 +222,6 @@ class ImageMarkerManager(private val context: ReactApplicationContext) : NativeI
    * @param opts
    * @param promise
    */
-  @OptIn(DelicateCoroutinesApi::class)
   @RequiresApi(Build.VERSION_CODES.N)
   @ReactMethod
   override fun markWithText(
@@ -236,25 +231,18 @@ class ImageMarkerManager(private val context: ReactApplicationContext) : NativeI
     val markOpts = MarkTextOptions.checkParams(options, promise) ?: return
     Log.d(IMAGE_MARKER_TAG, "uri: " + markOpts.backgroundImage.uri)
     Log.d(IMAGE_MARKER_TAG, "src: " + markOpts.backgroundImage.src.toString())
-    GlobalScope.launch(Dispatchers.Main) {
-      try {
-        val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
-          listOf(
-            markOpts.backgroundImage,
-          )
+    launchMarkerJob(promise) {
+      val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
+        listOf(
+          markOpts.backgroundImage,
         )
-        val bg = bitmaps[0]
-        val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
-        markImageByText(bg, dest, markOpts, promise)
-      } catch (e: Exception) {
-        Log.d(IMAGE_MARKER_TAG, "error：" + e.message)
-        e.printStackTrace()
-        promise.reject("error", e.message, e)
-      }
+      )
+      val bg = bitmaps[0]
+      val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
+      markImageByText(bg, dest, markOpts)
     }
   }
 
-  @OptIn(DelicateCoroutinesApi::class)
   @RequiresApi(Build.VERSION_CODES.N)
   @ReactMethod
   override fun markWithImage(
@@ -262,29 +250,22 @@ class ImageMarkerManager(private val context: ReactApplicationContext) : NativeI
     promise: Promise
   ) {
     val markOpts = MarkImageOptions.checkParams(options, promise) ?: return
-    GlobalScope.launch(Dispatchers.Main) {
-      try {
-        val markers = markOpts.watermarkImages.map { it.imageOption }
-        val concatenatedArray = listOf(
-          markOpts.backgroundImage,
-        ).plus(markers)
-        val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
-          concatenatedArray,
-          listOf(true).plus(List(markers.size) { false })
-        )
-        val bg = bitmaps[0]
-        val markerBitmaps = bitmaps.subList(1, bitmaps.lastIndex + 1)
-        val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
-        markImageByBitmap(bg, markerBitmaps, dest, markOpts, promise)
-      } catch (e: Exception) {
-        Log.d(IMAGE_MARKER_TAG, "error：" + e.message)
-        e.printStackTrace()
-        promise.reject("error", e.message, e)
-      }
+    launchMarkerJob(promise) {
+      val markers = markOpts.watermarkImages.map { it.imageOption }
+      val concatenatedArray = listOf(
+        markOpts.backgroundImage,
+      ).plus(markers)
+      val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
+        concatenatedArray,
+        listOf(true).plus(List(markers.size) { false })
+      )
+      val bg = bitmaps[0]
+      val markerBitmaps = bitmaps.drop(1)
+      val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
+      markImageByBitmap(bg, markerBitmaps, dest, markOpts)
     }
   }
 
-  @OptIn(DelicateCoroutinesApi::class)
   @RequiresApi(Build.VERSION_CODES.N)
   @ReactMethod
   override fun markWithWatermarks(
@@ -292,25 +273,19 @@ class ImageMarkerManager(private val context: ReactApplicationContext) : NativeI
     promise: Promise
   ) {
     val markOpts = MarkWatermarkOptions.checkParams(options, promise) ?: return
-    GlobalScope.launch(Dispatchers.Main) {
-      try {
-        val markers = markOpts.imageLayers.map { it.imageOptions.imageOption }
-        val concatenatedArray = listOf(
-          markOpts.backgroundImage,
-        ).plus(markers)
-        val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
-          concatenatedArray,
-          listOf(true).plus(List(markers.size) { false })
-        )
-        val bg = bitmaps[0]
-        val markerBitmaps = bitmaps.subList(1, bitmaps.lastIndex + 1)
-        val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
-        markImageByWatermarks(bg, markerBitmaps, dest, markOpts, promise)
-      } catch (e: Exception) {
-        Log.d(IMAGE_MARKER_TAG, "error：" + e.message)
-        e.printStackTrace()
-        promise.reject("error", e.message, e)
-      }
+    launchMarkerJob(promise) {
+      val markers = markOpts.imageLayers.map { it.imageOptions.imageOption }
+      val concatenatedArray = listOf(
+        markOpts.backgroundImage,
+      ).plus(markers)
+      val bitmaps = MarkerImageLoader(context, markOpts.maxSize).loadImages(
+        concatenatedArray,
+        listOf(true).plus(List(markers.size) { false })
+      )
+      val bg = bitmaps[0]
+      val markerBitmaps = bitmaps.drop(1)
+      val dest = generateCacheFilePathForMarker(markOpts.filename, markOpts.saveFormat)
+      markImageByWatermarks(bg, markerBitmaps, dest, markOpts)
     }
   }
 

--- a/android/src/main/java/com/jimmydaddy/imagemarker/MarkerImageLoader.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/MarkerImageLoader.kt
@@ -21,11 +21,14 @@ import com.jimmydaddy.imagemarker.base.Constants.IMAGE_MARKER_TAG
 import com.jimmydaddy.imagemarker.base.ErrorCode
 import com.jimmydaddy.imagemarker.base.ImageOptions
 import com.jimmydaddy.imagemarker.base.MarkerError
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class MarkerImageLoader(private val context: ReactApplicationContext, private val maxSize: Int) {
 
@@ -47,7 +50,7 @@ class MarkerImageLoader(private val context: ReactApplicationContext, private va
   suspend fun loadImages(
     images: List<ImageOptions>,
     scaleImages: List<Boolean> = List(images.size) { true }
-  ): List<Bitmap?> = withContext(Dispatchers.IO) {
+  ): List<Bitmap> = withContext(Dispatchers.IO) {
 
     val deferredList = images.mapIndexed { index, img ->
       async {
@@ -57,74 +60,14 @@ class MarkerImageLoader(private val context: ReactApplicationContext, private va
           val isCoilImg = isCoilImg(img.uri)
           Log.d(IMAGE_MARKER_TAG, "isCoilImg: $isCoilImg")
 
-          if (isBase64String(img.uri)) {
-            Log.d(IMAGE_MARKER_TAG, "Loading Base64 Image")
-            decodeBase64ToBitmap(img.uri)?.let { bitmap ->
-              val scaledBitmap = ImageProcess.scaleBitmap(bitmap, scale)
-                ?: throw MarkerError(ErrorCode.LOAD_IMAGE_FAILED, "Failed to scale Base64 image")
-              if (!bitmap.isRecycled && scale != 1f) {
-                bitmap.recycle()
-                System.gc()
-              }
-              return@async scaledBitmap
-            } ?: throw MarkerError(ErrorCode.GET_RESOURCE_FAILED, "Failed to decode Base64 image")
-          } else if (isCoilImg) {
-            val future = CompletableFuture<Bitmap?>()
-            var request = ImageRequest.Builder(context)
-              .data(img.uri)
-            if (img.src != null && img.src.width > 0 && img.src.height > 0) {
-              request = request.size(img.src.width, img.src.height)
-              Log.d(IMAGE_MARKER_TAG, "src.width: " + img.src.width + " src.height: " + img.src.height)
-            }  else {
-              request = request.size(Size.ORIGINAL)
-            }
-            imageLoader.enqueue(request.target (
-              onStart = { _ ->
-                // Handle the placeholder drawable.
-                Log.d(IMAGE_MARKER_TAG, "start to load image: " + img.uri)
-              },
-              onSuccess = { result ->
-                val bitmap = result.toBitmap()
-                val bg = ImageProcess.scaleBitmap(bitmap, scale)
-                if (bg == null) {
-                  future.completeExceptionally(MarkerError(ErrorCode.LOAD_IMAGE_FAILED,
-                      "Can't retrieve the file from the src: " + img.uri))
-                }
-                future.complete(bg)
-              },
-              onError = { _ ->
-                future.completeExceptionally(MarkerError(ErrorCode.LOAD_IMAGE_FAILED,
-                  "Can't retrieve the file from the src: " + img.uri))
-              }
-            ).build())
-            return@async future.get()
-          } else {
-            val resId = getDrawableResourceByName(img.uri)
-            Log.d(IMAGE_MARKER_TAG, "resId: $resId")
-            if (resId == 0) {
-              Log.d(IMAGE_MARKER_TAG, "cannot find res")
-              throw MarkerError(ErrorCode.GET_RESOURCE_FAILED, "Can't get resource by the path: ${img.uri}")
-            } else {
-              val r = resources
-              Log.d(IMAGE_MARKER_TAG, "src.width: " + img.src.width + " src.height: " + img.src.height)
-              val originalBitMap = BitmapFactory.decodeResource(r, resId)
-              var bitmap = originalBitMap
-              if (img.src != null && img.src.width > 0 && img.src.height > 0) {
-                bitmap = Bitmap.createScaledBitmap(originalBitMap, img.src.width, img.src.height, true);
-              }
-              Log.d(IMAGE_MARKER_TAG, bitmap!!.height.toString() + "")
-              val bg = ImageProcess.scaleBitmap(bitmap, scale)
-              Log.d(IMAGE_MARKER_TAG, bg!!.height.toString() + "")
-              if (!bitmap.isRecycled && scale != 1f) {
-                bitmap.recycle()
-                System.gc()
-              }
-              return@async bg
-            }
+          when {
+            isBase64String(img.uri) -> loadBase64Image(img, scale)
+            isCoilImg -> loadCoilImage(img, scale)
+            else -> loadResourceImage(img, scale)
           }
         } catch (e: Exception) {
           Log.e("ImageLoader", "Failed to load image: ${img.uri}", e)
-          null
+          throw e
         }
       }
     }
@@ -134,9 +77,10 @@ class MarkerImageLoader(private val context: ReactApplicationContext, private va
   private fun isCoilImg(uri: String?): Boolean {
     // val base64Pattern =
     // "^data:(image|img)/(bmp|jpg|png|tif|gif|pcx|tga|exif|fpx|svg|psd|cdr|pcd|dxf|ufo|eps|ai|raw|WMF|webp);base64,(([[A-Za-z0-9+/])*\\s\\S*)*"
-    return uri!!.startsWith("http://") || uri.startsWith("https://") || uri.startsWith("file://") || uri.startsWith(
-      "data:"
-    ) && uri.contains("base64") && (uri.contains("img") || uri.contains("image"))
+    return uri?.startsWith("http://") == true ||
+      uri?.startsWith("https://") == true ||
+      uri?.startsWith("file://") == true ||
+      uri?.startsWith("data:") == true && uri.contains("base64") && (uri.contains("img") || uri.contains("image"))
   }
 
   @SuppressLint("DiscouragedApi")
@@ -152,6 +96,97 @@ class MarkerImageLoader(private val context: ReactApplicationContext, private va
   private fun isBase64String(s: String?): Boolean {
     if (s == null) return false
     return s.startsWith("data:image/") && s.contains(";base64,")
+  }
+
+  private fun loadBase64Image(img: ImageOptions, scale: Float): Bitmap {
+    Log.d(IMAGE_MARKER_TAG, "Loading Base64 Image")
+    val bitmap = decodeBase64ToBitmap(img.uri)
+      ?: throw MarkerError(ErrorCode.GET_RESOURCE_FAILED, "Failed to decode Base64 image")
+    return scaleBitmap(bitmap, scale, "Base64 image")
+  }
+
+  private suspend fun loadCoilImage(img: ImageOptions, scale: Float): Bitmap =
+    suspendCancellableCoroutine { continuation ->
+      var request = ImageRequest.Builder(context)
+        .data(img.uri)
+      if (img.src.width > 0 && img.src.height > 0) {
+        request = request.size(img.src.width, img.src.height)
+        Log.d(IMAGE_MARKER_TAG, "src.width: " + img.src.width + " src.height: " + img.src.height)
+      } else {
+        request = request.size(Size.ORIGINAL)
+      }
+
+      val disposable = imageLoader.enqueue(
+        request.target(
+          onStart = {
+            Log.d(IMAGE_MARKER_TAG, "start to load image: " + img.uri)
+          },
+          onSuccess = { result ->
+            runCatching {
+              scaleBitmap(result.toBitmap(), scale, "image: ${img.uri}")
+            }.fold(
+              onSuccess = { continuation.resumeIfActive(it) },
+              onFailure = { continuation.resumeExceptionIfActive(it) }
+            )
+          },
+          onError = {
+            continuation.resumeExceptionIfActive(
+              MarkerError(
+                ErrorCode.LOAD_IMAGE_FAILED,
+                "Can't retrieve the file from the src: " + img.uri
+              )
+            )
+          }
+        ).build()
+      )
+      continuation.invokeOnCancellation {
+        disposable.dispose()
+      }
+    }
+
+  private fun loadResourceImage(img: ImageOptions, scale: Float): Bitmap {
+    val resId = getDrawableResourceByName(img.uri)
+    Log.d(IMAGE_MARKER_TAG, "resId: $resId")
+    if (resId == 0) {
+      Log.d(IMAGE_MARKER_TAG, "cannot find res")
+      throw MarkerError(ErrorCode.GET_RESOURCE_FAILED, "Can't get resource by the path: ${img.uri}")
+    }
+
+    Log.d(IMAGE_MARKER_TAG, "src.width: " + img.src.width + " src.height: " + img.src.height)
+    val originalBitmap = BitmapFactory.decodeResource(resources, resId)
+      ?: throw MarkerError(ErrorCode.GET_RESOURCE_FAILED, "Can't decode resource by the path: ${img.uri}")
+    val sizedBitmap = if (img.src.width > 0 && img.src.height > 0) {
+      Bitmap.createScaledBitmap(originalBitmap, img.src.width, img.src.height, true).also {
+        if (it !== originalBitmap && !originalBitmap.isRecycled) {
+          originalBitmap.recycle()
+        }
+      }
+    } else {
+      originalBitmap
+    }
+
+    return scaleBitmap(sizedBitmap, scale, "resource: ${img.uri}")
+  }
+
+  private fun scaleBitmap(bitmap: Bitmap, scale: Float, source: String): Bitmap {
+    val scaledBitmap = ImageProcess.scaleBitmap(bitmap, scale)
+      ?: throw MarkerError(ErrorCode.LOAD_IMAGE_FAILED, "Failed to scale $source")
+    if (scaledBitmap !== bitmap && !bitmap.isRecycled) {
+      bitmap.recycle()
+    }
+    return scaledBitmap
+  }
+
+  private fun CancellableContinuation<Bitmap>.resumeIfActive(bitmap: Bitmap) {
+    if (isActive) {
+      resume(bitmap)
+    }
+  }
+
+  private fun CancellableContinuation<Bitmap>.resumeExceptionIfActive(error: Throwable) {
+    if (isActive) {
+      resumeWithException(error)
+    }
   }
 
   private fun decodeBase64ToBitmap(base64Str: String?): Bitmap? {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
@@ -23,12 +23,19 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
     }
     if (markerImageOpts != null) {
       val marker = ImageOptions(markerImageOpts)
-      val positionOptions =
-        if (null != options.getMap("watermarkPositions")) options.getMap("watermarkPositions") else null
-      val x = if (positionOptions!!.hasKey("X")) Utils.handleDynamicToString(positionOptions.getDynamic("X")) else null
-      val y = if (positionOptions.hasKey("Y")) Utils.handleDynamicToString(positionOptions.getDynamic("Y")) else null
+      val positionOptions = options.getMap("watermarkPositions")
+      val x = if (positionOptions?.hasKey("X") == true) {
+        Utils.handleDynamicToString(positionOptions.getDynamic("X"))
+      } else {
+        null
+      }
+      val y = if (positionOptions?.hasKey("Y") == true) {
+        Utils.handleDynamicToString(positionOptions.getDynamic("Y"))
+      } else {
+        null
+      }
       val positionEnum =
-        if (null != positionOptions.getString("position")) PositionEnum.getPosition(
+        if (positionOptions?.getString("position") != null) PositionEnum.getPosition(
           positionOptions.getString("position")
         ) else null
       val markerOpts = WatermarkImageOptions(marker, x, y, positionEnum)

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkTextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkTextOptions.kt
@@ -4,21 +4,22 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 
 class MarkTextOptions(options: ReadableMap) : Options(options) {
-  lateinit var watermarkTexts: Array<TextOptions?>
+  var watermarkTexts: Array<TextOptions>
 
   init {
     val waterMarkTextsMap = options.getArray("watermarkTexts")
-    if (waterMarkTextsMap!!.size() > 0) {
-      watermarkTexts = arrayOfNulls(waterMarkTextsMap.size())
-      for (i in 0 until waterMarkTextsMap.size()) {
-        val textMap = waterMarkTextsMap.getMap(i)
-        textMap?.let {
-          watermarkTexts[i] = TextOptions(it)
-        } ?: run {
-          throw MarkerError(ErrorCode.NULL_MAP, "watermarkTexts[$i] is null")
-        }
-      }
+    if (waterMarkTextsMap == null || waterMarkTextsMap.size() <= 0) {
+      throw MarkerError(ErrorCode.PARAMS_REQUIRED, "watermarkTexts is required")
     }
+
+    val textOptions = arrayListOf<TextOptions>()
+    for (i in 0 until waterMarkTextsMap.size()) {
+      if (waterMarkTextsMap.isNull(i)) {
+        throw MarkerError(ErrorCode.NULL_MAP, "watermarkTexts[$i] is null")
+      }
+      textOptions.add(TextOptions(waterMarkTextsMap.getMap(i)))
+    }
+    watermarkTexts = textOptions.toTypedArray()
   }
 
   companion object {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkerError.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkerError.kt
@@ -1,6 +1,7 @@
 package com.jimmydaddy.imagemarker.base
 
-class MarkerError internal constructor(private var errorCode: ErrorCode, private var errMsg: String) : Error() {
+class MarkerError internal constructor(private var errorCode: ErrorCode, private var errMsg: String) :
+  Exception(errMsg) {
 
   fun getErrorCode(): String {
     return errorCode.value

--- a/example/src/ImageMarkerLab.tsx
+++ b/example/src/ImageMarkerLab.tsx
@@ -2,16 +2,13 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Dimensions,
-  Image,
   Modal,
   Platform,
   SafeAreaView,
   ScrollView,
   StyleSheet,
-  Switch,
   Text,
   TextInput,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import Marker, {
@@ -21,6 +18,20 @@ import Marker, {
 } from 'react-native-image-marker';
 import Toast from 'react-native-toast-message';
 import { filesize } from 'filesize';
+import {
+  AppButton,
+  ArchitecturePanel,
+  type AppTab,
+  ChipGroup,
+  FeatureCard,
+  Field,
+  NumericField,
+  type OffsetValue,
+  PreviewPanel,
+  Section,
+  TabBar,
+  ToggleRow,
+} from './lab/components';
 
 const { width } = Dimensions.get('window');
 
@@ -33,16 +44,7 @@ type BackgroundFormat =
   | 'picked image';
 type WatermarkType = 'text' | 'image' | 'mixed';
 type RunMode = 'anchorOffset' | 'absoluteXY';
-type OffsetValue = number | string;
-type AppTab = 'tests' | 'compose' | 'advanced';
 type FeatureVariant = 'orientation' | 'base64';
-type ArchitectureRuntime = {
-  hasTurboModuleProxy: boolean;
-  hasFabricUIManager: boolean;
-  isBridgeless: boolean;
-  modeLabel: string;
-  isNewArchitecture: boolean;
-};
 
 export type ImageMarkerLabAssets = {
   icon: unknown;
@@ -110,35 +112,9 @@ const textAlignOptions: MarkerConfig['textAlign'][] = [
   'center',
   'right',
 ];
-const appTabs: Array<{ label: string; value: AppTab }> = [
-  { label: 'Tests', value: 'tests' },
-  { label: 'Compose', value: 'compose' },
-  { label: 'Advanced', value: 'advanced' },
-];
-
 const exampleFontName = 'MaShanZheng-Regular';
 const sharpWatermarkDataUrl =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAA1klEQVR42u3aWw6DMAwEwNz/0u0RaGRn47YTiS8eiQbJYJa11np1bk/j6fjd/Q0bAAAADgLsAu2O6noAAABwtwh2n/91TwEAAIYBdE9YfTE6UPQAAABwsAhWFxQoegAAANgogulx4YYAAAAg2MwMvD4AAAAuNjMDmiUAAP4aIB1mdu8vh6sAAACI/qBQvV53+AoAAIC7zUi6WdouggAA/DhAOphIh58fzAcAAICL4eiA5gkAAADBCQeGrwAAADj4wWJ6uAoAAIDsi1A6/Cz/IAEAwG8DvAHibmyc3jWFggAAAABJRU5ErkJggg==';
-
-function getArchitectureRuntime(): ArchitectureRuntime {
-  const runtime = globalThis as typeof globalThis & {
-    __turboModuleProxy?: unknown;
-    nativeFabricUIManager?: unknown;
-    RN$Bridgeless?: unknown;
-  };
-  const hasTurboModuleProxy = typeof runtime.__turboModuleProxy === 'function';
-  const hasFabricUIManager = runtime.nativeFabricUIManager != null;
-  const isBridgeless = runtime.RN$Bridgeless === true;
-  const isNewArchitecture = hasTurboModuleProxy && hasFabricUIManager;
-
-  return {
-    hasTurboModuleProxy,
-    hasFabricUIManager,
-    isBridgeless,
-    isNewArchitecture,
-    modeLabel: isNewArchitecture ? 'New architecture' : 'Legacy bridge',
-  };
-}
 
 const normalizeOffset = (value: OffsetValue) => {
   if (typeof value === 'string' && value.trim() === '') {
@@ -168,164 +144,6 @@ function sourceFromBackgroundFormat(
     case 'picked image':
       return assets.bg;
   }
-}
-
-function Section(props: { title: string; children: React.ReactNode }) {
-  return (
-    <View style={s.section}>
-      <Text style={s.sectionTitle}>{props.title}</Text>
-      {props.children}
-    </View>
-  );
-}
-
-function AppButton(props: {
-  label: string;
-  onPress: () => void;
-  tone?: 'primary' | 'neutral' | 'danger';
-  compact?: boolean;
-  wide?: boolean;
-  testID?: string;
-}) {
-  const tone = props.tone ?? 'primary';
-
-  return (
-    <TouchableOpacity
-      activeOpacity={0.78}
-      accessible
-      accessibilityLabel={props.label}
-      accessibilityRole="button"
-      onPress={props.onPress}
-      testID={props.testID}
-      style={[
-        s.button,
-        props.compact ? s.buttonCompact : null,
-        props.wide ? s.buttonWide : null,
-        tone === 'neutral' ? s.buttonNeutral : null,
-        tone === 'danger' ? s.buttonDanger : null,
-      ]}
-    >
-      <Text
-        style={[s.buttonText, tone === 'neutral' ? s.buttonTextDark : null]}
-      >
-        {props.label}
-      </Text>
-    </TouchableOpacity>
-  );
-}
-
-function Chip<T extends string>(props: {
-  label: string;
-  value: T;
-  selected: boolean;
-  onPress: (value: T) => void;
-}) {
-  return (
-    <TouchableOpacity
-      activeOpacity={0.78}
-      accessibilityLabel={props.label}
-      onPress={() => props.onPress(props.value)}
-      style={[s.chip, props.selected ? s.chipSelected : null]}
-    >
-      <Text style={[s.chipText, props.selected ? s.chipTextSelected : null]}>
-        {props.label}
-      </Text>
-    </TouchableOpacity>
-  );
-}
-
-function ChipGroup<T extends string>(props: {
-  options: T[];
-  value: T;
-  onChange: (value: T) => void;
-  labelFor?: (value: T) => string;
-}) {
-  return (
-    <View style={s.chipGroup}>
-      {props.options.map((option) => (
-        <Chip
-          key={option}
-          label={props.labelFor ? props.labelFor(option) : option}
-          value={option}
-          selected={option === props.value}
-          onPress={props.onChange}
-        />
-      ))}
-    </View>
-  );
-}
-
-function Field(props: {
-  label: string;
-  value: OffsetValue;
-  onChange: (value: string) => void;
-  width?: number;
-}) {
-  return (
-    <View style={[s.field, props.width ? { width: props.width } : null]}>
-      <Text style={s.fieldLabel}>{props.label}</Text>
-      <TextInput
-        keyboardType="default"
-        onChangeText={props.onChange}
-        selectTextOnFocus
-        style={s.input}
-        value={String(props.value)}
-      />
-    </View>
-  );
-}
-
-function NumericField(props: {
-  label: string;
-  value: number;
-  onChange: (value: number) => void;
-  min?: number;
-  max?: number;
-  width?: number;
-}) {
-  return (
-    <Field
-      label={props.label}
-      value={props.value}
-      width={props.width}
-      onChange={(text) => {
-        const value = Number(text);
-        if (!Number.isFinite(value)) {
-          return;
-        }
-        if (props.min != null && value < props.min) {
-          Toast.show({
-            type: 'error',
-            text1: `${props.label} range error`,
-            text2: `${props.label} must be greater than or equal to ${props.min}`,
-          });
-          return;
-        }
-        if (props.max != null && value > props.max) {
-          Toast.show({
-            type: 'error',
-            text1: `${props.label} range error`,
-            text2: `${props.label} must be less than or equal to ${props.max}`,
-          });
-          return;
-        }
-        props.onChange(value);
-      }}
-    />
-  );
-}
-
-function ToggleRow(props: {
-  label: string;
-  value: boolean;
-  onValueChange: (value: boolean) => void;
-}) {
-  return (
-    <View style={s.toggleRow}>
-      <Text style={s.toggleLabel}>{props.label}</Text>
-      <Switch value={props.value} onValueChange={props.onValueChange} />
-    </View>
-  );
 }
 
 function useViewModel(props: ImageMarkerLabProps) {
@@ -1264,158 +1082,6 @@ function useViewModel(props: ImageMarkerLabProps) {
   };
 }
 
-function FeatureCard(props: {
-  badge: string;
-  title: string;
-  meta: string;
-  tone: 'blue' | 'green' | 'orange';
-  onPress: () => void;
-  testID: string;
-}) {
-  const toneStyle = {
-    blue: {
-      badge: s.featureBadge_blue,
-      card: s.featureCard_blue,
-    },
-    green: {
-      badge: s.featureBadge_green,
-      card: s.featureCard_green,
-    },
-    orange: {
-      badge: s.featureBadge_orange,
-      card: s.featureCard_orange,
-    },
-  }[props.tone];
-
-  return (
-    <TouchableOpacity
-      activeOpacity={0.82}
-      accessible
-      accessibilityLabel={props.title}
-      accessibilityRole="button"
-      onPress={props.onPress}
-      style={[s.featureCard, toneStyle.card]}
-      testID={props.testID}
-    >
-      <Text numberOfLines={1} style={[s.featureBadge, toneStyle.badge]}>
-        {props.badge}
-      </Text>
-      <View style={s.featureCopy}>
-        <Text numberOfLines={1} style={s.featureTitle}>
-          {props.title}
-        </Text>
-        <Text numberOfLines={1} style={s.featureMeta}>
-          {props.meta}
-        </Text>
-      </View>
-      <View style={s.featureRunPill}>
-        <Text style={s.featureRunText}>Run</Text>
-      </View>
-    </TouchableOpacity>
-  );
-}
-
-function TabBar(props: { value: AppTab; onChange: (value: AppTab) => void }) {
-  return (
-    <View style={s.tabs}>
-      {appTabs.map((tab) => {
-        const selected = tab.value === props.value;
-
-        return (
-          <TouchableOpacity
-            activeOpacity={0.78}
-            accessibilityLabel={tab.label}
-            accessibilityRole="button"
-            key={tab.value}
-            onPress={() => props.onChange(tab.value)}
-            style={[s.tab, selected ? s.tabSelected : null]}
-          >
-            <Text style={[s.tabText, selected ? s.tabTextSelected : null]}>
-              {tab.label}
-            </Text>
-          </TouchableOpacity>
-        );
-      })}
-    </View>
-  );
-}
-
-function ArchitectureSignal(props: { label: string; active: boolean }) {
-  return (
-    <View
-      accessibilityLabel={`${props.label} ${props.active ? 'on' : 'off'}`}
-      style={s.archSignal}
-    >
-      <View
-        style={[
-          s.archSignalDot,
-          props.active ? s.archSignalDotOn : s.archSignalDotOff,
-        ]}
-      />
-      <Text style={s.archSignalLabel}>{props.label}</Text>
-      <Text
-        style={[
-          s.archSignalValue,
-          props.active ? s.archSignalValueOn : s.archSignalValueOff,
-        ]}
-      >
-        {props.active ? 'on' : 'off'}
-      </Text>
-    </View>
-  );
-}
-
-function ArchitecturePanel() {
-  const runtime = useMemo(getArchitectureRuntime, []);
-
-  return (
-    <View
-      accessibilityLabel={`runtime architecture ${runtime.modeLabel}`}
-      accessible
-      style={s.archPanel}
-      testID="runtime-architecture-status"
-    >
-      <View style={s.archHeader}>
-        <View>
-          <Text style={s.archEyebrow}>Runtime</Text>
-          <Text style={s.archTitle}>Architecture status</Text>
-        </View>
-        <View
-          style={[
-            s.archModePill,
-            runtime.isNewArchitecture
-              ? s.archModePillNew
-              : s.archModePillLegacy,
-          ]}
-        >
-          <Text
-            style={[
-              s.archModeText,
-              runtime.isNewArchitecture
-                ? s.archModeTextNew
-                : s.archModeTextLegacy,
-            ]}
-            numberOfLines={1}
-          >
-            {runtime.modeLabel}
-          </Text>
-        </View>
-      </View>
-      <View style={s.archSignals}>
-        <ArchitectureSignal
-          label="TurboModule"
-          active={runtime.hasTurboModuleProxy}
-        />
-        <ArchitectureSignal
-          label="Fabric renderer"
-          active={runtime.hasFabricUIManager}
-        />
-        <ArchitectureSignal label="Bridgeless" active={runtime.isBridgeless} />
-      </View>
-    </View>
-  );
-}
-
 function TabPage(props: {
   show: boolean;
   uri: string;
@@ -1436,122 +1102,6 @@ function TabPage(props: {
       />
       {props.children}
     </>
-  );
-}
-
-function PreviewPanel(props: {
-  show: boolean;
-  uri: string;
-  fileSize: string;
-  onClear: () => void;
-  compact?: boolean;
-}) {
-  const [previewOpen, setPreviewOpen] = useState(false);
-
-  useEffect(() => {
-    if (!props.show) {
-      setPreviewOpen(false);
-    }
-  }, [props.show]);
-
-  return (
-    <View style={s.previewPanel}>
-      <View style={s.previewHeader}>
-        <View>
-          <Text style={s.previewTitle}>Result preview</Text>
-          <Text style={s.previewSubtle}>Size {props.fileSize}</Text>
-        </View>
-        <View style={s.previewActions}>
-          <AppButton
-            compact
-            label="Clear"
-            tone="neutral"
-            onPress={props.onClear}
-          />
-        </View>
-      </View>
-      <View
-        accessibilityLabel={
-          props.show ? 'result-preview-ready' : 'result-preview-empty'
-        }
-        accessible
-        style={[s.previewFrame, props.compact ? s.previewFrameCompact : null]}
-        testID={props.show ? 'result-preview-ready' : 'result-preview-empty'}
-      >
-        {props.show ? (
-          <TouchableOpacity
-            activeOpacity={0.9}
-            accessibilityLabel="Open result preview"
-            accessibilityRole="imagebutton"
-            onPress={() => setPreviewOpen(true)}
-            style={s.previewImageButton}
-            testID="result-preview-open"
-          >
-            <Image
-              accessible
-              accessibilityLabel="result-preview-image"
-              source={{ uri: props.uri }}
-              testID="result-preview-image"
-              resizeMode="contain"
-              style={s.previewImage}
-            />
-          </TouchableOpacity>
-        ) : (
-          <View style={s.previewEmpty}>
-            <Text style={s.previewEmptyTitle}>No output yet</Text>
-            <Text style={s.previewEmptyText}>Ready for the next mark</Text>
-          </View>
-        )}
-      </View>
-      {props.show && previewOpen ? (
-        <Modal
-          animationType="fade"
-          transparent
-          visible
-          statusBarTranslucent
-          onRequestClose={() => setPreviewOpen(false)}
-        >
-          <SafeAreaView style={s.previewModalContainer}>
-            <View style={s.previewModalContent}>
-              <View style={s.previewModalHeader}>
-                <Text style={s.previewModalTitle}>Result preview</Text>
-                <TouchableOpacity
-                  activeOpacity={0.78}
-                  accessible
-                  accessibilityLabel="Close result preview"
-                  accessibilityRole="button"
-                  onPress={() => setPreviewOpen(false)}
-                  style={[
-                    s.button,
-                    s.buttonCompact,
-                    s.buttonNeutral,
-                    s.previewModalCloseButton,
-                  ]}
-                  testID="result-preview-close"
-                >
-                  <Text style={[s.buttonText, s.buttonTextDark]}>Close</Text>
-                </TouchableOpacity>
-              </View>
-              <View
-                accessibilityLabel="result-preview-modal"
-                accessible
-                style={s.previewModalFrame}
-                testID="result-preview-modal"
-              >
-                <Image
-                  accessible
-                  accessibilityLabel="result-preview-modal-image"
-                  resizeMode="contain"
-                  source={{ uri: props.uri }}
-                  style={s.previewModalImage}
-                  testID="result-preview-modal-image"
-                />
-              </View>
-            </View>
-          </SafeAreaView>
-        </Modal>
-      ) : null}
-    </View>
   );
 }
 
@@ -2048,321 +1598,8 @@ const s = StyleSheet.create({
     fontSize: 12,
     fontWeight: '700',
   },
-  tabs: {
-    backgroundColor: '#E6EDF2',
-    borderColor: '#D6E0E6',
-    borderRadius: 8,
-    borderWidth: 1,
-    flexDirection: 'row',
-    marginTop: 12,
-    padding: 3,
-  },
-  tab: {
-    alignItems: 'center',
-    borderRadius: 6,
-    flex: 1,
-    justifyContent: 'center',
-    minHeight: 36,
-  },
-  tabSelected: {
-    backgroundColor: '#0F172A',
-  },
-  tabText: {
-    color: '#475569',
-    fontSize: 13,
-    fontWeight: '800',
-  },
-  tabTextSelected: {
-    color: '#FFFFFF',
-  },
-  archPanel: {
-    backgroundColor: '#FFFFFF',
-    borderColor: '#DCE5EA',
-    borderRadius: 8,
-    borderWidth: 1,
-    marginBottom: 12,
-    padding: 10,
-  },
-  archHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 10,
-  },
-  archEyebrow: {
-    color: '#64748B',
-    fontSize: 11,
-    fontWeight: '800',
-    letterSpacing: 0,
-    textTransform: 'uppercase',
-  },
-  archTitle: {
-    color: '#0F172A',
-    fontSize: 16,
-    fontWeight: '800',
-    marginTop: 2,
-  },
-  archModePill: {
-    borderRadius: 7,
-    borderWidth: 1,
-    marginLeft: 10,
-    maxWidth: width * 0.48,
-    paddingHorizontal: 10,
-    paddingVertical: 7,
-  },
-  archModePillNew: {
-    backgroundColor: '#DCFCE7',
-    borderColor: '#BBF7D0',
-  },
-  archModePillLegacy: {
-    backgroundColor: '#FEF3C7',
-    borderColor: '#FDE68A',
-  },
-  archModeText: {
-    fontSize: 12,
-    fontWeight: '800',
-  },
-  archModeTextNew: {
-    color: '#166534',
-  },
-  archModeTextLegacy: {
-    color: '#92400E',
-  },
-  archSignals: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginHorizontal: -3,
-    marginVertical: -3,
-  },
-  archSignal: {
-    alignItems: 'center',
-    backgroundColor: '#F8FAFC',
-    borderColor: '#E2E8F0',
-    borderRadius: 7,
-    borderWidth: 1,
-    flexDirection: 'row',
-    margin: 3,
-    minHeight: 32,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
-  },
-  archSignalDot: {
-    borderRadius: 4,
-    height: 8,
-    marginRight: 6,
-    width: 8,
-  },
-  archSignalDotOn: {
-    backgroundColor: '#16A34A',
-  },
-  archSignalDotOff: {
-    backgroundColor: '#CBD5E1',
-  },
-  archSignalLabel: {
-    color: '#334155',
-    fontSize: 12,
-    fontWeight: '700',
-    marginRight: 6,
-  },
-  archSignalValue: {
-    fontSize: 12,
-    fontWeight: '800',
-  },
-  archSignalValueOn: {
-    color: '#15803D',
-  },
-  archSignalValueOff: {
-    color: '#64748B',
-  },
-  previewPanel: {
-    backgroundColor: '#FFFFFF',
-    borderColor: '#DCE5EA',
-    borderRadius: 8,
-    borderWidth: 1,
-    marginBottom: 12,
-    padding: 10,
-    shadowColor: '#0F172A',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.05,
-    shadowRadius: 10,
-    elevation: 1,
-  },
-  previewHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 10,
-  },
-  previewTitle: {
-    color: '#0F172A',
-    fontSize: 16,
-    fontWeight: '800',
-  },
-  previewSubtle: {
-    color: '#64748B',
-    fontSize: 12,
-    marginTop: 2,
-  },
-  previewActions: {
-    alignItems: 'flex-end',
-  },
-  previewFrame: {
-    alignItems: 'center',
-    aspectRatio: 16 / 7,
-    backgroundColor: '#E7EEF3',
-    borderRadius: 6,
-    justifyContent: 'center',
-    overflow: 'hidden',
-    width: '100%',
-  },
-  previewFrameCompact: {
-    aspectRatio: 16 / 5,
-  },
-  previewImageButton: {
-    height: '100%',
-    width: '100%',
-  },
-  previewImage: {
-    height: '100%',
-    width: '100%',
-  },
-  previewEmpty: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 20,
-  },
-  previewEmptyTitle: {
-    color: '#334155',
-    fontSize: 17,
-    fontWeight: '800',
-  },
-  previewEmptyText: {
-    color: '#64748B',
-    fontSize: 13,
-    marginTop: 4,
-  },
-  previewModalContainer: {
-    backgroundColor: 'rgba(15, 23, 42, 0.86)',
-    flex: 1,
-    justifyContent: 'center',
-    padding: 14,
-  },
-  previewModalContent: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-  previewModalHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 12,
-  },
-  previewModalTitle: {
-    color: '#F8FAFC',
-    fontSize: 18,
-    fontWeight: '800',
-  },
-  previewModalCloseButton: {
-    margin: 0,
-  },
-  previewModalFrame: {
-    alignItems: 'center',
-    backgroundColor: '#0F172A',
-    borderColor: '#334155',
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    justifyContent: 'center',
-    overflow: 'hidden',
-    width: '100%',
-  },
-  previewModalImage: {
-    height: '100%',
-    width: '100%',
-  },
-  section: {
-    marginBottom: 14,
-  },
-  sectionTitle: {
-    color: '#0F172A',
-    fontSize: 15,
-    fontWeight: '800',
-    marginBottom: 8,
-  },
   featureList: {
     marginBottom: -8,
-  },
-  featureCard: {
-    alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 8,
-    borderWidth: 1,
-    flexDirection: 'row',
-    marginBottom: 8,
-    minHeight: 64,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    width: '100%',
-  },
-  featureCard_blue: {
-    borderColor: '#BFDBFE',
-  },
-  featureCard_green: {
-    borderColor: '#BBF7D0',
-  },
-  featureCard_orange: {
-    borderColor: '#FED7AA',
-  },
-  featureBadge: {
-    borderRadius: 6,
-    fontSize: 12,
-    fontWeight: '800',
-    marginRight: 10,
-    overflow: 'hidden',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    textAlign: 'center',
-    width: 64,
-  },
-  featureBadge_blue: {
-    backgroundColor: '#DBEAFE',
-    color: '#1D4ED8',
-  },
-  featureBadge_green: {
-    backgroundColor: '#DCFCE7',
-    color: '#15803D',
-  },
-  featureBadge_orange: {
-    backgroundColor: '#FFEDD5',
-    color: '#C2410C',
-  },
-  featureTitle: {
-    color: '#0F172A',
-    fontSize: 15,
-    fontWeight: '800',
-  },
-  featureMeta: {
-    color: '#64748B',
-    fontSize: 13,
-    marginTop: 3,
-  },
-  featureCopy: {
-    flex: 1,
-    minWidth: 0,
-  },
-  featureRunPill: {
-    backgroundColor: '#F8FAFC',
-    borderColor: '#CBD5E1',
-    borderRadius: 6,
-    borderWidth: 1,
-    marginLeft: 10,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-  },
-  featureRunText: {
-    color: '#0F172A',
-    fontSize: 12,
-    fontWeight: '800',
   },
   controlPanel: {
     backgroundColor: '#FFFFFF',
@@ -2380,75 +1617,12 @@ const s = StyleSheet.create({
     fontWeight: '800',
     marginBottom: 8,
   },
-  chipGroup: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginHorizontal: -3,
-    marginVertical: -3,
-  },
-  chip: {
-    backgroundColor: '#F8FAFC',
-    borderColor: '#CBD5E1',
-    borderRadius: 7,
-    borderWidth: 1,
-    margin: 3,
-    minHeight: 32,
-    paddingHorizontal: 10,
-    paddingVertical: 7,
-  },
-  chipSelected: {
-    backgroundColor: '#0F172A',
-    borderColor: '#0F172A',
-  },
-  chipText: {
-    color: '#334155',
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  chipTextSelected: {
-    color: '#FFFFFF',
-  },
   inlineActions: {
     alignItems: 'center',
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginHorizontal: -4,
     marginTop: 4,
-  },
-  button: {
-    alignItems: 'center',
-    backgroundColor: '#2563EB',
-    borderRadius: 7,
-    justifyContent: 'center',
-    margin: 4,
-    minHeight: 42,
-    paddingHorizontal: 14,
-    paddingVertical: 9,
-  },
-  buttonCompact: {
-    minHeight: 36,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-  },
-  buttonNeutral: {
-    backgroundColor: '#E6EDF2',
-  },
-  buttonDanger: {
-    backgroundColor: '#E11D48',
-  },
-  buttonText: {
-    color: '#FFFFFF',
-    fontSize: 13,
-    fontWeight: '800',
-    textAlign: 'center',
-  },
-  buttonTextDark: {
-    color: '#0F172A',
-  },
-  buttonWide: {
-    flexBasis: 0,
-    flexGrow: 1,
-    minWidth: 150,
   },
   fieldGrid: {
     flexDirection: 'row',
@@ -2462,25 +1636,11 @@ const s = StyleSheet.create({
     marginHorizontal: -4,
     marginTop: -4,
   },
-  field: {
-    margin: 4,
-  },
   fieldLabel: {
     color: '#475569',
     fontSize: 12,
     fontWeight: '800',
     marginBottom: 6,
-  },
-  input: {
-    backgroundColor: '#F8FAFC',
-    borderColor: '#CBD5E1',
-    borderRadius: 7,
-    borderWidth: 1,
-    color: '#0F172A',
-    fontSize: 15,
-    minHeight: 40,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
   },
   textEditor: {
     marginTop: 2,
@@ -2556,19 +1716,6 @@ const s = StyleSheet.create({
   },
   toggleGrid: {
     marginTop: 12,
-  },
-  toggleRow: {
-    alignItems: 'center',
-    borderBottomColor: '#E2E8F0',
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    minHeight: 46,
-  },
-  toggleLabel: {
-    color: '#334155',
-    fontSize: 14,
-    fontWeight: '700',
   },
   loading: {
     alignItems: 'center',

--- a/example/src/lab/components.tsx
+++ b/example/src/lab/components.tsx
@@ -1,0 +1,894 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Dimensions,
+  Image,
+  Modal,
+  SafeAreaView,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Toast from 'react-native-toast-message';
+
+const { width } = Dimensions.get('window');
+
+export type OffsetValue = number | string;
+export type AppTab = 'tests' | 'compose' | 'advanced';
+
+type ArchitectureRuntime = {
+  hasTurboModuleProxy: boolean;
+  hasFabricUIManager: boolean;
+  isBridgeless: boolean;
+  modeLabel: string;
+  isNewArchitecture: boolean;
+};
+
+const appTabs: Array<{ label: string; value: AppTab }> = [
+  { label: 'Tests', value: 'tests' },
+  { label: 'Compose', value: 'compose' },
+  { label: 'Advanced', value: 'advanced' },
+];
+
+function getArchitectureRuntime(): ArchitectureRuntime {
+  const runtime = globalThis as typeof globalThis & {
+    __turboModuleProxy?: unknown;
+    nativeFabricUIManager?: unknown;
+    RN$Bridgeless?: unknown;
+  };
+  const hasTurboModuleProxy = typeof runtime.__turboModuleProxy === 'function';
+  const hasFabricUIManager = runtime.nativeFabricUIManager != null;
+  const isBridgeless = runtime.RN$Bridgeless === true;
+  const isNewArchitecture = hasTurboModuleProxy && hasFabricUIManager;
+
+  return {
+    hasTurboModuleProxy,
+    hasFabricUIManager,
+    isBridgeless,
+    isNewArchitecture,
+    modeLabel: isNewArchitecture ? 'New architecture' : 'Legacy bridge',
+  };
+}
+
+export function Section(props: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={s.section}>
+      <Text style={s.sectionTitle}>{props.title}</Text>
+      {props.children}
+    </View>
+  );
+}
+
+export function AppButton(props: {
+  label: string;
+  onPress: () => void;
+  tone?: 'primary' | 'neutral' | 'danger';
+  compact?: boolean;
+  wide?: boolean;
+  testID?: string;
+}) {
+  const tone = props.tone ?? 'primary';
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.78}
+      accessible
+      accessibilityLabel={props.label}
+      accessibilityRole="button"
+      onPress={props.onPress}
+      testID={props.testID}
+      style={[
+        s.button,
+        props.compact ? s.buttonCompact : null,
+        props.wide ? s.buttonWide : null,
+        tone === 'neutral' ? s.buttonNeutral : null,
+        tone === 'danger' ? s.buttonDanger : null,
+      ]}
+    >
+      <Text
+        style={[s.buttonText, tone === 'neutral' ? s.buttonTextDark : null]}
+      >
+        {props.label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function Chip<T extends string>(props: {
+  label: string;
+  value: T;
+  selected: boolean;
+  onPress: (value: T) => void;
+}) {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.78}
+      accessibilityLabel={props.label}
+      onPress={() => props.onPress(props.value)}
+      style={[s.chip, props.selected ? s.chipSelected : null]}
+    >
+      <Text style={[s.chipText, props.selected ? s.chipTextSelected : null]}>
+        {props.label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+export function ChipGroup<T extends string>(props: {
+  options: T[];
+  value: T;
+  onChange: (value: T) => void;
+  labelFor?: (value: T) => string;
+}) {
+  return (
+    <View style={s.chipGroup}>
+      {props.options.map((option) => (
+        <Chip
+          key={option}
+          label={props.labelFor ? props.labelFor(option) : option}
+          value={option}
+          selected={option === props.value}
+          onPress={props.onChange}
+        />
+      ))}
+    </View>
+  );
+}
+
+export function Field(props: {
+  label: string;
+  value: OffsetValue;
+  onChange: (value: string) => void;
+  width?: number;
+}) {
+  return (
+    <View style={[s.field, props.width ? { width: props.width } : null]}>
+      <Text style={s.fieldLabel}>{props.label}</Text>
+      <TextInput
+        keyboardType="default"
+        onChangeText={props.onChange}
+        selectTextOnFocus
+        style={s.input}
+        value={String(props.value)}
+      />
+    </View>
+  );
+}
+
+export function NumericField(props: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  width?: number;
+}) {
+  return (
+    <Field
+      label={props.label}
+      value={props.value}
+      width={props.width}
+      onChange={(text) => {
+        const value = Number(text);
+        if (!Number.isFinite(value)) {
+          return;
+        }
+        if (props.min != null && value < props.min) {
+          Toast.show({
+            type: 'error',
+            text1: `${props.label} range error`,
+            text2: `${props.label} must be greater than or equal to ${props.min}`,
+          });
+          return;
+        }
+        if (props.max != null && value > props.max) {
+          Toast.show({
+            type: 'error',
+            text1: `${props.label} range error`,
+            text2: `${props.label} must be less than or equal to ${props.max}`,
+          });
+          return;
+        }
+        props.onChange(value);
+      }}
+    />
+  );
+}
+
+export function ToggleRow(props: {
+  label: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+}) {
+  return (
+    <View style={s.toggleRow}>
+      <Text style={s.toggleLabel}>{props.label}</Text>
+      <Switch value={props.value} onValueChange={props.onValueChange} />
+    </View>
+  );
+}
+
+export function FeatureCard(props: {
+  badge: string;
+  title: string;
+  meta: string;
+  tone: 'blue' | 'green' | 'orange';
+  onPress: () => void;
+  testID: string;
+}) {
+  const toneStyle = {
+    blue: {
+      badge: s.featureBadge_blue,
+      card: s.featureCard_blue,
+    },
+    green: {
+      badge: s.featureBadge_green,
+      card: s.featureCard_green,
+    },
+    orange: {
+      badge: s.featureBadge_orange,
+      card: s.featureCard_orange,
+    },
+  }[props.tone];
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.82}
+      accessible
+      accessibilityLabel={props.title}
+      accessibilityRole="button"
+      onPress={props.onPress}
+      style={[s.featureCard, toneStyle.card]}
+      testID={props.testID}
+    >
+      <Text numberOfLines={1} style={[s.featureBadge, toneStyle.badge]}>
+        {props.badge}
+      </Text>
+      <View style={s.featureCopy}>
+        <Text numberOfLines={1} style={s.featureTitle}>
+          {props.title}
+        </Text>
+        <Text numberOfLines={1} style={s.featureMeta}>
+          {props.meta}
+        </Text>
+      </View>
+      <View style={s.featureRunPill}>
+        <Text style={s.featureRunText}>Run</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export function TabBar(props: {
+  value: AppTab;
+  onChange: (value: AppTab) => void;
+}) {
+  return (
+    <View style={s.tabs}>
+      {appTabs.map((tab) => {
+        const selected = tab.value === props.value;
+
+        return (
+          <TouchableOpacity
+            activeOpacity={0.78}
+            accessibilityLabel={tab.label}
+            accessibilityRole="button"
+            key={tab.value}
+            onPress={() => props.onChange(tab.value)}
+            style={[s.tab, selected ? s.tabSelected : null]}
+          >
+            <Text style={[s.tabText, selected ? s.tabTextSelected : null]}>
+              {tab.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+function ArchitectureSignal(props: { label: string; active: boolean }) {
+  return (
+    <View
+      accessibilityLabel={`${props.label} ${props.active ? 'on' : 'off'}`}
+      style={s.archSignal}
+    >
+      <View
+        style={[
+          s.archSignalDot,
+          props.active ? s.archSignalDotOn : s.archSignalDotOff,
+        ]}
+      />
+      <Text style={s.archSignalLabel}>{props.label}</Text>
+      <Text
+        style={[
+          s.archSignalValue,
+          props.active ? s.archSignalValueOn : s.archSignalValueOff,
+        ]}
+      >
+        {props.active ? 'on' : 'off'}
+      </Text>
+    </View>
+  );
+}
+
+export function ArchitecturePanel() {
+  const runtime = useMemo(getArchitectureRuntime, []);
+
+  return (
+    <View
+      accessibilityLabel={`runtime architecture ${runtime.modeLabel}`}
+      accessible
+      style={s.archPanel}
+      testID="runtime-architecture-status"
+    >
+      <View style={s.archHeader}>
+        <View>
+          <Text style={s.archEyebrow}>Runtime</Text>
+          <Text style={s.archTitle}>Architecture status</Text>
+        </View>
+        <View
+          style={[
+            s.archModePill,
+            runtime.isNewArchitecture
+              ? s.archModePillNew
+              : s.archModePillLegacy,
+          ]}
+        >
+          <Text
+            style={[
+              s.archModeText,
+              runtime.isNewArchitecture
+                ? s.archModeTextNew
+                : s.archModeTextLegacy,
+            ]}
+            numberOfLines={1}
+          >
+            {runtime.modeLabel}
+          </Text>
+        </View>
+      </View>
+      <View style={s.archSignals}>
+        <ArchitectureSignal
+          label="TurboModule"
+          active={runtime.hasTurboModuleProxy}
+        />
+        <ArchitectureSignal
+          label="Fabric renderer"
+          active={runtime.hasFabricUIManager}
+        />
+        <ArchitectureSignal label="Bridgeless" active={runtime.isBridgeless} />
+      </View>
+    </View>
+  );
+}
+
+export function PreviewPanel(props: {
+  show: boolean;
+  uri: string;
+  fileSize: string;
+  onClear: () => void;
+  compact?: boolean;
+}) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  useEffect(() => {
+    if (!props.show) {
+      setPreviewOpen(false);
+    }
+  }, [props.show]);
+
+  return (
+    <View style={s.previewPanel}>
+      <View style={s.previewHeader}>
+        <View>
+          <Text style={s.previewTitle}>Result preview</Text>
+          <Text style={s.previewSubtle}>Size {props.fileSize}</Text>
+        </View>
+        <View style={s.previewActions}>
+          <AppButton
+            compact
+            label="Clear"
+            tone="neutral"
+            onPress={props.onClear}
+          />
+        </View>
+      </View>
+      <View
+        accessibilityLabel={
+          props.show ? 'result-preview-ready' : 'result-preview-empty'
+        }
+        accessible
+        style={[s.previewFrame, props.compact ? s.previewFrameCompact : null]}
+        testID={props.show ? 'result-preview-ready' : 'result-preview-empty'}
+      >
+        {props.show ? (
+          <TouchableOpacity
+            activeOpacity={0.9}
+            accessibilityLabel="Open result preview"
+            accessibilityRole="imagebutton"
+            onPress={() => setPreviewOpen(true)}
+            style={s.previewImageButton}
+            testID="result-preview-open"
+          >
+            <Image
+              accessible
+              accessibilityLabel="result-preview-image"
+              source={{ uri: props.uri }}
+              testID="result-preview-image"
+              resizeMode="contain"
+              style={s.previewImage}
+            />
+          </TouchableOpacity>
+        ) : (
+          <View style={s.previewEmpty}>
+            <Text style={s.previewEmptyTitle}>No output yet</Text>
+            <Text style={s.previewEmptyText}>Ready for the next mark</Text>
+          </View>
+        )}
+      </View>
+      {props.show && previewOpen ? (
+        <Modal
+          animationType="fade"
+          transparent
+          visible
+          statusBarTranslucent
+          onRequestClose={() => setPreviewOpen(false)}
+        >
+          <SafeAreaView style={s.previewModalContainer}>
+            <View style={s.previewModalContent}>
+              <View style={s.previewModalHeader}>
+                <Text style={s.previewModalTitle}>Result preview</Text>
+                <TouchableOpacity
+                  activeOpacity={0.78}
+                  accessible
+                  accessibilityLabel="Close result preview"
+                  accessibilityRole="button"
+                  onPress={() => setPreviewOpen(false)}
+                  style={[
+                    s.button,
+                    s.buttonCompact,
+                    s.buttonNeutral,
+                    s.previewModalCloseButton,
+                  ]}
+                  testID="result-preview-close"
+                >
+                  <Text style={[s.buttonText, s.buttonTextDark]}>Close</Text>
+                </TouchableOpacity>
+              </View>
+              <View
+                accessibilityLabel="result-preview-modal"
+                accessible
+                style={s.previewModalFrame}
+                testID="result-preview-modal"
+              >
+                <Image
+                  accessible
+                  accessibilityLabel="result-preview-modal-image"
+                  resizeMode="contain"
+                  source={{ uri: props.uri }}
+                  style={s.previewModalImage}
+                  testID="result-preview-modal-image"
+                />
+              </View>
+            </View>
+          </SafeAreaView>
+        </Modal>
+      ) : null}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  tabs: {
+    backgroundColor: '#E6EDF2',
+    borderColor: '#D6E0E6',
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginTop: 12,
+    padding: 3,
+  },
+  tab: {
+    alignItems: 'center',
+    borderRadius: 6,
+    flex: 1,
+    justifyContent: 'center',
+    minHeight: 36,
+  },
+  tabSelected: {
+    backgroundColor: '#0F172A',
+  },
+  tabText: {
+    color: '#475569',
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  tabTextSelected: {
+    color: '#FFFFFF',
+  },
+  archPanel: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#DCE5EA',
+    borderRadius: 8,
+    borderWidth: 1,
+    marginBottom: 12,
+    padding: 10,
+  },
+  archHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  archEyebrow: {
+    color: '#64748B',
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0,
+    textTransform: 'uppercase',
+  },
+  archTitle: {
+    color: '#0F172A',
+    fontSize: 16,
+    fontWeight: '800',
+    marginTop: 2,
+  },
+  archModePill: {
+    borderRadius: 7,
+    borderWidth: 1,
+    marginLeft: 10,
+    maxWidth: width * 0.48,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  archModePillNew: {
+    backgroundColor: '#DCFCE7',
+    borderColor: '#BBF7D0',
+  },
+  archModePillLegacy: {
+    backgroundColor: '#FEF3C7',
+    borderColor: '#FDE68A',
+  },
+  archModeText: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  archModeTextNew: {
+    color: '#166534',
+  },
+  archModeTextLegacy: {
+    color: '#92400E',
+  },
+  archSignals: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -3,
+    marginVertical: -3,
+  },
+  archSignal: {
+    alignItems: 'center',
+    backgroundColor: '#F8FAFC',
+    borderColor: '#E2E8F0',
+    borderRadius: 7,
+    borderWidth: 1,
+    flexDirection: 'row',
+    margin: 3,
+    minHeight: 32,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  archSignalDot: {
+    borderRadius: 4,
+    height: 8,
+    marginRight: 6,
+    width: 8,
+  },
+  archSignalDotOn: {
+    backgroundColor: '#16A34A',
+  },
+  archSignalDotOff: {
+    backgroundColor: '#CBD5E1',
+  },
+  archSignalLabel: {
+    color: '#334155',
+    fontSize: 12,
+    fontWeight: '700',
+    marginRight: 6,
+  },
+  archSignalValue: {
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  archSignalValueOn: {
+    color: '#15803D',
+  },
+  archSignalValueOff: {
+    color: '#64748B',
+  },
+  previewPanel: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#DCE5EA',
+    borderRadius: 8,
+    borderWidth: 1,
+    marginBottom: 12,
+    padding: 10,
+    shadowColor: '#0F172A',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    elevation: 1,
+  },
+  previewHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  previewTitle: {
+    color: '#0F172A',
+    fontSize: 16,
+    fontWeight: '800',
+  },
+  previewSubtle: {
+    color: '#64748B',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  previewActions: {
+    alignItems: 'flex-end',
+  },
+  previewFrame: {
+    alignItems: 'center',
+    aspectRatio: 16 / 7,
+    backgroundColor: '#E7EEF3',
+    borderRadius: 6,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    width: '100%',
+  },
+  previewFrameCompact: {
+    aspectRatio: 16 / 5,
+  },
+  previewImageButton: {
+    height: '100%',
+    width: '100%',
+  },
+  previewImage: {
+    height: '100%',
+    width: '100%',
+  },
+  previewEmpty: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  previewEmptyTitle: {
+    color: '#334155',
+    fontSize: 17,
+    fontWeight: '800',
+  },
+  previewEmptyText: {
+    color: '#64748B',
+    fontSize: 13,
+    marginTop: 4,
+  },
+  previewModalContainer: {
+    backgroundColor: 'rgba(15, 23, 42, 0.86)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 14,
+  },
+  previewModalContent: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  previewModalHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  previewModalTitle: {
+    color: '#F8FAFC',
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  previewModalCloseButton: {
+    margin: 0,
+  },
+  previewModalFrame: {
+    alignItems: 'center',
+    backgroundColor: '#0F172A',
+    borderColor: '#334155',
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    width: '100%',
+  },
+  previewModalImage: {
+    height: '100%',
+    width: '100%',
+  },
+  section: {
+    marginBottom: 14,
+  },
+  sectionTitle: {
+    color: '#0F172A',
+    fontSize: 15,
+    fontWeight: '800',
+    marginBottom: 8,
+  },
+  featureCard: {
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginBottom: 8,
+    minHeight: 64,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    width: '100%',
+  },
+  featureCard_blue: {
+    borderColor: '#BFDBFE',
+  },
+  featureCard_green: {
+    borderColor: '#BBF7D0',
+  },
+  featureCard_orange: {
+    borderColor: '#FED7AA',
+  },
+  featureBadge: {
+    borderRadius: 6,
+    fontSize: 12,
+    fontWeight: '800',
+    marginRight: 10,
+    overflow: 'hidden',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    textAlign: 'center',
+    width: 64,
+  },
+  featureBadge_blue: {
+    backgroundColor: '#DBEAFE',
+    color: '#1D4ED8',
+  },
+  featureBadge_green: {
+    backgroundColor: '#DCFCE7',
+    color: '#15803D',
+  },
+  featureBadge_orange: {
+    backgroundColor: '#FFEDD5',
+    color: '#C2410C',
+  },
+  featureTitle: {
+    color: '#0F172A',
+    fontSize: 15,
+    fontWeight: '800',
+  },
+  featureMeta: {
+    color: '#64748B',
+    fontSize: 13,
+    marginTop: 3,
+  },
+  featureCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  featureRunPill: {
+    backgroundColor: '#F8FAFC',
+    borderColor: '#CBD5E1',
+    borderRadius: 6,
+    borderWidth: 1,
+    marginLeft: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  featureRunText: {
+    color: '#0F172A',
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  chipGroup: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -3,
+    marginVertical: -3,
+  },
+  chip: {
+    backgroundColor: '#F8FAFC',
+    borderColor: '#CBD5E1',
+    borderRadius: 7,
+    borderWidth: 1,
+    margin: 3,
+    minHeight: 32,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  chipSelected: {
+    backgroundColor: '#0F172A',
+    borderColor: '#0F172A',
+  },
+  chipText: {
+    color: '#334155',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  chipTextSelected: {
+    color: '#FFFFFF',
+  },
+  button: {
+    alignItems: 'center',
+    backgroundColor: '#2563EB',
+    borderRadius: 7,
+    justifyContent: 'center',
+    margin: 4,
+    minHeight: 42,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+  },
+  buttonCompact: {
+    minHeight: 36,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  buttonNeutral: {
+    backgroundColor: '#E6EDF2',
+  },
+  buttonDanger: {
+    backgroundColor: '#E11D48',
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  buttonTextDark: {
+    color: '#0F172A',
+  },
+  buttonWide: {
+    flexBasis: 0,
+    flexGrow: 1,
+    minWidth: 150,
+  },
+  field: {
+    margin: 4,
+  },
+  fieldLabel: {
+    color: '#475569',
+    fontSize: 12,
+    fontWeight: '800',
+    marginBottom: 6,
+  },
+  input: {
+    backgroundColor: '#F8FAFC',
+    borderColor: '#CBD5E1',
+    borderRadius: 7,
+    borderWidth: 1,
+    color: '#0F172A',
+    fontSize: 15,
+    minHeight: 40,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  toggleRow: {
+    alignItems: 'center',
+    borderBottomColor: '#E2E8F0',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    minHeight: 46,
+  },
+  toggleLabel: {
+    color: '#334155',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/expo-example/babel.config.js
+++ b/expo-example/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],

--- a/ios/RCTImageMarker/CornerRadius.swift
+++ b/ios/RCTImageMarker/CornerRadius.swift
@@ -56,10 +56,10 @@ class CornerRadius: NSObject {
     func radiusPath(rect: CGRect) -> UIBezierPath {
         let path = UIBezierPath()
         let cornerRadii = self.all?.radii(rect: rect) ?? CGSize(width: 0, height: 0)
-        let topLeftRadii = (self.topLeft != nil) ? self.topLeft!.radii(rect: rect) : cornerRadii
-        let topRightRadii = (self.topRight != nil) ? self.topRight!.radii(rect: rect) : cornerRadii
-        let bottomRightRadii = (self.bottomRight != nil) ? self.bottomRight!.radii(rect: rect) : cornerRadii
-        let bottomLeftRadii = (self.bottomLeft != nil) ? self.bottomLeft!.radii(rect: rect) : cornerRadii
+        let topLeftRadii = self.topLeft?.radii(rect: rect) ?? cornerRadii
+        let topRightRadii = self.topRight?.radii(rect: rect) ?? cornerRadii
+        let bottomRightRadii = self.bottomRight?.radii(rect: rect) ?? cornerRadii
+        let bottomLeftRadii = self.bottomLeft?.radii(rect: rect) ?? cornerRadii
 
         let topLeft = CGPoint(x: rect.minX, y: rect.minY + topLeftRadii.height / 4)
         let topRight = CGPoint(x: rect.maxX, y: rect.minY + topRightRadii.height / 4)

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -19,7 +19,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     func loadImages(with imageOptions: [ImageOptions]) async throws -> [UIImage] {
         let className = "RCTImageLoader"
         let classType: AnyClass? = NSClassFromString(className)
-        guard let imageLoader = self.bridge.module(for: classType) as? RCTImageLoader else {
+        guard let bridge = self.bridge,
+              let imageLoader = bridge.module(for: classType) as? RCTImageLoader else {
             throw NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to get ImageLoader module"])
         }
         let images = try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
@@ -39,13 +40,10 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                                 continuation.resume(throwing: error)
                                 return
                             }
-                            imageLoader.loadImage(with: request, size: CGSizeMake(img.rnSrc.width, img.rnSrc.height), scale: img.rnSrc.scale, clipped: false, resizeMode: RCTResizeMode.cover) { progress, total in
-                                print("Loading image: \(img.uri) progress: \(progress) total\(total)")
-                            } partialLoad: { loadedImage in
+                            imageLoader.loadImage(with: request, size: CGSizeMake(img.rnSrc.width, img.rnSrc.height), scale: img.rnSrc.scale, clipped: false, resizeMode: RCTResizeMode.cover) { _, _ in
+                            } partialLoad: { _ in
                                 //
                             } completionBlock: { error, loadedImage in
-                                print("Loaded image: ", img.uri)
-
                                 if let loadedImage = loadedImage {
                                     continuation.resume(returning: (index, loadedImage.normalizedForImageMarker()))
                                 } else if let error = error {
@@ -87,18 +85,25 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     }
     
     public static func moduleName() -> String! {
-        return "ImageMarker";
+        return "ImageMarker"
     }
     
-    func saveImageForMarker(_ image: UIImage, with opts: Options) -> String? {
+    private func markerError(_ message: String) -> NSError {
+        return NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    func saveImageForMarker(_ image: UIImage, with opts: Options) throws -> String {
         let fullPath = generateCacheFilePathForMarker(Utils.getExt(opts.saveFormat), opts.filename)
         if let saveFormat = opts.saveFormat, saveFormat == "base64" {
-            let base64String = image.pngData()?.base64EncodedString(options: .lineLength64Characters)
-            return "data:image/png;base64,\(base64String ?? "")"
+            guard let imageData = image.pngData() else {
+                throw markerError("Failed to encode image as PNG")
+            }
+            return "data:image/png;base64,\(imageData.base64EncodedString(options: .lineLength64Characters))"
         }
-        let data = Utils.isPng(opts.saveFormat) ? image.pngData() : image.jpegData(compressionQuality: CGFloat(opts.quality) / 100.0)
-        let fileManager = FileManager.default
-        fileManager.createFile(atPath: fullPath, contents: data, attributes: nil)
+        guard let data = Utils.isPng(opts.saveFormat) ? image.pngData() : image.jpegData(compressionQuality: CGFloat(opts.quality) / 100.0) else {
+            throw markerError("Failed to encode image")
+        }
+        try data.write(to: URL(fileURLWithPath: fullPath), options: .atomic)
         return fullPath
     }
     
@@ -265,7 +270,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
 
         if let textBackground = textOpts.style.textBackground {
             let bgEdgeInsets = textBackground.toEdgeInsets(width: w, height: h)
-            context.setFillColor(textBackground.colorBg!.cgColor)
+            context.setFillColor((textBackground.colorBg ?? UIColor.clear).cgColor)
             let stretchX = bgEdgeInsets.left + bgEdgeInsets.right
             let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom
             var bgRect = CGRect(
@@ -282,8 +287,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
 
             bgRect.inset(by: bgEdgeInsets)
 
-            if !Utils.isNULL(textBackground.cornerRadius) {
-                let path = textBackground.cornerRadius!.radiusPath(rect: bgRect)
+            if let cornerRadius = textBackground.cornerRadius {
+                let path = cornerRadius.radiusPath(rect: bgRect)
                 context.addPath(path.cgPath)
                 context.fillPath()
             } else {
@@ -297,130 +302,28 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     }
 
     func markImgWithText(_ image: UIImage, _ opts: MarkTextOptions) -> UIImage? {
+        let canvasSize = image.size
+        UIGraphicsBeginImageContextWithOptions(canvasSize, false, opts.backgroundImage.scale)
+        defer {
+            UIGraphicsEndImageContext()
+        }
 
-        let bg = image;
-        let w = bg.size.width
-        let h = bg.size.height
-        UIGraphicsBeginImageContextWithOptions(bg.size, false, opts.backgroundImage.scale)
-        
-        guard let context = UIGraphicsGetCurrentContext() else {
+        guard let context = UIGraphicsGetCurrentContext(), let backgroundImage = image.cgImage else {
             return nil
         }
-        let canvasRect = CGRect(x: 0, y: 0, width: w, height: h)
 
-        context.saveGState()
-        
-        let transform = CGAffineTransform(translationX: 0, y: canvasRect.height)
-            .scaledBy(x: 1, y: -1)
-        context.concatenate(transform)
-        if opts.backgroundImage.alpha != 1.0 {
-            context.beginTransparencyLayer(auxiliaryInfo: nil)
-            context.setAlpha(opts.backgroundImage.alpha)
-            context.setBlendMode(.multiply)
-            context.draw(bg.cgImage!, in: canvasRect)
-            context.endTransparencyLayer()
-            context.setBlendMode(.normal)
-        } else {
-            context.draw(bg.cgImage!, in: canvasRect)
-        }
-        context.restoreGState()
+        ImageMarkerRenderer.drawBackground(
+            context: context,
+            image: backgroundImage,
+            rect: CGRect(origin: .zero, size: canvasSize),
+            alpha: opts.backgroundImage.alpha
+        )
 
-        
         for textOpts in opts.watermarkTexts {
-            context.saveGState()
-            let font = fontWithTraits(
-                textOpts.style.resolvedFont(backgroundWidth: w),
-                bold: textOpts.style.bold,
-                italic: textOpts.style.italic
-            )
-            
-            var attributes: [NSAttributedString.Key: Any] = [
-                .font: font as Any,   //设置字体
-                .foregroundColor: textOpts.style.color as Any,      //设置字体颜色
-            ]
-            
-            if let shadow = textOpts.style.shadow {
-                attributes[.shadow] = shadow
-            }
-            if textOpts.style.underline {
-                attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
-            }
-            if textOpts.style.strikeThrough {
-                attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
-            }
-            if let textAlign = textOpts.style.textAlign {
-                let paragraphStyle = NSMutableParagraphStyle()
-                switch textAlign {
-                case "right":
-                    paragraphStyle.alignment = .right
-                case "center":
-                    paragraphStyle.alignment = .center
-                default:
-                    paragraphStyle.alignment = .left
-                }
-                attributes[.paragraphStyle] = paragraphStyle
-            }
-            if textOpts.style.skewX != 0 {
-                attributes[.obliqueness] = textOpts.style.skewX
-            }
-            
-            let attributedText = NSAttributedString(string: textOpts.text, attributes: attributes)
-            
-            let maxSize = CGSize(width: w, height: h) // 最大宽度和高度
-            let textRect = attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
-            let size = textRect.size
-            
-            let origin = markerOrigin(
-                position: textOpts.position,
-                offsetX: textOpts.X,
-                offsetY: textOpts.Y,
-                canvasSize: CGSize(width: w, height: h),
-                itemSize: size
-            )
-            let posX = origin.x
-            let posY = origin.y
-            
-            if textOpts.style.rotate != 0 {
-                context.saveGState()
-                let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style.rotate) * .pi / 180)
-                let textRectWithPos = CGRect(x: CGFloat(posX), y: CGFloat(posY), width: size.width, height: size.height)
-                context.translateBy(x: textRectWithPos.midX, y: textRectWithPos.midY)
-                context.concatenate(rotation)
-                context.translateBy(x: -( textRectWithPos.midX), y: -(textRectWithPos.midY))
-            }
-            
-            if let textBackground = textOpts.style.textBackground {
-                let bgEdgeInsets = textBackground.toEdgeInsets(width: CGFloat(w), height: CGFloat(h))
-                context.setFillColor(textBackground.colorBg!.cgColor)
-                let stretchX = bgEdgeInsets.left + bgEdgeInsets.right;
-                let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom;
-                var bgRect = CGRect(x: CGFloat(CGFloat(posX) - bgEdgeInsets.left), y: CGFloat(CGFloat(posY) - bgEdgeInsets.top), width: size.width + stretchX, height: size.height + stretchY)
-                if textBackground.typeBg == "stretchX" {
-                    bgRect = CGRect(x: 0, y: CGFloat(posY) - bgEdgeInsets.top, width: CGFloat(w), height: size.height + stretchY)
-                } else if textBackground.typeBg == "stretchY" {
-                    bgRect = CGRect(x: CGFloat(CGFloat(posX) - bgEdgeInsets.left), y: 0, width: size.width + stretchX, height: CGFloat(h))
-                }
-                
-                bgRect.inset(by: bgEdgeInsets)
-                
-                if !Utils.isNULL(textBackground.cornerRadius) {
-                    let path = textBackground.cornerRadius!.radiusPath(rect: bgRect)
-                    context.addPath(path.cgPath)
-                    context.fillPath()
-                } else {
-                    context.fill(bgRect)
-                }
-            }
-            
-            let rect = CGRect(origin: CGPoint(x: posX, y: posY), size: size)
-            attributedText.draw(in: rect)
-            context.restoreGState()
+            drawTextWatermark(textOpts, in: context, canvasSize: canvasSize)
         }
-        
-        var aimg = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        aimg = aimg?.rotatedImageWithTransform(opts.backgroundImage.rotate)
-        return aimg
+
+        return UIGraphicsGetImageFromCurrentImageContext()?.rotatedImageWithTransform(opts.backgroundImage.rotate)
     }
     
     func markImage(with image: UIImage, waterImages: [UIImage], options: MarkImageOptions) -> UIImage? {
@@ -461,23 +364,12 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             return nil
         }
 
-        let canvasRect = CGRect(origin: .zero, size: canvasSize)
-        context.saveGState()
-
-        let transform = CGAffineTransform(translationX: 0, y: canvasRect.height)
-            .scaledBy(x: 1, y: -1)
-        context.concatenate(transform)
-        if options.backgroundImage.alpha != 1.0 {
-            context.beginTransparencyLayer(auxiliaryInfo: nil)
-            context.setAlpha(options.backgroundImage.alpha)
-            context.setBlendMode(.multiply)
-            context.draw(backgroundImage, in: canvasRect)
-            context.endTransparencyLayer()
-            context.setBlendMode(.normal)
-        } else {
-            context.draw(backgroundImage, in: canvasRect)
-        }
-        context.restoreGState()
+        ImageMarkerRenderer.drawBackground(
+            context: context,
+            image: backgroundImage,
+            rect: CGRect(origin: .zero, size: canvasSize),
+            alpha: options.backgroundImage.alpha
+        )
 
         var imageIndex = 0
         for layer in options.watermarkLayers {
@@ -521,11 +413,9 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                     reject("error", "Failed to render watermarked image", nil)
                     return
                 }
-                let res = self.saveImageForMarker(scaledImage, with: markOpts)
+                let res = try self.saveImageForMarker(scaledImage, with: markOpts)
                 resolve(res)
-                print("Loaded images: \(images)")
             } catch {
-                print("Failed to load images, error: \(error).")
                 reject("error", error.localizedDescription, error)
             }
         }
@@ -544,11 +434,9 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                     reject("error", "Failed to render watermarked image", nil)
                     return
                 }
-                let res = self.saveImageForMarker(scaledImage, with: markOpts)
+                let res = try self.saveImageForMarker(scaledImage, with: markOpts)
                 resolve(res)
-                print("Loaded images: \(images), waterImages: \(waterImages)")
             } catch {
-                print("Failed to load images, error: \(error).")
                 reject("error", error.localizedDescription, error)
             }
         }
@@ -567,11 +455,9 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                     reject("error", "Failed to render watermarked image", nil)
                     return
                 }
-                let res = self.saveImageForMarker(scaledImage, with: markOpts)
+                let res = try self.saveImageForMarker(scaledImage, with: markOpts)
                 resolve(res)
-                print("Loaded images: \(images), waterImages: \(waterImages)")
             } catch {
-                print("Failed to load images, error: \(error).")
                 reject("error", error.localizedDescription, error)
             }
         }

--- a/ios/RCTImageMarker/UIImageEdit.swift
+++ b/ios/RCTImageMarker/UIImageEdit.swift
@@ -114,28 +114,42 @@ enum ImageMarkerRenderer {
         }
 
         let canvasRect = CGRect(origin: .zero, size: canvasSize)
-        let transform = CGAffineTransform(translationX: 0, y: canvasRect.height)
-            .scaledBy(x: 1, y: -1)
-
-        context.saveGState()
-        context.concatenate(transform)
-        if backgroundAlpha != 1.0 {
-            context.beginTransparencyLayer(auxiliaryInfo: nil)
-            context.setAlpha(backgroundAlpha)
-            context.setBlendMode(.multiply)
-            context.draw(backgroundImage, in: canvasRect)
-            context.endTransparencyLayer()
-            context.setBlendMode(.normal)
-        } else {
-            context.draw(backgroundImage, in: canvasRect)
-        }
-        context.restoreGState()
+        drawBackground(
+            context: context,
+            image: backgroundImage,
+            rect: canvasRect,
+            alpha: backgroundAlpha
+        )
 
         for watermark in watermarks {
             drawImageWatermark(context: context, canvasSize: canvasSize, watermark: watermark)
         }
 
         return UIGraphicsGetImageFromCurrentImageContext()?.rotatedImageWithTransform(backgroundRotate)
+    }
+
+    static func drawBackground(
+        context: CGContext,
+        image: CGImage,
+        rect: CGRect,
+        alpha: CGFloat
+    ) {
+        let transform = CGAffineTransform(translationX: 0, y: rect.height)
+            .scaledBy(x: 1, y: -1)
+
+        context.saveGState()
+        context.concatenate(transform)
+        if alpha != 1.0 {
+            context.beginTransparencyLayer(auxiliaryInfo: nil)
+            context.setAlpha(alpha)
+            context.setBlendMode(.multiply)
+            context.draw(image, in: rect)
+            context.endTransparencyLayer()
+            context.setBlendMode(.normal)
+        } else {
+            context.draw(image, in: rect)
+        }
+        context.restoreGState()
     }
 
     static func drawImageWatermark(
@@ -215,14 +229,15 @@ extension UIImage {
         let scale = rotatedImage.scale
         let cropRect = rect.applying(CGAffineTransform(scaleX: scale, y: scale))
         
-        let croppedImage = rotatedImage.cgImage?.cropping(to: cropRect)
-        let image = UIImage(cgImage: croppedImage!, scale: self.scale, orientation: rotatedImage.imageOrientation)
-        return image
+        guard let croppedImage = rotatedImage.cgImage?.cropping(to: cropRect) else {
+            return rotatedImage
+        }
+        return UIImage(cgImage: croppedImage, scale: self.scale, orientation: rotatedImage.imageOrientation)
     }
     
     func rotatedImageWithTransform(_ rotate: CGFloat) -> UIImage {
         if rotate == 0 || rotate.isNaN {
-            return self;
+            return self
         }
         let rotation = CGAffineTransform(rotationAngle: rotate * .pi / 180)
         let rotatedImage = rotatedImageWithTransform(rotation)

--- a/ios/RCTImageMarker/Utils.swift
+++ b/ios/RCTImageMarker/Utils.swift
@@ -107,16 +107,15 @@ class Utils: NSObject {
     }
 
     static func isPng(_ saveFormat: String?) -> Bool {
-        return saveFormat != nil && (saveFormat!.caseInsensitiveCompare("png") == .orderedSame)
+        return saveFormat?.caseInsensitiveCompare("png") == .orderedSame
     }
 
     static func getExt(_ saveFormat: String?) -> String {
-        let ext = saveFormat != nil && (saveFormat!.caseInsensitiveCompare("png") == .orderedSame) ? ".png" : ".jpg"
-        return ext
+        return isPng(saveFormat) ? ".png" : ".jpg"
     }
 
     static func isBase64(_ uri: String?) -> Bool {
-        return uri != nil ? uri!.hasPrefix("data:") : false
+        return uri?.hasPrefix("data:") ?? false
     }
 
     static func isNULL(_ obj: Any?) -> Bool {
@@ -134,12 +133,12 @@ class Utils: NSObject {
     }
 
     static func parseSpreadValue(v: String?, relativeTo length: CGFloat) -> CGFloat? {
-        if v == nil { return nil }
-        if v?.hasSuffix(String(describing: "%")) ?? false {
-            let percent = CGFloat(Double(v!.dropLast()) ?? 0) / 100
+        guard let v else { return nil }
+        if v.hasSuffix("%") {
+            let percent = CGFloat(Double(v.dropLast()) ?? 0) / 100
             return length * percent
         } else {
-            return CGFloat(Double(v!) ?? 0)
+            return CGFloat(Double(v) ?? 0)
         }
     }
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -86,6 +86,9 @@ describe('Marker JS wrapper', () => {
     expect(nativeOptions.watermarkTexts[0]).not.toHaveProperty(
       'positionOptions'
     );
+    expect(options.backgroundImage.src).toBe('file:///tmp/background.png');
+    expect(options.watermarkTexts[0]).toHaveProperty('positionOptions');
+    expect(options.watermarkTexts[0]).not.toHaveProperty('position');
   });
 
   it('resolves markImage assets and preserves explicit maxSize', async () => {
@@ -136,6 +139,19 @@ describe('Marker JS wrapper', () => {
       uri: 'file:///tmp/watermark.png',
       __packager_asset: false,
     });
+    expect(options.backgroundImage.src).toBe(10);
+    expect(options.watermarkImage.src).toBe('file:///tmp/legacy-watermark.png');
+    expect(options.watermarkImages[0].src).toBe('file:///tmp/watermark.png');
+  });
+
+  it('rejects markImage calls without any image watermark', () => {
+    expect(() =>
+      Marker.markImage({
+        backgroundImage: {
+          src: 'file:///tmp/background.png',
+        },
+      } as any)
+    ).toThrow('please set mark image!');
   });
 
   it('rejects image watermark entries without a source', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
-import { NativeModules, Platform, Image } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
+import type { Spec } from './NativeImageMarker';
 import NativeImageMarker from './NativeImageMarker';
+import {
+  createNativeMarkOptions,
+  normalizeImageMarkOptions,
+  normalizeTextMarkOptions,
+} from './normalize';
 
-const { resolveAssetSource } = Image;
 const LINKING_ERROR =
   `The package 'react-native-image-marker' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
@@ -932,191 +937,17 @@ export interface MarkOptions {
   maxSize?: number;
 }
 
-const ImageMarker =
-  NativeImageMarker ??
-  NativeModules.ImageMarker ??
-  new Proxy(
-    {},
-    {
-      get() {
-        throw new Error(LINKING_ERROR);
-      },
-    }
-  );
-
-type OutputOptions = Pick<
-  MarkOptions,
-  'quality' | 'filename' | 'saveFormat' | 'maxSize'
->;
-
-function clonePositionOptions(
-  position?: PositionOptions
-): PositionOptions | undefined {
-  return position ? { ...position } : position;
-}
-
-function cloneCornerRadius(
-  cornerRadius?: CornerRadius
-): CornerRadius | undefined {
-  if (!cornerRadius) {
-    return cornerRadius;
-  }
-
-  return {
-    topLeft: cornerRadius.topLeft ? { ...cornerRadius.topLeft } : undefined,
-    topRight: cornerRadius.topRight ? { ...cornerRadius.topRight } : undefined,
-    bottomLeft: cornerRadius.bottomLeft
-      ? { ...cornerRadius.bottomLeft }
-      : undefined,
-    bottomRight: cornerRadius.bottomRight
-      ? { ...cornerRadius.bottomRight }
-      : undefined,
-    all: cornerRadius.all ? { ...cornerRadius.all } : undefined,
-  };
-}
-
-function cloneTextBackgroundStyle(
-  style?: TextBackgroundStyle | null
-): TextBackgroundStyle | null | undefined {
-  if (!style) {
-    return style;
-  }
-
-  return {
-    ...style,
-    cornerRadius: cloneCornerRadius(style.cornerRadius),
-  };
-}
-
-function cloneTextStyle(style?: TextStyle): TextStyle | undefined {
-  if (!style) {
-    return style;
-  }
-
-  return {
-    ...style,
-    shadowStyle: style.shadowStyle
-      ? { ...style.shadowStyle }
-      : style.shadowStyle,
-    textBackgroundStyle: cloneTextBackgroundStyle(style.textBackgroundStyle),
-  };
-}
-
-function cloneTextWatermarks(watermarkTexts: TextOptions[]): TextOptions[] {
-  return watermarkTexts.map((textOptions) => ({
-    ...textOptions,
-    position: clonePositionOptions(textOptions.position),
-    positionOptions: clonePositionOptions(textOptions.positionOptions),
-    style: cloneTextStyle(textOptions.style),
-  }));
-}
-
-function cloneImageOptions<T extends ImageOptions | undefined>(
-  imageOptions: T
-): T {
-  return imageOptions ? ({ ...imageOptions } as T) : imageOptions;
-}
-
-function cloneImageWatermarks(
-  watermarkImages: WatermarkImageOptions[]
-): WatermarkImageOptions[] {
-  return watermarkImages.map((imageOptions) => ({
-    ...imageOptions,
-    position: clonePositionOptions(imageOptions.position),
-  }));
-}
-
-function getOutputOptions(options: MarkOptions): OutputOptions {
-  const outputOptions: OutputOptions = {};
-
-  if (options.quality !== undefined) {
-    outputOptions.quality = options.quality;
-  }
-  if (options.filename !== undefined) {
-    outputOptions.filename = options.filename;
-  }
-  if (options.saveFormat !== undefined) {
-    outputOptions.saveFormat = options.saveFormat;
-  }
-  if (options.maxSize !== undefined) {
-    outputOptions.maxSize = options.maxSize;
-  }
-
-  return outputOptions;
-}
-
-function resolveImageSource(src: any) {
-  let srcObj: any = resolveAssetSource(src);
-  if (!srcObj) {
-    srcObj = {
-      uri: src,
-      __packager_asset: false,
-    };
-  }
-  return srcObj;
-}
-
-function createTextLayer(textOptions: TextOptions): TextWatermarkLayer {
-  return {
-    ...textOptions,
-    type: 'text',
-    position:
-      clonePositionOptions(
-        textOptions.position || textOptions.positionOptions
-      ) || {},
-    style: cloneTextStyle(textOptions.style),
-  };
-}
-
-function createImageLayer(
-  imageOptions: WatermarkImageOptions
-): ImageWatermarkLayer {
-  return {
-    ...imageOptions,
-    type: 'image',
-    src: resolveImageSource(imageOptions.src),
-    position: clonePositionOptions(imageOptions.position) || {},
-  };
-}
-
-function createWatermarkLayers(options: MarkOptions): WatermarkLayer[] {
-  if ((options.watermarks?.length ?? 0) > 0) {
-    return options.watermarks!.map((layer) => {
-      if (layer.type === 'text') {
-        return createTextLayer(layer);
+function getImageMarker(): Spec {
+  return (NativeImageMarker ??
+    NativeModules.ImageMarker ??
+    new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
       }
-      return createImageLayer(layer);
-    });
-  }
-
-  const layers: WatermarkLayer[] = [
-    ...cloneTextWatermarks(options.watermarkTexts ?? []).map(createTextLayer),
-    ...cloneImageWatermarks(options.watermarkImages ?? []).map(
-      createImageLayer
-    ),
-  ];
-
-  if (options.watermarkImage?.src) {
-    layers.push(
-      createImageLayer({
-        ...cloneImageOptions(options.watermarkImage),
-        position: clonePositionOptions(options.watermarkPositions),
-      })
-    );
-  }
-
-  return layers;
-}
-
-function createNativeMarkOptions(options: MarkOptions): MarkOptions {
-  return {
-    backgroundImage: {
-      ...cloneImageOptions(options.backgroundImage),
-      src: resolveImageSource(options.backgroundImage.src),
-    },
-    watermarks: createWatermarkLayers(options),
-    ...getOutputOptions(options),
-  };
+    )) as Spec;
 }
 
 class Marker {
@@ -1208,30 +1039,17 @@ class Marker {
    * await ImageMarker.markText(options);
    */
   static markText(options: TextMarkOptions): Promise<string> {
-    const { backgroundImage } = options;
+    const { backgroundImage, watermarkTexts } = options;
 
     if (!backgroundImage || !backgroundImage.src) {
       throw new Error('please set image!');
     }
 
-    let srcObj: any = resolveAssetSource(backgroundImage.src);
-    if (!srcObj) {
-      srcObj = {
-        uri: backgroundImage.src,
-        __packager_asset: false,
-      };
+    if (!watermarkTexts || watermarkTexts.length === 0) {
+      throw new Error('please set watermark text!');
     }
 
-    options.watermarkTexts.forEach((item) => {
-      item.position = item.position || item.positionOptions;
-      delete item.positionOptions;
-    });
-
-    options.backgroundImage.src = srcObj;
-    // let mShadowStyle = shadowStyle || {};
-    // let mTextBackgroundStyle = textBackgroundStyle || {};
-    options.maxSize = options.maxSize || 2048;
-    return ImageMarker.markWithText(options);
+    return getImageMarker().markWithText(normalizeTextMarkOptions(options));
   }
 
   /**
@@ -1284,61 +1102,19 @@ class Marker {
    * await ImageMarker.markImage(options);
    */
   static markImage(options: ImageMarkOptions): Promise<string> {
-    const {
-      backgroundImage,
-      watermarkImage = {} as any,
-      watermarkImages = [],
-    } = options;
+    const { backgroundImage, watermarkImage, watermarkImages = [] } = options;
 
     if (!backgroundImage || !backgroundImage.src) {
       throw new Error('please set image!');
     }
-    if (
-      (!watermarkImage || !watermarkImage.src) &&
-      watermarkImages.some((item) => !item.src)
-    ) {
+    if (!watermarkImage?.src && watermarkImages.length === 0) {
+      throw new Error('please set mark image!');
+    }
+    if (watermarkImages.some((item) => !item.src)) {
       throw new Error('please set mark image!');
     }
 
-    let srcObj: any = resolveAssetSource(backgroundImage.src);
-    if (!srcObj) {
-      srcObj = {
-        uri: backgroundImage.src,
-        __packager_asset: false,
-      };
-    }
-
-    if (watermarkImage && options.watermarkImage) {
-      let markerObj: any = resolveAssetSource(watermarkImage.src);
-      if (!markerObj) {
-        markerObj = {
-          uri: watermarkImage.src,
-          __packager_asset: false,
-        };
-      }
-
-      options.watermarkImage.src = markerObj;
-    }
-
-    if (watermarkImages.length > 0) {
-      for (const myWi of watermarkImages) {
-        let markerObj: any = resolveAssetSource(myWi.src);
-        if (!markerObj) {
-          markerObj = {
-            uri: myWi.src,
-            __packager_asset: false,
-          };
-        }
-        myWi.src = markerObj;
-      }
-    } else {
-      options.watermarkImages = [];
-    }
-
-    options.backgroundImage.src = srcObj;
-    options.maxSize = options.maxSize || 2048;
-
-    return ImageMarker.markWithImage(options);
+    return getImageMarker().markWithImage(normalizeImageMarkOptions(options));
   }
 
   /**
@@ -1380,9 +1156,7 @@ class Marker {
     if (!nativeOptions.watermarks || nativeOptions.watermarks.length === 0) {
       throw new Error('please set watermark text or image!');
     }
-    nativeOptions.maxSize = nativeOptions.maxSize || 2048;
-
-    return ImageMarker.markWithWatermarks(nativeOptions);
+    return getImageMarker().markWithWatermarks(nativeOptions);
   }
 }
 

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,267 @@
+import { Image } from 'react-native';
+import type {
+  CornerRadius,
+  ImageMarkOptions,
+  ImageOptions,
+  ImageWatermarkLayer,
+  MarkOptions,
+  PositionOptions,
+  TextBackgroundStyle,
+  TextMarkOptions,
+  TextOptions,
+  TextStyle,
+  TextWatermarkLayer,
+  WatermarkImageOptions,
+  WatermarkLayer,
+} from './index';
+
+export const DEFAULT_MAX_SIZE = 2048;
+
+type AssetResolver = (source: any) => any;
+type OutputOptions = Pick<
+  MarkOptions,
+  'quality' | 'filename' | 'saveFormat' | 'maxSize'
+>;
+
+const defaultAssetResolver: AssetResolver = (source) =>
+  Image.resolveAssetSource(source);
+
+function clonePositionOptions(
+  position?: PositionOptions
+): PositionOptions | undefined {
+  return position ? { ...position } : position;
+}
+
+function cloneCornerRadius(
+  cornerRadius?: CornerRadius
+): CornerRadius | undefined {
+  if (!cornerRadius) {
+    return cornerRadius;
+  }
+
+  return {
+    topLeft: cornerRadius.topLeft ? { ...cornerRadius.topLeft } : undefined,
+    topRight: cornerRadius.topRight ? { ...cornerRadius.topRight } : undefined,
+    bottomLeft: cornerRadius.bottomLeft
+      ? { ...cornerRadius.bottomLeft }
+      : undefined,
+    bottomRight: cornerRadius.bottomRight
+      ? { ...cornerRadius.bottomRight }
+      : undefined,
+    all: cornerRadius.all ? { ...cornerRadius.all } : undefined,
+  };
+}
+
+function cloneTextBackgroundStyle(
+  style?: TextBackgroundStyle | null
+): TextBackgroundStyle | null | undefined {
+  if (!style) {
+    return style;
+  }
+
+  return {
+    ...style,
+    cornerRadius: cloneCornerRadius(style.cornerRadius),
+  };
+}
+
+function cloneTextStyle(style?: TextStyle): TextStyle | undefined {
+  if (!style) {
+    return style;
+  }
+
+  return {
+    ...style,
+    shadowStyle: style.shadowStyle
+      ? { ...style.shadowStyle }
+      : style.shadowStyle,
+    textBackgroundStyle: cloneTextBackgroundStyle(style.textBackgroundStyle),
+  };
+}
+
+function cloneTextWatermarks(watermarkTexts: TextOptions[]): TextOptions[] {
+  return watermarkTexts.map((textOptions) => ({
+    ...textOptions,
+    position: clonePositionOptions(textOptions.position),
+    positionOptions: clonePositionOptions(textOptions.positionOptions),
+    style: cloneTextStyle(textOptions.style),
+  }));
+}
+
+function cloneImageOptions<T extends ImageOptions | undefined>(
+  imageOptions: T
+): T {
+  return imageOptions ? ({ ...imageOptions } as T) : imageOptions;
+}
+
+function cloneImageWatermarks(
+  watermarkImages: WatermarkImageOptions[]
+): WatermarkImageOptions[] {
+  return watermarkImages.map((imageOptions) => ({
+    ...imageOptions,
+    position: clonePositionOptions(imageOptions.position),
+  }));
+}
+
+function getOutputOptions(options: MarkOptions): OutputOptions {
+  const outputOptions: OutputOptions = {};
+
+  if (options.quality !== undefined) {
+    outputOptions.quality = options.quality;
+  }
+  if (options.filename !== undefined) {
+    outputOptions.filename = options.filename;
+  }
+  if (options.saveFormat !== undefined) {
+    outputOptions.saveFormat = options.saveFormat;
+  }
+  outputOptions.maxSize = options.maxSize || DEFAULT_MAX_SIZE;
+
+  return outputOptions;
+}
+
+function resolveImageSource(src: any, assetResolver: AssetResolver) {
+  let srcObj: any = assetResolver(src);
+  if (!srcObj) {
+    srcObj = {
+      uri: src,
+      __packager_asset: false,
+    };
+  }
+  return srcObj;
+}
+
+function resolveImageOptions<T extends ImageOptions>(
+  imageOptions: T,
+  assetResolver: AssetResolver
+): T {
+  return {
+    ...imageOptions,
+    src: resolveImageSource(imageOptions.src, assetResolver),
+  };
+}
+
+function createTextLayer(textOptions: TextOptions): TextWatermarkLayer {
+  return {
+    ...textOptions,
+    type: 'text',
+    position:
+      clonePositionOptions(
+        textOptions.position || textOptions.positionOptions
+      ) || {},
+    style: cloneTextStyle(textOptions.style),
+  };
+}
+
+function createImageLayer(
+  imageOptions: WatermarkImageOptions,
+  assetResolver: AssetResolver
+): ImageWatermarkLayer {
+  return {
+    ...imageOptions,
+    type: 'image',
+    src: resolveImageSource(imageOptions.src, assetResolver),
+    position: clonePositionOptions(imageOptions.position) || {},
+  };
+}
+
+function createWatermarkLayers(
+  options: MarkOptions,
+  assetResolver: AssetResolver
+): WatermarkLayer[] {
+  if ((options.watermarks?.length ?? 0) > 0) {
+    return options.watermarks!.map((layer) => {
+      if (layer.type === 'text') {
+        return createTextLayer(layer);
+      }
+      return createImageLayer(layer, assetResolver);
+    });
+  }
+
+  const layers: WatermarkLayer[] = [
+    ...cloneTextWatermarks(options.watermarkTexts ?? []).map(createTextLayer),
+    ...cloneImageWatermarks(options.watermarkImages ?? []).map((imageOptions) =>
+      createImageLayer(imageOptions, assetResolver)
+    ),
+  ];
+
+  if (options.watermarkImage?.src) {
+    layers.push(
+      createImageLayer(
+        {
+          ...cloneImageOptions(options.watermarkImage),
+          position: clonePositionOptions(options.watermarkPositions),
+        },
+        assetResolver
+      )
+    );
+  }
+
+  return layers;
+}
+
+export function normalizeTextMarkOptions(
+  options: TextMarkOptions,
+  assetResolver: AssetResolver = defaultAssetResolver
+): TextMarkOptions {
+  return {
+    ...options,
+    backgroundImage: resolveImageOptions(
+      options.backgroundImage,
+      assetResolver
+    ),
+    watermarkTexts: cloneTextWatermarks(options.watermarkTexts).map(
+      (textOptions) => {
+        const nativeTextOptions = { ...textOptions };
+        delete nativeTextOptions.positionOptions;
+        return {
+          ...nativeTextOptions,
+          position: textOptions.position || textOptions.positionOptions,
+        };
+      }
+    ),
+    maxSize: options.maxSize || DEFAULT_MAX_SIZE,
+  };
+}
+
+export function normalizeImageMarkOptions(
+  options: ImageMarkOptions,
+  assetResolver: AssetResolver = defaultAssetResolver
+): ImageMarkOptions {
+  const nativeOptions: ImageMarkOptions = {
+    ...options,
+    backgroundImage: resolveImageOptions(
+      options.backgroundImage,
+      assetResolver
+    ),
+    watermarkImages: cloneImageWatermarks(options.watermarkImages ?? []).map(
+      (imageOptions) => resolveImageOptions(imageOptions, assetResolver)
+    ),
+    maxSize: options.maxSize || DEFAULT_MAX_SIZE,
+  };
+
+  if (options.watermarkImage?.src) {
+    nativeOptions.watermarkImage = resolveImageOptions(
+      options.watermarkImage,
+      assetResolver
+    );
+  } else {
+    delete nativeOptions.watermarkImage;
+  }
+
+  return nativeOptions;
+}
+
+export function createNativeMarkOptions(
+  options: MarkOptions,
+  assetResolver: AssetResolver = defaultAssetResolver
+): MarkOptions {
+  return {
+    backgroundImage: resolveImageOptions(
+      options.backgroundImage,
+      assetResolver
+    ),
+    watermarks: createWatermarkLayers(options, assetResolver),
+    ...getOutputOptions(options),
+  };
+}


### PR DESCRIPTION
## Summary
- restore the full ESLint gate by ignoring generated base64 fixtures instead of broad example paths
- harden Android loading/rendering by replacing GlobalScope/null bitmap flow with scoped coroutines, explicit errors, IO/default dispatching, and centralized output writing
- move JS option normalization into a dedicated module and keep public options immutable before native calls
- consolidate iOS background/text rendering helpers, remove avoidable force unwraps, and make save failures reject explicitly
- split reusable example lab UI pieces into a dedicated components module
- align npm publish workflow with npm Trusted Publishing by relying on OIDC-backed npm publish and automatic provenance generation

## Verification
- yarn lint
- yarn typecheck
- yarn test --runInBand
- yarn prepack
- npm pack --dry-run
- JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :react-native-image-marker:compileDebugKotlin :react-native-image-marker:testDebugUnitTest (from example/android)
- xcodebuild -workspace ImageMarkerExample.xcworkspace -scheme ImageMarkerExample -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/CodebaseMaintenance build | xcpretty (from example/ios)

## Notes
- npm Trusted Publishing docs state trusted publishing automatically generates provenance for GitHub Actions publishes, so the workflow now uses plain npm publish while keeping id-token: write.
