### PR TITLE
fix(native): guard nullable image marker inputs

### DIFF
--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/ImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/ImageOptions.kt
@@ -20,12 +20,13 @@ class ImageOptions(val options: ReadableMap) {
   private var alpha: Int
 
   init {
-    if (!options.hasKey("src")) {
+    if (!options.hasKey("src") || options.isNull("src")) {
       throw MarkerError(ErrorCode.PARAMS_REQUIRED, "image is required")
     }
-    var originalSRC = options.getMap("src")
+    val originalSRC = options.getMap("src")
+      ?: throw MarkerError(ErrorCode.PARAMS_REQUIRED, "image is required")
     src = RNImageSRC(originalSRC)
-    uri = originalSRC!!.getString(PROP_ICON_URI)
+    uri = originalSRC.getString(PROP_ICON_URI)
     scale = if (options.hasKey("scale")) options.getDouble("scale").toFloat() else DEFAULT_SCALE
     if (!scale.isFinite() || scale <= 0f) {
       throw MarkerError(ErrorCode.INVALID_PARAMS, "image scale must be finite and greater than zero")

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
@@ -1,6 +1,7 @@
 package com.jimmydaddy.imagemarker.base
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
 class MarkImageOptions(options: ReadableMap) : Options(options) {
@@ -14,13 +15,7 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
         "marker image is required"
       )
     }
-    val myMarkerList = arrayListOf<WatermarkImageOptions>()
-    if (markerImagesOpts != null && markerImagesOpts.size() > 0) {
-      for (i in 0 until markerImagesOpts.size()) {
-        val marker = WatermarkImageOptions(markerImagesOpts.getMap(i))
-        myMarkerList.add(marker)
-      }
-    }
+    val myMarkerList = readWatermarkImages(markerImagesOpts)
     if (markerImageOpts != null) {
       val marker = ImageOptions(markerImageOpts)
       val positionOptions = options.getMap("watermarkPositions")
@@ -39,10 +34,9 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
       } else {
         null
       }
-      val positionEnum =
-        if (positionOptions?.getString("position") != null) PositionEnum.getPosition(
-          positionOptions.getString("position")
-        ) else null
+      val positionEnum = positionOptions
+        ?.getString("position")
+        ?.let(PositionEnum::getPosition)
       val trimTransparentPadding =
         markerImageOpts.hasKey("trimTransparentPadding") && markerImageOpts.getBoolean("trimTransparentPadding")
       val markerOpts = WatermarkImageOptions(
@@ -59,6 +53,20 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
   }
 
   companion object {
+    internal fun readWatermarkImages(watermarkImages: ReadableArray?): ArrayList<WatermarkImageOptions> {
+      if (watermarkImages == null || watermarkImages.size() <= 0) {
+        return arrayListOf()
+      }
+
+      return ArrayList<WatermarkImageOptions>(watermarkImages.size()).apply {
+        for (index in 0 until watermarkImages.size()) {
+          val markerMap = watermarkImages.getMap(index)
+            ?: throw MarkerError(ErrorCode.NULL_MAP, "watermarkImages[$index] is null")
+          add(WatermarkImageOptions(markerMap))
+        }
+      }
+    }
+
     @JvmStatic
     fun checkParams(opts: ReadableMap, promise: Promise): MarkImageOptions? {
       try {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkTextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkTextOptions.kt
@@ -1,28 +1,29 @@
 package com.jimmydaddy.imagemarker.base
 
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
 class MarkTextOptions(options: ReadableMap) : Options(options) {
   var watermarkTexts: Array<TextOptions>
 
   init {
-    val waterMarkTextsMap = options.getArray("watermarkTexts")
-    if (waterMarkTextsMap == null || waterMarkTextsMap.size() <= 0) {
-      throw MarkerError(ErrorCode.PARAMS_REQUIRED, "watermarkTexts is required")
-    }
-
-    val textOptions = arrayListOf<TextOptions>()
-    for (i in 0 until waterMarkTextsMap.size()) {
-      if (waterMarkTextsMap.isNull(i)) {
-        throw MarkerError(ErrorCode.NULL_MAP, "watermarkTexts[$i] is null")
-      }
-      textOptions.add(TextOptions(waterMarkTextsMap.getMap(i)))
-    }
-    watermarkTexts = textOptions.toTypedArray()
+    watermarkTexts = readWatermarkTexts(options.getArray("watermarkTexts"))
   }
 
   companion object {
+    internal fun readWatermarkTexts(watermarkTexts: ReadableArray?): Array<TextOptions> {
+      if (watermarkTexts == null || watermarkTexts.size() <= 0) {
+        throw MarkerError(ErrorCode.PARAMS_REQUIRED, "watermarkTexts is required")
+      }
+
+      return Array(watermarkTexts.size()) { index ->
+        val textMap = watermarkTexts.getMap(index)
+          ?: throw MarkerError(ErrorCode.NULL_MAP, "watermarkTexts[$index] is null")
+        TextOptions(textMap)
+      }
+    }
+
     @JvmStatic
     fun checkParams(opts: ReadableMap, promise: Promise): MarkTextOptions? {
       try {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/Options.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/Options.kt
@@ -7,8 +7,6 @@ import com.facebook.react.bridge.ReadableMap
 open class Options(val options: ReadableMap) {
   var backgroundImage: ImageOptions
 
-  private var backgroundImageOpts = options.getMap("backgroundImage")
-
   var quality: Int
 
   var filename: String?
@@ -22,11 +20,9 @@ open class Options(val options: ReadableMap) {
   var rotationCanvasMode: RotationCanvasMode
 
   init {
-    this.backgroundImageOpts ?: throw MarkerError(
-      ErrorCode.PARAMS_REQUIRED,
-      "backgroundImage is required"
-    )
-    backgroundImage = ImageOptions(this.backgroundImageOpts!!)
+    val backgroundImageOptions = options.getMap("backgroundImage")
+      ?: throw MarkerError(ErrorCode.PARAMS_REQUIRED, "backgroundImage is required")
+    backgroundImage = ImageOptions(backgroundImageOptions)
     quality = readQuality(options)
     maxSize = readMaxSize(options)
     filename = options.getString("filename")

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/RNImageSRC.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/RNImageSRC.kt
@@ -10,9 +10,9 @@ data class RNImageSRC(val options: ReadableMap?) {
   var uri: String = ""
 
   init {
-    width = if (options?.hasKey("width") == true) options.getInt("width")!! else 0
+    width = if (options?.hasKey("width") == true) options.getInt("width") else 0
     height = if (options?.hasKey("height") == true) options.getInt("height") else 0
     scale = if (options?.hasKey("scale") == true) options.getInt("scale") else 1
-    uri = if (options?.hasKey("uri") == true) options.getString("uri").toString() else ""
+    uri = if (options?.hasKey("uri") == true) options.getString("uri").orEmpty() else ""
   }
 }

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextBackgroundStyle.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextBackgroundStyle.kt
@@ -14,8 +14,8 @@ data class TextBackgroundStyle(val readableMap: ReadableMap?): Padding(readableM
       try {
         type = readableMap.getString("type")
         setColor(readableMap.getString("color"))
-        if(readableMap.hasKey("cornerRadius")) {
-          cornerRadius = readableMap.getMap("cornerRadius")?.let { CornerRadius(it) }!!
+        if (readableMap.hasKey("cornerRadius")) {
+          cornerRadius = readableMap.getMap("cornerRadius")?.let(::CornerRadius)
         }
       } catch (e: Exception) {
         Log.d(Utils.TAG, "Unknown text background options ", e)

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkImageOptions.kt
@@ -20,10 +20,9 @@ data class WatermarkImageOptions(val options: ReadableMap?) {
         if (positionOptions != null && positionOptions.hasKey("Y")) Utils.handleDynamicToString(positionOptions.getDynamic("Y")) else null
       edgeInset =
         if (positionOptions != null && positionOptions.hasKey("edgeInset")) Utils.handleDynamicToString(positionOptions.getDynamic("edgeInset")) else null
-      positionEnum =
-        if (positionOptions != null && null != positionOptions.getString("position")) PositionEnum.getPosition(
-          positionOptions.getString("position")
-        ) else null
+      positionEnum = positionOptions
+        ?.getString("position")
+        ?.let(PositionEnum::getPosition)
       trimTransparentPadding =
         options.hasKey("trimTransparentPadding") && options.getBoolean("trimTransparentPadding")
     }

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/ImageOptionsTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/ImageOptionsTest.kt
@@ -8,6 +8,18 @@ import org.mockito.Mockito
 
 class ImageOptionsTest {
   @Test
+  fun rejectsNullSourceMapAsMissingImage() {
+    val options = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(options.hasKey("src")).thenReturn(true)
+    Mockito.`when`(options.isNull("src")).thenReturn(false)
+    Mockito.`when`(options.getMap("src")).thenReturn(null)
+
+    val error = assertThrows(MarkerError::class.java) { ImageOptions(options) }
+
+    assertEquals(ErrorCode.PARAMS_REQUIRED.value, error.getErrorCode())
+  }
+
+  @Test
   fun rejectsNonPositiveAndNonFiniteScale() {
     for (scale in listOf(0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY)) {
       val error = assertThrows(MarkerError::class.java) {

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/MarkImageOptionsTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/MarkImageOptionsTest.kt
@@ -1,0 +1,24 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.ReadableArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.mockito.Mockito
+
+class MarkImageOptionsTest {
+  @Test
+  fun rejectsNullMapEvenWhenArrayDoesNotReportNull() {
+    val images = Mockito.mock(ReadableArray::class.java)
+    Mockito.`when`(images.size()).thenReturn(1)
+    Mockito.`when`(images.isNull(0)).thenReturn(false)
+    Mockito.`when`(images.getMap(0)).thenReturn(null)
+
+    val error = assertThrows(MarkerError::class.java) {
+      MarkImageOptions.readWatermarkImages(images)
+    }
+
+    assertEquals(ErrorCode.NULL_MAP.value, error.getErrorCode())
+    assertEquals("watermarkImages[0] is null", error.getErrMsg())
+  }
+}

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/MarkTextOptionsTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/MarkTextOptionsTest.kt
@@ -1,0 +1,42 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.mockito.Mockito
+
+class MarkTextOptionsTest {
+  @Test
+  fun acceptsNonNullTextMap() {
+    val textMap = JavaOnlyMap.of("text", "watermark")
+    val texts = readableArray(textMap)
+
+    val watermarkTexts = MarkTextOptions.readWatermarkTexts(texts)
+
+    assertSame(textMap, watermarkTexts.single().options)
+  }
+
+  @Test
+  fun rejectsNullMapEvenWhenArrayDoesNotReportNull() {
+    val texts = readableArray(null)
+
+    val error = assertThrows(MarkerError::class.java) {
+      MarkTextOptions.readWatermarkTexts(texts)
+    }
+
+    assertEquals(ErrorCode.NULL_MAP.value, error.getErrorCode())
+    assertEquals("watermarkTexts[0] is null", error.getErrMsg())
+  }
+
+  private fun readableArray(value: ReadableMap?): ReadableArray {
+    val array = Mockito.mock(ReadableArray::class.java)
+    Mockito.`when`(array.size()).thenReturn(1)
+    Mockito.`when`(array.isNull(0)).thenReturn(false)
+    Mockito.`when`(array.getMap(0)).thenReturn(value)
+    return array
+  }
+}

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/RNImageSRCTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/RNImageSRCTest.kt
@@ -1,0 +1,17 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+
+class RNImageSRCTest {
+  @Test
+  fun nullableUriDoesNotBecomeLiteralNull() {
+    val source = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(source.hasKey("uri")).thenReturn(true)
+    Mockito.`when`(source.getString("uri")).thenReturn(null)
+
+    assertEquals("", RNImageSRC(source).uri)
+  }
+}

--- a/ios/RCTImageMarker/RCTConvert+ImageMarker.swift
+++ b/ios/RCTImageMarker/RCTConvert+ImageMarker.swift
@@ -7,47 +7,9 @@
 
 import Foundation
 import UIKit
-import CoreFoundation
 import React
-import CoreGraphics
 
 extension RCTConvert {
-    static func CGSize(_ json: Any, offset: Int) -> CGSize {
-        let arr = self.nsArray(json)
-        if arr!.count < offset + 2 {
-            NSLog("Too few elements in array (expected at least %zd): %@", 2 + offset, arr!)
-            return CoreGraphics.CGSize.zero
-        }
-        return CoreGraphics.CGSize(width: self.cgFloat(arr![offset]), height: self.cgFloat(arr![offset + 1]))
-    }
-
-    static func CGPoint(_ json: Any, offset: Int) -> CGPoint {
-        let arr = self.nsArray(json)
-        if arr!.count < offset + 2 {
-            NSLog("Too few elements in array (expected at least %zd): %@", 2 + offset, arr!)
-            return CoreGraphics.CGPoint.zero
-        }
-        return CoreGraphics.CGPoint(x: self.cgFloat(arr?[offset]), y: self.cgFloat(arr![offset + 1]))
-    }
-
-    static func CGRect(_ json: Any, offset: Int) -> CGRect {
-        let arr = self.nsArray(json)
-        if arr!.count < offset + 4 {
-            NSLog("Too few elements in array (expected at least %zd): %@", 4 + offset, arr!)
-            return CoreGraphics.CGRect.zero
-        }
-        return CoreGraphics.CGRect(x: self.cgFloat(arr![offset]), y: self.cgFloat(arr![offset + 1]), width: self.cgFloat(arr![offset + 2]), height: self.cgFloat(arr![offset + 3]))
-    }
-
-    static func CGColor(_ json: Any, offset: Int) -> CGColor? {
-        let arr = self.nsArray(json)
-        if arr!.count < offset + 4 {
-            NSLog("Too few elements in array (expected at least %zd): %@", 4 + offset, arr!)
-            return nil
-        }
-        return self.cgColor(arr?[offset..<4])
-    }
-
     static func MarkerPosition(_ value: Any?) -> MarkerPositionEnum {
         let MyEnumMap: [String: MarkerPositionEnum] = [
             "topLeft": MarkerPositionEnum.topLeft,


### PR DESCRIPTION
## Summary

- update Android option parsing to handle nullable `ReadableMap` values exposed by newer React Native bridge APIs
- reject null watermark entries and missing nested image sources with explicit marker errors
- avoid converting a null image URI into the literal string `"null"`
- remove unused iOS `RCTConvert` geometry helpers that contained unsafe force unwraps
- add Android regression tests for nullable watermark maps, source maps, and URIs

## Root cause

Newer React Native Kotlin bridge definitions expose `ReadableArray.getMap` and related accessors as nullable. The Android implementation passed those results directly into constructors requiring non-null `ReadableMap` values, which causes the Kotlin compilation failure reported in #300. Several adjacent option parsers also relied on forced unwraps or string conversion that could hide malformed null input.

The active iOS option parsing path already uses conditional casts and throwing initializers, so it does not reproduce the Android failure. The unused legacy conversion helpers were removed to eliminate a similar future crash risk.

## Impact

Projects using newer React Native versions can compile the Android library, while invalid null inputs now fail predictably instead of producing compiler errors, forced-unwrapping crashes, or a literal `"null"` URI.

## Validation

- `./gradlew :react-native-image-marker:build --stacktrace`
- full Android Debug and Release JVM unit tests
- Android Release AAR build
- Kotlin compatibility compile against the React Native 0.83.9 nullable bridge interfaces
- iOS Simulator build of the `react-native-image-marker` pod scheme with Xcode 26.2
- `git diff --check`

Closes #300
