### PR TITLE
feat: add text stroke rendering

### DIFF
--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
@@ -143,21 +143,32 @@ data class TextOptions(val options: ReadableMap) {
           .coerceAtLeast(textLayout.getLineWidth(a) + textLayout.getLineLeft(a)).toDouble()
       ).toInt()
     }
+    val strokeWidth = style.strokeStyle?.width ?: 0f
+    val outlineInset = strokeWidth / 2f
+    val visualTextWidth = ceil(textWidth + strokeWidth.toDouble()).toInt()
+    val visualTextHeight = ceil(textHeight + strokeWidth.toDouble()).toInt()
     val position = Position.getTextPosition(
       positionEnum,
       x,
       y,
       maxWidth,
       maxHeight,
-      textWidth,
-      textHeight,
+      visualTextWidth,
+      visualTextHeight,
       edgeInset
     )
-    val x = position.x
-    val y = position.y
+    val visualX = position.x
+    val visualY = position.y
+    val x = visualX + outlineInset
+    val y = visualY + outlineInset
 
     canvas.save()
-    val rotationPivot = rotationPivot(x, y, textWidth.toFloat(), textHeight.toFloat())
+    val rotationPivot = rotationPivot(
+      visualX,
+      visualY,
+      visualTextWidth.toFloat(),
+      visualTextHeight.toFloat()
+    )
     canvas.rotate(style.rotate.toFloat(), rotationPivot.first, rotationPivot.second)
 
     // Draw text background
@@ -166,17 +177,22 @@ data class TextOptions(val options: ReadableMap) {
       paint.style = Paint.Style.FILL
       paint.color = style.textBackgroundStyle!!.color
       val bgInsets = style.textBackgroundStyle!!.toEdgeInsets(maxWidth, maxHeight)
-      var bgRect = RectF(x - bgInsets.left, y - bgInsets.top, x + textWidth + bgInsets.right, y + textHeight + bgInsets.bottom)
+      var bgRect = RectF(
+        x - outlineInset - bgInsets.left,
+        y - outlineInset - bgInsets.top,
+        x + textWidth + outlineInset + bgInsets.right,
+        y + textHeight + outlineInset + bgInsets.bottom
+      )
       when (style.textBackgroundStyle!!.type) {
         "stretchX" -> {
-          bgRect = RectF(0f, y - bgInsets.top, maxWidth.toFloat(),
-            y + textHeight + bgInsets.bottom
+          bgRect = RectF(0f, y - outlineInset - bgInsets.top, maxWidth.toFloat(),
+            y + textHeight + outlineInset + bgInsets.bottom
           )
         }
 
         "stretchY" -> {
-          bgRect = RectF(x - bgInsets.left, 0f,
-            x + textWidth + bgInsets.right, maxHeight.toFloat())
+          bgRect = RectF(x - outlineInset - bgInsets.left, 0f,
+            x + textWidth + outlineInset + bgInsets.right, maxHeight.toFloat())
         }
       }
 
@@ -197,6 +213,17 @@ data class TextOptions(val options: ReadableMap) {
       else -> x
     }
     canvas.translate(textX, y)
+    val fillColor = textPaint.color
+    if (strokeWidth > 0f) {
+      textPaint.style = Paint.Style.STROKE
+      textPaint.strokeWidth = strokeWidth
+      textPaint.strokeJoin = Paint.Join.ROUND
+      textPaint.color = Color.parseColor(Utils.transRGBColor(style.strokeStyle!!.color))
+      textLayout.draw(canvas)
+      textPaint.clearShadowLayer()
+      textPaint.style = Paint.Style.FILL
+      textPaint.color = fillColor
+    }
     textLayout.draw(canvas)
     canvas.restore()
   }

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStrokeStyle.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStrokeStyle.kt
@@ -1,0 +1,19 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.ReadableMap
+
+data class TextStrokeStyle(
+  val color: String,
+  val width: Float
+) {
+  constructor(options: ReadableMap) : this(
+    color = options.getString("color")
+      ?.takeIf { it.isNotBlank() }
+      ?: throw IllegalArgumentException("stroke color is required"),
+    width = options.getDouble("width").toFloat().also {
+      require(it.isFinite() && it >= 0f) {
+        "stroke width must be a non-negative finite number"
+      }
+    }
+  )
+}

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStyle.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextStyle.kt
@@ -11,6 +11,7 @@ class TextStyle(private val options: ReadableMap?) {
   var fontSizeRatio: Float? = null
   var shadowLayerStyle: ShadowLayerStyle? = null
   var textBackgroundStyle: TextBackgroundStyle? = null
+  var strokeStyle: TextStrokeStyle? = null
   var underline: Boolean = false
   var skewX: Float = 0f
   var strikeThrough: Boolean = false
@@ -28,6 +29,7 @@ class TextStyle(private val options: ReadableMap?) {
         fontSizeRatio = options.numberOrNull("fontSizeRatio")?.toFloat()
         shadowLayerStyle = options.mapOrNull("shadowStyle")?.let(::ShadowLayerStyle)
         textBackgroundStyle = options.mapOrNull("textBackgroundStyle")?.let(::TextBackgroundStyle)
+        strokeStyle = options.mapOrNull("strokeStyle")?.let(::TextStrokeStyle)
         underline = options.booleanOrDefault("underline", false)
         skewX = options.numberOrNull("skewX")?.toFloat() ?: 0f
         strikeThrough = options.booleanOrDefault("strikeThrough", false)

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/TextStyleTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/TextStyleTest.kt
@@ -18,6 +18,7 @@ class TextStyleTest {
     assertNull(style.fontSizeRatio)
     assertNull(style.shadowLayerStyle)
     assertNull(style.textBackgroundStyle)
+    assertNull(style.strokeStyle)
     assertFalse(style.underline)
     assertEquals(0f, style.skewX, 0f)
     assertFalse(style.strikeThrough)
@@ -48,5 +49,21 @@ class TextStyleTest {
     val style = TextStyle(options)
 
     assertEquals(24f, style.resolveFontSize(1000), 0.001f)
+  }
+
+  @Test
+  fun parsesTextStrokeStyle() {
+    val stroke = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(stroke.getString("color")).thenReturn("#11223380")
+    Mockito.`when`(stroke.getDouble("width")).thenReturn(3.5)
+    val options = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(options.hasKey("strokeStyle")).thenReturn(true)
+    Mockito.`when`(options.isNull("strokeStyle")).thenReturn(false)
+    Mockito.`when`(options.getMap("strokeStyle")).thenReturn(stroke)
+
+    val style = TextStyle(options)
+
+    assertEquals(3.5f, style.strokeStyle?.width ?: -1f, 0.001f)
+    assertEquals("#11223380", style.strokeStyle?.color)
   }
 }

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerRendererTest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerRendererTest.kt
@@ -415,6 +415,37 @@ class ImageMarkerRendererTest {
   }
 
   @Test
+  fun textStrokeRendersWhenTheFillIsTransparent() {
+    val output = ImageMarkerRenderer.renderTextWatermarks(
+      solidBitmap(180, 90, Color.WHITE),
+      textOptions(
+        x = 12,
+        y = 12,
+        style = JavaOnlyMap.of(
+          "color", "#00000000",
+          "fontSize", 34,
+          "strokeStyle", JavaOnlyMap.of(
+            "color", "#E11D48",
+            "width", 4
+          )
+        )
+      ),
+      reactContext()
+    )
+
+    var outlinePixels = 0
+    for (y in 0 until output.height) {
+      for (x in 0 until output.width) {
+        val pixel = output.getPixel(x, y)
+        if (Color.red(pixel) > 180 && Color.green(pixel) < 100 && Color.blue(pixel) < 130) {
+          outlinePixels += 1
+        }
+      }
+    }
+    assertTrue("Expected the transparent text fill to retain a visible outline", outlinePixels > 0)
+  }
+
+  @Test
   fun rotatedTextAtNonZeroCoordinatesKeepsItsLocalCenter() {
     val style = JavaOnlyMap.of(
       "color", "#00000000",

--- a/example/src/ImageMarkerLab.tsx
+++ b/example/src/ImageMarkerLab.tsx
@@ -651,6 +651,10 @@ function useViewModel(props: ImageMarkerLabProps) {
             : positionOptions,
         style: {
           color: '#F8FAFC',
+          strokeStyle: {
+            color: '#0F172ACC',
+            width: 2,
+          },
           fontName: nextConfig.fontName,
           fontSize: nextConfig.fontSize,
           underline: nextConfig.underline,

--- a/expo-example/App.tsx
+++ b/expo-example/App.tsx
@@ -60,6 +60,10 @@ function App() {
             position: { position: Position.bottomLeft, X: 36, Y: 36 },
             style: {
               color: '#FFFFFF',
+              strokeStyle: {
+                color: '#101828CC',
+                width: 2,
+              },
               fontSize: 34,
               bold: true,
               shadowStyle: {

--- a/expo-example/App.web.tsx
+++ b/expo-example/App.web.tsx
@@ -86,6 +86,10 @@ function App() {
             },
             style: {
               color: '#FFFFFF',
+              strokeStyle: {
+                color: '#101828CC',
+                width: 3,
+              },
               fontSize,
               bold: true,
               shadowStyle: {

--- a/expo-example/smoke-harness.web.ts
+++ b/expo-example/smoke-harness.web.ts
@@ -118,6 +118,10 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
               color: '#FFFFFF',
               fontSize: 48,
               bold: true,
+              strokeStyle: {
+                color: '#111827',
+                width: 3,
+              },
             },
           },
         ],

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -189,25 +189,35 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         if textOpts.style.skewX != 0 {
             attributes[.obliqueness] = textOpts.style.skewX
         }
+        let strokeWidth = textOpts.style.strokeStyle?.width ?? 0
+        let outlineInset = strokeWidth / 2
+        if let strokeStyle = textOpts.style.strokeStyle, strokeWidth > 0 {
+            attributes[.strokeColor] = strokeStyle.color
+            attributes[.strokeWidth] = -(strokeWidth / max(font.pointSize, 1) * 100)
+        }
 
         let attributedText = NSAttributedString(string: textOpts.text, attributes: attributes)
         let textRect = attributedText.boundingRect(with: canvasSize, options: .usesLineFragmentOrigin, context: nil)
         let size = textRect.size
+        let visualSize = CGSize(
+            width: size.width + strokeWidth,
+            height: size.height + strokeWidth
+        )
         let renderPosition = ImageMarkerRenderPosition(rawValue: textOpts.position.rawValue as String) ?? .none
-        let origin = ImageMarkerRenderer.markerOrigin(
+        let visualOrigin = ImageMarkerRenderer.markerOrigin(
             position: renderPosition,
             offsetX: textOpts.X,
             offsetY: textOpts.Y,
             canvasSize: canvasSize,
-            itemSize: size,
+            itemSize: visualSize,
             edgeInset: textOpts.edgeInset
         )
-        let posX = origin.x
-        let posY = origin.y
+        let posX = visualOrigin.x + outlineInset
+        let posY = visualOrigin.y + outlineInset
 
         if textOpts.style.rotate != 0 {
             let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style.rotate) * .pi / 180)
-            let textRectWithPos = CGRect(x: posX, y: posY, width: size.width, height: size.height)
+            let textRectWithPos = CGRect(origin: visualOrigin, size: visualSize)
             context.translateBy(x: textRectWithPos.midX, y: textRectWithPos.midY)
             context.concatenate(rotation)
             context.translateBy(x: -(textRectWithPos.midX), y: -(textRectWithPos.midY))
@@ -219,15 +229,25 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             let stretchX = bgEdgeInsets.left + bgEdgeInsets.right
             let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom
             var bgRect = CGRect(
-                x: posX - bgEdgeInsets.left,
-                y: posY - bgEdgeInsets.top,
-                width: size.width + stretchX,
-                height: size.height + stretchY
+                x: posX - outlineInset - bgEdgeInsets.left,
+                y: posY - outlineInset - bgEdgeInsets.top,
+                width: size.width + strokeWidth + stretchX,
+                height: size.height + strokeWidth + stretchY
             )
             if textBackground.typeBg == "stretchX" {
-                bgRect = CGRect(x: 0, y: posY - bgEdgeInsets.top, width: w, height: size.height + stretchY)
+                bgRect = CGRect(
+                    x: 0,
+                    y: posY - outlineInset - bgEdgeInsets.top,
+                    width: w,
+                    height: size.height + strokeWidth + stretchY
+                )
             } else if textBackground.typeBg == "stretchY" {
-                bgRect = CGRect(x: posX - bgEdgeInsets.left, y: 0, width: size.width + stretchX, height: h)
+                bgRect = CGRect(
+                    x: posX - outlineInset - bgEdgeInsets.left,
+                    y: 0,
+                    width: size.width + strokeWidth + stretchX,
+                    height: h
+                )
             }
 
             bgRect.inset(by: bgEdgeInsets)

--- a/ios/RCTImageMarker/TextStyle.swift
+++ b/ios/RCTImageMarker/TextStyle.swift
@@ -9,10 +9,38 @@ import Foundation
 import UIKit
 import React
 
+struct TextStrokeStyle {
+    let color: UIColor
+    let width: CGFloat
+
+    init(dicOpts opts: [AnyHashable: Any]) throws {
+        guard let colorValue = opts["color"] as? String,
+              !colorValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let color = UIColor(hex: colorValue) else {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "stroke color is invalid"]
+            )
+        }
+        let width = RCTConvert.cgFloat(opts["width"])
+        guard width.isFinite, width >= 0 else {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "stroke width must be a non-negative finite number"]
+            )
+        }
+        self.color = color
+        self.width = width
+    }
+}
+
 class TextStyle: NSObject {
     var color: UIColor?
     var shadow: NSShadow?
     var textBackground: TextBackground?
+    var strokeStyle: TextStrokeStyle?
     var fontName: String?
     var fontSize: CGFloat = 14.0
     var fontSizeRatio: CGFloat?
@@ -32,6 +60,11 @@ class TextStyle: NSObject {
             self.shadow = nil
         }
         self.textBackground = try TextBackground(textBackgroundStyle: (opts["textBackgroundStyle"] as? [AnyHashable : Any]))
+        if let strokeStyle = opts["strokeStyle"] as? [AnyHashable: Any] {
+            self.strokeStyle = try TextStrokeStyle(dicOpts: strokeStyle)
+        } else {
+            self.strokeStyle = nil
+        }
         self.fontName = opts["fontName"] as? String
         self.fontSize = opts["fontSize"] != nil ? RCTConvert.cgFloat(opts["fontSize"]) : 14.0
         self.fontSizeRatio = opts["fontSizeRatio"] != nil ? RCTConvert.cgFloat(opts["fontSizeRatio"]) : nil

--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -1,4 +1,8 @@
-import Marker, { type ImageMarkOptions } from '../index';
+import Marker, {
+  type ImageMarkOptions,
+  type TextMarkOptions,
+  type TextStrokeStyle,
+} from '../index';
 
 // The deprecated single-watermark shape remains source-compatible for users
 // that have not migrated to watermarkImages yet.
@@ -25,3 +29,18 @@ export const multipleWatermarks: ImageMarkOptions = {
 export function markWithLegacyWatermarkOnly(): Promise<string> {
   return Marker.markImage(legacyWatermarkOnly);
 }
+
+export const textStroke: TextStrokeStyle = {
+  color: '#00000099',
+  width: 2,
+};
+
+export const outlinedText: TextMarkOptions = {
+  backgroundImage: { src: 'file:///tmp/background.png' },
+  watermarkTexts: [
+    {
+      text: 'Outlined',
+      style: { color: '#FFFFFF', strokeStyle: textStroke },
+    },
+  ],
+};

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -313,6 +313,69 @@ describe('Marker JS wrapper', () => {
     expect(nativeModule.markWithImage).not.toHaveBeenCalled();
   });
 
+  it('preserves text stroke options without mutating the caller input', async () => {
+    nativeModule.markWithText.mockResolvedValue('/tmp/outlined-text.png');
+    const options = {
+      backgroundImage: { src: 'file:///tmp/background.png' },
+      watermarkTexts: [
+        {
+          text: 'Outlined',
+          style: {
+            color: '#FFFFFF',
+            strokeStyle: { color: '#00000099', width: 2 },
+          },
+        },
+      ],
+    };
+    deepFreeze(options);
+
+    await expect(Marker.markText(options)).resolves.toBe(
+      '/tmp/outlined-text.png'
+    );
+
+    const nativeStroke =
+      nativeModule.markWithText.mock.calls[0][0].watermarkTexts[0].style
+        .strokeStyle;
+    expect(nativeStroke).toEqual({ color: '#00000099', width: 2 });
+    expect(nativeStroke).not.toBe(options.watermarkTexts[0].style.strokeStyle);
+  });
+
+  it('rejects invalid text stroke styles before rendering', () => {
+    for (const width of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        Marker.markText({
+          backgroundImage: { src: 'file:///tmp/background.png' },
+          watermarkTexts: [
+            {
+              text: 'Invalid outline',
+              style: { strokeStyle: { color: '#000000', width } },
+            },
+          ],
+        })
+      ).toThrow(
+        'watermarkTexts[0].style.strokeStyle.width must be a non-negative finite number.'
+      );
+    }
+
+    expect(() =>
+      Marker.mark({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarks: [
+          {
+            type: 'text',
+            text: 'Invalid outline',
+            style: { strokeStyle: { color: '  ', width: 2 } },
+          },
+        ],
+      })
+    ).toThrow(
+      'watermarks[0].style.strokeStyle.color must be a non-empty string.'
+    );
+
+    expect(nativeModule.markWithText).not.toHaveBeenCalled();
+    expect(nativeModule.markWithWatermarks).not.toHaveBeenCalled();
+  });
+
   it('accepts quality and alpha boundary values', async () => {
     nativeModule.markWithText.mockResolvedValue('/tmp/boundary-text.png');
     nativeModule.markWithWatermarks.mockResolvedValue(

--- a/src/__tests__/web-marker-render.test.ts
+++ b/src/__tests__/web-marker-render.test.ts
@@ -50,6 +50,7 @@ function createFakeCanvas() {
     shadowOffsetX: 0,
     shadowOffsetY: 0,
     imageSmoothingEnabled: true,
+    lineJoin: 'miter',
     lineWidth: 1,
     strokeStyle: '#000000',
     save: jest.fn(),
@@ -69,6 +70,7 @@ function createFakeCanvas() {
     transform: jest.fn(),
     drawImage: jest.fn(),
     fillText: jest.fn(),
+    strokeText: jest.fn(),
     stroke: jest.fn(),
     measureText: jest.fn((text: string) => ({
       width: text.length * 10,
@@ -247,6 +249,37 @@ describe('WebMarker browser render integration', () => {
     expect(context.textAlign).toBe('right');
     expect(context.font).toContain('italic 700');
     expect(context.shadowBlur).toBe(4);
+  });
+
+  it('draws a text outline before the fill and includes it in anchoring', async () => {
+    const canvases = installFakeBrowserRuntime();
+
+    await WebMarker.markText({
+      backgroundImage: { src: '/background.jpg' },
+      watermarkTexts: [
+        {
+          text: 'Outline',
+          position: { position: Position.topLeft, X: 0, Y: 0 },
+          style: {
+            color: '#FFFFFF',
+            strokeStyle: { color: '#111827', width: 6 },
+            textBackgroundStyle: { color: '#F97316' },
+          },
+        },
+      ],
+      saveFormat: ImageFormat.png,
+    });
+
+    const { context } = canvases[0]!;
+    expect(context.strokeStyle).toBe('#111827');
+    expect(context.lineWidth).toBe(6);
+    expect(context.lineJoin).toBe('round');
+    expect(context.strokeText).toHaveBeenCalledWith('Outline', 3, 3);
+    expect(context.fillText).toHaveBeenCalledWith('Outline', 3, 3);
+    expect(context.strokeText.mock.invocationCallOrder[0]).toBeLessThan(
+      context.fillText.mock.invocationCallOrder[0]
+    );
+    expect(context.moveTo).toHaveBeenCalledWith(0, 0);
   });
 
   it('bounds large inputs before applying background and watermark scales', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,16 @@ export interface TextStyle {
    */
   textBackgroundStyle?: TextBackgroundStyle | null;
   /**
+   * Optional outline drawn around the text before the fill. The width is
+   * measured in output-image pixels. Set `width` to `0` to disable it.
+   * @example
+   * strokeStyle: {
+   *   color: '#00000099',
+   *   width: 2,
+   * }
+   */
+  strokeStyle?: TextStrokeStyle | null;
+  /**
    * text underline style
    * @defaultValue false
    * @example
@@ -314,6 +324,14 @@ export interface TextStyle {
    *  rotate: 45
    */
   rotate?: number;
+}
+
+/** Outline style for text watermarks. */
+export interface TextStrokeStyle {
+  /** Outline color. */
+  color: string;
+  /** Non-negative outline width in output-image pixels. */
+  width: number;
 }
 
 /**

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -80,6 +80,9 @@ function cloneTextStyle(style?: TextStyle): TextStyle | undefined {
     shadowStyle: style.shadowStyle
       ? { ...style.shadowStyle }
       : style.shadowStyle,
+    strokeStyle: style.strokeStyle
+      ? { ...style.strokeStyle }
+      : style.strokeStyle,
     textBackgroundStyle: cloneTextBackgroundStyle(style.textBackgroundStyle),
   };
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -2,6 +2,7 @@ import type {
   ImageMarkOptions,
   ImageOptions,
   MarkOptions,
+  TextOptions,
   TextMarkOptions,
 } from './index';
 
@@ -52,8 +53,28 @@ function validateCommonOptions(options: MarkRequestOptions): void {
   validateAlpha(options.backgroundImage, 'backgroundImage');
 }
 
+function validateTextOptions(textOptions: TextOptions, path: string): void {
+  const strokeStyle = textOptions.style?.strokeStyle;
+  if (!strokeStyle) {
+    return;
+  }
+  if (!Number.isFinite(strokeStyle.width) || strokeStyle.width < 0) {
+    throw new Error(
+      `${path}.style.strokeStyle.width must be a non-negative finite number.`
+    );
+  }
+  if (typeof strokeStyle.color !== 'string' || !strokeStyle.color.trim()) {
+    throw new Error(
+      `${path}.style.strokeStyle.color must be a non-empty string.`
+    );
+  }
+}
+
 export function validateTextMarkOptions(options: TextMarkOptions): void {
   validateCommonOptions(options);
+  options.watermarkTexts.forEach((textOptions, index) => {
+    validateTextOptions(textOptions, `watermarkTexts[${index}]`);
+  });
 }
 
 export function validateImageMarkOptions(options: ImageMarkOptions): void {
@@ -73,6 +94,11 @@ export function validateMarkOptions(options: MarkOptions): void {
   options.watermarks?.forEach((layer, index) => {
     if (layer.type === 'image') {
       validateAlpha(layer, `watermarks[${index}]`);
+    } else {
+      validateTextOptions(layer, `watermarks[${index}]`);
     }
+  });
+  options.watermarkTexts?.forEach((textOptions, index) => {
+    validateTextOptions(textOptions, `watermarkTexts[${index}]`);
   });
 }

--- a/src/web/browser.ts
+++ b/src/web/browser.ts
@@ -18,6 +18,9 @@ export interface WebCanvasContext {
   shadowOffsetX: number;
   shadowOffsetY: number;
   imageSmoothingEnabled: boolean;
+  lineJoin: string;
+  lineWidth: number;
+  strokeStyle: unknown;
   save(): void;
   restore(): void;
   beginPath(): void;
@@ -42,6 +45,7 @@ export interface WebCanvasContext {
   ): void;
   drawImage(...args: unknown[]): void;
   fillText(text: string, x: number, y: number): void;
+  strokeText(text: string, x: number, y: number): void;
   measureText(text: string): WebTextMetrics;
   getImageData(
     sx: number,

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -8,6 +8,11 @@ import type {
 } from '../index';
 import { renderWebComposition } from './renderer';
 import type { WebRenderLayer } from './renderer';
+import {
+  validateImageMarkOptions,
+  validateMarkOptions,
+  validateTextMarkOptions,
+} from '../validate';
 
 function createTextLayer(options: TextOptions): WebRenderLayer {
   return { type: 'text', options };
@@ -65,6 +70,7 @@ class Marker {
     if (!options.watermarkTexts || options.watermarkTexts.length === 0) {
       throw new Error('please set watermark text!');
     }
+    validateTextMarkOptions(options);
 
     return renderWebComposition(
       options.backgroundImage,
@@ -85,6 +91,7 @@ class Marker {
     if (watermarkImages.some((watermark) => !watermark.src)) {
       throw new Error('please set mark image!');
     }
+    validateImageMarkOptions(options);
 
     const layers: WebRenderLayer[] = [];
     appendCompatibilityLayers(layers, options);
@@ -110,6 +117,7 @@ class Marker {
     if (layers.some((layer) => layer.type === 'image' && !layer.options.src)) {
       throw new Error('please set mark image!');
     }
+    validateMarkOptions(options);
 
     return renderWebComposition(options.backgroundImage, layers, options);
   }

--- a/src/web/renderer.ts
+++ b/src/web/renderer.ts
@@ -375,13 +375,14 @@ function drawTextBackground(
   style: TextBackgroundStyle,
   origin: Point,
   layout: TextLayout,
-  canvas: Size
+  canvas: Size,
+  outlineInset = 0
 ) {
   const padding = resolvePadding(style, canvas);
-  let x = origin.x - padding.left;
-  let y = origin.y - padding.top;
-  let width = layout.width + padding.left + padding.right;
-  let height = layout.height + padding.top + padding.bottom;
+  let x = origin.x - outlineInset - padding.left;
+  let y = origin.y - outlineInset - padding.top;
+  let width = layout.width + outlineInset * 2 + padding.left + padding.right;
+  let height = layout.height + outlineInset * 2 + padding.top + padding.bottom;
 
   if ((style.type as string | null | undefined) === 'stretchX') {
     x = 0;
@@ -464,25 +465,35 @@ function drawTextLayer(
 ) {
   const style = options.style;
   const layout = measureTextLayout(context, options.text, style, canvas.width);
-  const position = resolveAnchoredPosition(
+  const strokeWidth = style?.strokeStyle?.width ?? 0;
+  const outlineInset = strokeWidth / 2;
+  const visualSize = {
+    width: layout.width + outlineInset * 2,
+    height: layout.height + outlineInset * 2,
+  };
+  const visualPosition = resolveAnchoredPosition(
     options.position ?? options.positionOptions,
     canvas,
-    layout,
+    visualSize,
     20
   );
+  const position = {
+    x: visualPosition.x + outlineInset,
+    y: visualPosition.y + outlineInset,
+  };
   const rotation = resolveRotation(style?.rotate, 'text rotation');
 
   context.save();
   try {
     if (rotation !== 0) {
       context.translate(
-        position.x + layout.width / 2,
-        position.y + layout.height / 2
+        visualPosition.x + visualSize.width / 2,
+        visualPosition.y + visualSize.height / 2
       );
       context.rotate(degreesToRadians(rotation));
       context.translate(
-        -(position.x + layout.width / 2),
-        -(position.y + layout.height / 2)
+        -(visualPosition.x + visualSize.width / 2),
+        -(visualPosition.y + visualSize.height / 2)
       );
     }
 
@@ -492,7 +503,8 @@ function drawTextLayer(
         style.textBackgroundStyle,
         position,
         layout,
-        canvas
+        canvas,
+        outlineInset
       );
     }
 
@@ -504,6 +516,9 @@ function drawTextLayer(
     context.shadowOffsetX = style?.shadowStyle?.dx ?? 0;
     context.shadowOffsetY = style?.shadowStyle?.dy ?? 0;
     context.shadowColor = style?.shadowStyle?.color ?? 'transparent';
+    context.lineJoin = 'round';
+    context.lineWidth = strokeWidth;
+    context.strokeStyle = style?.strokeStyle?.color ?? '#000000';
 
     const textX = getAlignedTextX(style?.textAlign, position.x, layout.width);
     if (style?.skewX) {
@@ -514,7 +529,15 @@ function drawTextLayer(
 
     layout.lines.forEach((line, lineIndex) => {
       const lineY = position.y + lineIndex * layout.lineHeight;
-      context.fillText(line.text, textX, lineY);
+      if (strokeWidth > 0) {
+        context.strokeText(line.text, textX, lineY);
+        const shadowColor = context.shadowColor;
+        context.shadowColor = 'transparent';
+        context.fillText(line.text, textX, lineY);
+        context.shadowColor = shadowColor;
+      } else {
+        context.fillText(line.text, textX, lineY);
+      }
       context.save();
       context.translate(position.x, position.y);
       drawTextDecorations(


### PR DESCRIPTION
## Summary
- add the `strokeStyle` text API without changing existing defaults
- render text outlines on Android, iOS, and Web with corrected anchor, rotation, and background bounds
- validate inputs and cover TypeScript, browser, Android, and example paths

## Verification
- `npm test -- --coverage --runInBand`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:example`
- `npm run typecheck:expo-example`
- `npm run prepack`
- `npm run docs`
- Android library unit tests and Android instrumentation-test compilation
- iOS `react-native-image-marker` scheme build
- Expo Web Chromium, Firefox, and WebKit smoke tests

The full legacy iOS example workspace currently stops at a pre-existing missing React Native Fabric source in `example/node_modules`; the library Pod scheme itself builds successfully.