### PR TITLE
feat: add tiled watermark layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,6 +857,8 @@ jobs:
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testWatermarkOrientationMatchesUprightPixelReference \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testNormalizesUIImageOrientationBeforeCGImageRendering \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testKeepsAlreadyUprightUIImageInstance \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTileLayoutResolvesOffsetsStaggerAndCopyLimit \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTiledImageRepeatsAcrossCanvas \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testPositionDefaultsAndEdgeInsetOverrides \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testRotatesFortyFiveDegreesWithExpandedTransparentCanvas \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testRotatesFortyFiveDegreesWithCroppedOriginalCanvas \

--- a/android/src/main/java/com/jimmydaddy/imagemarker/ImageMarkerRenderer.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/ImageMarkerRenderer.kt
@@ -39,34 +39,46 @@ object ImageMarkerRenderer {
         scaledHeight,
         markOpts.imageOption.rotate
       )
-      val position = Position.getImageRectFromPosition(
-        markOpts.positionEnum,
-        markOpts.x,
-        markOpts.y,
-        rotatedBounds.width,
-        rotatedBounds.height,
-        canvasWidth,
-        canvasHeight,
-        markOpts.edgeInset
-      )
-
-      canvas.save()
-      // Translate the transformed content bounds to the resolved anchor. Scaling and rotation
-      // happen directly on the destination Canvas, avoiding temporary watermark bitmaps.
-      canvas.translate(
-        position.x - rotatedBounds.left,
-        position.y - rotatedBounds.top
-      )
-      canvas.rotate(markOpts.imageOption.rotate)
-      canvas.scale(scale, scale)
-      canvas.translate(-sourceBounds.left.toFloat(), -sourceBounds.top.toFloat())
-      canvas.clipRect(sourceBounds)
+      val positions = if (markOpts.layout?.isTile == true) {
+        markOpts.layout!!.placements(
+          canvasWidth,
+          canvasHeight,
+          rotatedBounds.width,
+          rotatedBounds.height
+        )
+      } else {
+        listOf(
+          Position.getImageRectFromPosition(
+            markOpts.positionEnum,
+            markOpts.x,
+            markOpts.y,
+            rotatedBounds.width,
+            rotatedBounds.height,
+            canvasWidth,
+            canvasHeight,
+            markOpts.edgeInset
+          )
+        )
+      }
       val paint = markOpts.imageOption.applyStyle().apply {
         // Preserve hard edges for QR codes, barcodes and pixel-art watermarks.
         isFilterBitmap = false
       }
-      canvas.drawBitmap(sourceMarker, 0f, 0f, paint)
-      canvas.restore()
+      for (position in positions) {
+        canvas.save()
+        // Translate the transformed content bounds to the resolved anchor. Scaling and rotation
+        // happen directly on the destination Canvas, avoiding temporary watermark bitmaps.
+        canvas.translate(
+          position.x - rotatedBounds.left,
+          position.y - rotatedBounds.top
+        )
+        canvas.rotate(markOpts.imageOption.rotate)
+        canvas.scale(scale, scale)
+        canvas.translate(-sourceBounds.left.toFloat(), -sourceBounds.top.toFloat())
+        canvas.clipRect(sourceBounds)
+        canvas.drawBitmap(sourceMarker, 0f, 0f, paint)
+        canvas.restore()
+      }
     } finally {
       if (recycleSource && !sourceMarker.isRecycled) {
         sourceMarker.recycle()

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/MarkImageOptions.kt
@@ -39,13 +39,22 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
         ?.let(PositionEnum::getPosition)
       val trimTransparentPadding =
         markerImageOpts.hasKey("trimTransparentPadding") && markerImageOpts.getBoolean("trimTransparentPadding")
+      val layout = if (markerImageOpts.hasKey("layout") && !markerImageOpts.isNull("layout")) {
+        markerImageOpts.getMap("layout")?.let(::WatermarkLayout)
+      } else {
+        null
+      }
+      if (layout?.isTile == true && positionOptions != null) {
+        throw MarkerError(ErrorCode.INVALID_PARAMS, "layout cannot be combined with position")
+      }
       val markerOpts = WatermarkImageOptions(
         marker,
         x,
         y,
         edgeInset,
         positionEnum,
-        trimTransparentPadding
+        trimTransparentPadding,
+        layout
       )
       myMarkerList.add(markerOpts)
     }
@@ -60,9 +69,12 @@ class MarkImageOptions(options: ReadableMap) : Options(options) {
 
       return ArrayList<WatermarkImageOptions>(watermarkImages.size()).apply {
         for (index in 0 until watermarkImages.size()) {
-          val markerMap = watermarkImages.getMap(index)
-            ?: throw MarkerError(ErrorCode.NULL_MAP, "watermarkImages[$index] is null")
-          add(WatermarkImageOptions(markerMap))
+          val markerMap: ReadableMap? = watermarkImages.getMap(index)
+          add(
+            WatermarkImageOptions(
+              markerMap ?: throw MarkerError(ErrorCode.NULL_MAP, "watermarkImages[$index] is null")
+            )
+          )
         }
       }
     }

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
@@ -15,6 +15,7 @@ import android.util.TypedValue
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.assets.ReactFontManager
+import com.jimmydaddy.imagemarker.ImageProcess
 import kotlin.math.ceil
 
 @Suppress("DEPRECATION")
@@ -25,6 +26,7 @@ data class TextOptions(val options: ReadableMap) {
   private var edgeInset: String?
   private var positionEnum: PositionEnum?
   private var style: TextStyle
+  private var layout: WatermarkLayout?
 
   init {
     try {
@@ -48,6 +50,15 @@ data class TextOptions(val options: ReadableMap) {
         null
       }
       positionEnum = positionName?.let(PositionEnum::getPosition)
+      val layoutOptions = if (options.hasKey("layout") && !options.isNull("layout")) {
+        options.getMap("layout")
+      } else {
+        null
+      }
+      layout = layoutOptions?.let(::WatermarkLayout)
+      if (layout?.isTile == true && positionOptions != null) {
+        throw MarkerError(ErrorCode.INVALID_PARAMS, "layout cannot be combined with position")
+      }
       val styleOptions = if (options.hasKey("style") && !options.isNull("style")) {
         options.getMap("style")
       } else {
@@ -147,85 +158,113 @@ data class TextOptions(val options: ReadableMap) {
     val outlineInset = strokeWidth / 2f
     val visualTextWidth = ceil(textWidth + strokeWidth.toDouble()).toInt()
     val visualTextHeight = ceil(textHeight + strokeWidth.toDouble()).toInt()
-    val position = Position.getTextPosition(
-      positionEnum,
-      x,
-      y,
-      maxWidth,
-      maxHeight,
-      visualTextWidth,
-      visualTextHeight,
-      edgeInset
-    )
-    val visualX = position.x
-    val visualY = position.y
-    val x = visualX + outlineInset
-    val y = visualY + outlineInset
-
-    canvas.save()
-    val rotationPivot = rotationPivot(
-      visualX,
-      visualY,
-      visualTextWidth.toFloat(),
-      visualTextHeight.toFloat()
-    )
-    canvas.rotate(style.rotate.toFloat(), rotationPivot.first, rotationPivot.second)
-
-    // Draw text background
-    if (null != style.textBackgroundStyle) {
-      val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.LINEAR_TEXT_FLAG)
-      paint.style = Paint.Style.FILL
-      paint.color = style.textBackgroundStyle!!.color
-      val bgInsets = style.textBackgroundStyle!!.toEdgeInsets(maxWidth, maxHeight)
-      var bgRect = RectF(
-        x - outlineInset - bgInsets.left,
-        y - outlineInset - bgInsets.top,
-        x + textWidth + outlineInset + bgInsets.right,
-        y + textHeight + outlineInset + bgInsets.bottom
+    val positions = if (layout?.isTile == true) {
+      val rotatedBounds = ImageProcess.rotatedBounds(
+        visualTextWidth.toFloat(),
+        visualTextHeight.toFloat(),
+        style.rotate
       )
-      when (style.textBackgroundStyle!!.type) {
-        "stretchX" -> {
-          bgRect = RectF(0f, y - outlineInset - bgInsets.top, maxWidth.toFloat(),
-            y + textHeight + outlineInset + bgInsets.bottom
+      val originInsetX = (rotatedBounds.width - visualTextWidth) / 2f
+      val originInsetY = (rotatedBounds.height - visualTextHeight) / 2f
+      layout!!.placements(
+        maxWidth,
+        maxHeight,
+        rotatedBounds.width,
+        rotatedBounds.height
+      ).map { Position(it.x + originInsetX, it.y + originInsetY) }
+    } else {
+      listOf(
+        Position.getTextPosition(
+          positionEnum,
+          x,
+          y,
+          maxWidth,
+          maxHeight,
+          visualTextWidth,
+          visualTextHeight,
+          edgeInset
+        )
+      )
+    }
+
+    for (position in positions) {
+      val visualX = position.x
+      val visualY = position.y
+      val drawX = visualX + outlineInset
+      val drawY = visualY + outlineInset
+      canvas.save()
+      val rotationPivot = rotationPivot(
+        visualX,
+        visualY,
+        visualTextWidth.toFloat(),
+        visualTextHeight.toFloat()
+      )
+      canvas.rotate(style.rotate.toFloat(), rotationPivot.first, rotationPivot.second)
+
+      // Draw text background
+      if (null != style.textBackgroundStyle) {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.LINEAR_TEXT_FLAG)
+        paint.style = Paint.Style.FILL
+        paint.color = style.textBackgroundStyle!!.color
+        val bgInsets = style.textBackgroundStyle!!.toEdgeInsets(maxWidth, maxHeight)
+        var bgRect = RectF(
+          drawX - outlineInset - bgInsets.left,
+          drawY - outlineInset - bgInsets.top,
+          drawX + textWidth + outlineInset + bgInsets.right,
+          drawY + textHeight + outlineInset + bgInsets.bottom
+        )
+        when (style.textBackgroundStyle!!.type) {
+          "stretchX" -> {
+            bgRect = RectF(0f, drawY - outlineInset - bgInsets.top, maxWidth.toFloat(),
+              drawY + textHeight + outlineInset + bgInsets.bottom
+            )
+          }
+
+          "stretchY" -> {
+            bgRect = RectF(drawX - outlineInset - bgInsets.left, 0f,
+              drawX + textWidth + outlineInset + bgInsets.right, maxHeight.toFloat())
+          }
+        }
+
+        if (style.textBackgroundStyle!!.cornerRadius != null) {
+          val path = Path()
+
+          path.addRoundRect(bgRect, style.textBackgroundStyle!!.cornerRadius!!.radii(bgRect), Path.Direction.CW)
+
+          canvas.drawPath(path, paint)
+        } else {
+          canvas.drawRect(bgRect, paint)
+        }
+      }
+      val textX = when(textPaint.textAlign) {
+        Paint.Align.RIGHT -> drawX + textWidth
+        Paint.Align.CENTER -> drawX + textWidth / 2
+        Paint.Align.LEFT -> drawX
+        else -> drawX
+      }
+      canvas.translate(textX, drawY)
+      val fillColor = textPaint.color
+      if (strokeWidth > 0f) {
+        if (style.shadowLayerStyle != null) {
+          textPaint.setShadowLayer(
+            style.shadowLayerStyle!!.radius,
+            style.shadowLayerStyle!!.dx,
+            style.shadowLayerStyle!!.dy,
+            style.shadowLayerStyle!!.color
           )
         }
-
-        "stretchY" -> {
-          bgRect = RectF(x - outlineInset - bgInsets.left, 0f,
-            x + textWidth + outlineInset + bgInsets.right, maxHeight.toFloat())
-        }
+        textPaint.style = Paint.Style.STROKE
+        textPaint.strokeWidth = strokeWidth
+        textPaint.strokeJoin = Paint.Join.ROUND
+        textPaint.color = Color.parseColor(Utils.transRGBColor(style.strokeStyle!!.color))
+        textLayout.draw(canvas)
+        textPaint.clearShadowLayer()
+        textPaint.style = Paint.Style.FILL
+        textPaint.color = fillColor
       }
-
-      if (style.textBackgroundStyle!!.cornerRadius != null) {
-        val path = Path()
-
-        path.addRoundRect(bgRect, style.textBackgroundStyle!!.cornerRadius!!.radii(bgRect), Path.Direction.CW)
-
-        canvas.drawPath(path, paint)
-      } else {
-        canvas.drawRect(bgRect, paint)
-      }
-    }
-    val textX = when(textPaint.textAlign) {
-      Paint.Align.RIGHT -> x + textWidth
-      Paint.Align.CENTER -> x + textWidth / 2
-      Paint.Align.LEFT -> x
-      else -> x
-    }
-    canvas.translate(textX, y)
-    val fillColor = textPaint.color
-    if (strokeWidth > 0f) {
-      textPaint.style = Paint.Style.STROKE
-      textPaint.strokeWidth = strokeWidth
-      textPaint.strokeJoin = Paint.Join.ROUND
-      textPaint.color = Color.parseColor(Utils.transRGBColor(style.strokeStyle!!.color))
       textLayout.draw(canvas)
-      textPaint.clearShadowLayer()
-      textPaint.style = Paint.Style.FILL
-      textPaint.color = fillColor
+      canvas.restore()
     }
-    textLayout.draw(canvas)
-    canvas.restore()
   }
 
   companion object {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkImageOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkImageOptions.kt
@@ -9,6 +9,7 @@ data class WatermarkImageOptions(val options: ReadableMap?) {
   var edgeInset: String? = null
   var positionEnum: PositionEnum? = null
   var trimTransparentPadding: Boolean = false
+  var layout: WatermarkLayout? = null
 
   init {
     if (options != null) {
@@ -25,6 +26,14 @@ data class WatermarkImageOptions(val options: ReadableMap?) {
         ?.let(PositionEnum::getPosition)
       trimTransparentPadding =
         options.hasKey("trimTransparentPadding") && options.getBoolean("trimTransparentPadding")
+      layout = if (options.hasKey("layout") && !options.isNull("layout")) {
+        options.getMap("layout")?.let(::WatermarkLayout)
+      } else {
+        null
+      }
+      if (layout?.isTile == true && positionOptions != null) {
+        throw IllegalArgumentException("layout cannot be combined with position")
+      }
     }
   }
 
@@ -34,7 +43,8 @@ data class WatermarkImageOptions(val options: ReadableMap?) {
     y: String?,
     edgeInset: String?,
     position: PositionEnum?,
-    trimTransparentPadding: Boolean = false
+    trimTransparentPadding: Boolean = false,
+    layout: WatermarkLayout? = null
   ) : this(null) {
     imageOption = watermarkImage
     this.x = x
@@ -42,6 +52,10 @@ data class WatermarkImageOptions(val options: ReadableMap?) {
     this.edgeInset = edgeInset
     this.positionEnum = position
     this.trimTransparentPadding = trimTransparentPadding
+    this.layout = layout
+    if (layout?.isTile == true && (x != null || y != null || edgeInset != null || position != null)) {
+      throw IllegalArgumentException("layout cannot be combined with position")
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkLayout.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/WatermarkLayout.kt
@@ -1,0 +1,137 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+
+class WatermarkLayout(options: ReadableMap?) {
+  val type: String
+  private val gapX: String?
+  private val gapY: String?
+  private val offsetX: String?
+  private val offsetY: String?
+  private val stagger: Boolean
+
+  val isTile: Boolean
+    get() = type == TYPE_TILE
+
+  init {
+    type = if (options?.hasKey("type") == true && !options.isNull("type")) {
+      options.getString("type") ?: TYPE_SINGLE
+    } else {
+      TYPE_SINGLE
+    }
+    require(type == TYPE_SINGLE || type == TYPE_TILE) {
+      "layout.type must be single or tile"
+    }
+    gapX = readSpreadValue(options, "gapX")
+    gapY = readSpreadValue(options, "gapY")
+    offsetX = readSpreadValue(options, "offsetX")
+    offsetY = readSpreadValue(options, "offsetY")
+    stagger = if (options?.hasKey("stagger") == true && !options.isNull("stagger")) {
+      options.getBoolean("stagger")
+    } else {
+      false
+    }
+  }
+
+  fun placements(
+    canvasWidth: Int,
+    canvasHeight: Int,
+    itemWidth: Number,
+    itemHeight: Number
+  ): List<Position> {
+    require(isTile) { "placements are only available for tile layouts" }
+    val width = itemWidth.toFloat()
+    val height = itemHeight.toFloat()
+    require(canvasWidth > 0 && canvasHeight > 0 && width.isFinite() && height.isFinite() && width > 0f && height > 0f) {
+      "canvas and watermark dimensions must be finite and greater than zero"
+    }
+
+    val resolvedGapX = parseSpreadValue(gapX, canvasWidth.toFloat(), "layout.gapX")
+    val resolvedGapY = parseSpreadValue(gapY, canvasHeight.toFloat(), "layout.gapY")
+    require(resolvedGapX >= 0f && resolvedGapY >= 0f) {
+      "layout gaps must be non-negative"
+    }
+    val stepX = width + resolvedGapX
+    val stepY = height + resolvedGapY
+    require(stepX.isFinite() && stepY.isFinite() && stepX > 0f && stepY > 0f) {
+      "tile layout step must be finite and greater than zero"
+    }
+
+    val phaseX = normalizedOffset(
+      parseSpreadValue(offsetX, canvasWidth.toFloat(), "layout.offsetX"),
+      stepX
+    )
+    val phaseY = normalizedOffset(
+      parseSpreadValue(offsetY, canvasHeight.toFloat(), "layout.offsetY"),
+      stepY
+    )
+    val result = ArrayList<Position>()
+    var row = -1
+    var y = phaseY - stepY
+    while (y < canvasHeight) {
+      if (y + height > 0f) {
+        val staggerOffset = if (stagger && row % 2 != 0) stepX / 2f else 0f
+        val rowPhaseX = normalizedOffset(phaseX + staggerOffset, stepX)
+        var x = rowPhaseX - stepX
+        while (x < canvasWidth) {
+          if (x + width > 0f) {
+            result.add(Position(x, y))
+            if (result.size > MAX_TILE_COPIES) {
+              throw IllegalArgumentException(
+                "tile layout exceeds the maximum of $MAX_TILE_COPIES copies per layer"
+              )
+            }
+          }
+          x += stepX
+        }
+      }
+      row += 1
+      y += stepY
+    }
+    return result
+  }
+
+  companion object {
+    const val MAX_TILE_COPIES = 4096
+    private const val TYPE_SINGLE = "single"
+    private const val TYPE_TILE = "tile"
+
+    private fun readSpreadValue(options: ReadableMap?, key: String): String? {
+      if (options?.hasKey(key) != true || options.isNull(key)) return null
+      val dynamic = options.getDynamic(key)
+      return when (dynamic.type) {
+        ReadableType.Number -> dynamic.asDouble().also {
+          require(it.isFinite()) { "layout.$key must be a finite number or percentage" }
+        }.toString()
+        ReadableType.String -> dynamic.asString()?.trim()?.also {
+          require(SPREAD_VALUE.matches(it)) {
+            "layout.$key must be a finite number or percentage"
+          }
+        }
+        else -> throw IllegalArgumentException(
+          "layout.$key must be a finite number or percentage"
+        )
+      }
+    }
+
+    private fun parseSpreadValue(value: String?, relativeTo: Float, label: String): Float {
+      if (value == null) return 0f
+      val parsed = if (value.endsWith("%")) {
+        value.dropLast(1).toFloatOrNull()?.let { relativeTo * it / 100f }
+      } else {
+        value.toFloatOrNull()
+      }
+      require(parsed != null && parsed.isFinite()) {
+        "$label must be a finite number or percentage"
+      }
+      return parsed
+    }
+
+    private fun normalizedOffset(value: Float, step: Float): Float {
+      return ((value % step) + step) % step
+    }
+
+    private val SPREAD_VALUE = Regex("^[+-]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)%?$")
+  }
+}

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/WatermarkLayoutTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/WatermarkLayoutTest.kt
@@ -1,0 +1,50 @@
+package com.jimmydaddy.imagemarker.base
+
+import com.facebook.react.bridge.JavaOnlyMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class WatermarkLayoutTest {
+  @Test
+  fun resolvesPercentOffsetsAndStaggeredRows() {
+    val layout = WatermarkLayout(
+      JavaOnlyMap.of(
+        "type", "tile",
+        "gapX", 20,
+        "gapY", 10,
+        "offsetX", "10%",
+        "offsetY", -5,
+        "stagger", true
+      )
+    )
+
+    val placements = layout.placements(100, 60, 20, 10)
+
+    assertEquals(-10f, placements[0].x, 0.001f)
+    assertEquals(-5f, placements[0].y, 0.001f)
+    assertEquals(30f, placements[1].x, 0.001f)
+    val secondRow = placements.filter { it.y == 15f }
+    assertEquals(10f, secondRow[0].x, 0.001f)
+    assertEquals(50f, secondRow[1].x, 0.001f)
+  }
+
+  @Test
+  fun rejectsNegativeGapsAndExcessiveCopies() {
+    val negativeGap = WatermarkLayout(
+      JavaOnlyMap.of("type", "tile", "gapX", -1)
+    )
+    assertThrows(IllegalArgumentException::class.java) {
+      negativeGap.placements(100, 100, 10, 10)
+    }
+
+    val dense = WatermarkLayout(JavaOnlyMap.of("type", "tile"))
+    val error = assertThrows(IllegalArgumentException::class.java) {
+      dense.placements(100, 100, 1, 1)
+    }
+    assertEquals(
+      "tile layout exceeds the maximum of 4096 copies per layer",
+      error.message
+    )
+  }
+}

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerRendererTest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerRendererTest.kt
@@ -446,6 +446,56 @@ class ImageMarkerRendererTest {
   }
 
   @Test
+  fun tiledImageRepeatsAcrossTheCanvas() {
+    val output = ImageMarkerRenderer.renderImageWatermarks(
+      solidBitmap(12, 8, Color.RED),
+      listOf(solidBitmap(2, 2, Color.BLUE)),
+      imageOptions(
+        watermarkPosition = null,
+        layout = JavaOnlyMap.of(
+          "type", "tile",
+          "gapX", 2,
+          "gapY", 2
+        )
+      )
+    )
+
+    var bluePixels = 0
+    for (y in 0 until output.height) {
+      for (x in 0 until output.width) {
+        if (output.getPixel(x, y) == Color.BLUE) bluePixels += 1
+      }
+    }
+    assertEquals(24, bluePixels)
+  }
+
+  @Test
+  fun tiledTextProducesMoreVisiblePixelsThanOneCopy() {
+    val background = solidBitmap(180, 100, Color.WHITE)
+    val single = ImageMarkerRenderer.renderTextWatermarks(
+      background,
+      textOptions(x = 0, y = 0),
+      reactContext()
+    )
+    val tiled = ImageMarkerRenderer.renderTextWatermarks(
+      background,
+      textOptions(
+        x = null,
+        y = null,
+        layout = JavaOnlyMap.of(
+          "type", "tile",
+          "gapX", 30,
+          "gapY", 20,
+          "stagger", true
+        )
+      ),
+      reactContext()
+    )
+
+    assertTrue(countNonWhitePixels(tiled) > countNonWhitePixels(single) * 2)
+  }
+
+  @Test
   fun rotatedTextAtNonZeroCoordinatesKeepsItsLocalCenter() {
     val style = JavaOnlyMap.of(
       "color", "#00000000",
@@ -492,8 +542,25 @@ class ImageMarkerRendererTest {
     saveFormat: String = "png",
     matteColor: String = "#FFFFFF",
     trimTransparentPadding: Boolean = false,
-    watermarkPosition: JavaOnlyMap
+    watermarkPosition: JavaOnlyMap?,
+    layout: JavaOnlyMap? = null
   ): MarkImageOptions {
+    val watermark = JavaOnlyMap.of(
+      "src",
+      imageSource("watermark"),
+      "scale",
+      watermarkScale,
+      "trimTransparentPadding",
+      trimTransparentPadding,
+      "alpha",
+      1
+    )
+    if (watermarkPosition != null) {
+      watermark.putMap("position", watermarkPosition)
+    }
+    if (layout != null) {
+      watermark.putMap("layout", layout)
+    }
     return MarkImageOptions(
       JavaOnlyMap.of(
         "backgroundImage",
@@ -507,21 +574,7 @@ class ImageMarkerRendererTest {
           "alpha",
           1
         ),
-        "watermarkImages",
-        JavaOnlyArray.of(
-          JavaOnlyMap.of(
-            "src",
-            imageSource("watermark"),
-            "scale",
-            watermarkScale,
-            "position",
-            watermarkPosition,
-            "trimTransparentPadding",
-            trimTransparentPadding,
-            "alpha",
-            1
-          )
-        ),
+        "watermarkImages", JavaOnlyArray.of(watermark),
         "saveFormat",
         saveFormat,
         "matteColor",
@@ -533,16 +586,23 @@ class ImageMarkerRendererTest {
   }
 
   private fun textOptions(
-    x: Int,
-    y: Int,
-    style: JavaOnlyMap? = null
+    x: Int?,
+    y: Int?,
+    style: JavaOnlyMap? = null,
+    layout: JavaOnlyMap? = null
   ): MarkTextOptions {
-    val watermark = JavaOnlyMap.of(
-      "text", "Marker",
-      "position", JavaOnlyMap.of("X", x, "Y", y)
-    )
+    val watermark = JavaOnlyMap.of("text", "Marker")
+    if (x != null || y != null) {
+      val position = JavaOnlyMap()
+      if (x != null) position.putInt("X", x)
+      if (y != null) position.putInt("Y", y)
+      watermark.putMap("position", position)
+    }
     if (style != null) {
       watermark.putMap("style", style)
+    }
+    if (layout != null) {
+      watermark.putMap("layout", layout)
     }
     return MarkTextOptions(
       JavaOnlyMap.of(
@@ -607,5 +667,18 @@ class ImageMarkerRendererTest {
 
   private fun isBlue(pixel: Int): Boolean {
     return Color.blue(pixel) > 200 && Color.red(pixel) < 80 && Color.green(pixel) < 80
+  }
+
+  private fun countNonWhitePixels(bitmap: Bitmap): Int {
+    var count = 0
+    for (y in 0 until bitmap.height) {
+      for (x in 0 until bitmap.width) {
+        val pixel = bitmap.getPixel(x, y)
+        if (Color.red(pixel) < 245 || Color.green(pixel) < 245 || Color.blue(pixel) < 245) {
+          count += 1
+        }
+      }
+    }
+    return count
   }
 }

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -246,6 +246,77 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertTrue(image.normalizedForImageMarker() === image)
   }
 
+  func testTileLayoutResolvesOffsetsStaggerAndCopyLimit() throws {
+    let layout = try ImageMarkerWatermarkLayout(dicOpts: [
+      "type": "tile",
+      "gapX": 20,
+      "gapY": 10,
+      "offsetX": "10%",
+      "offsetY": -5,
+      "stagger": true,
+    ])
+
+    let placements = try layout.placements(
+      canvasSize: CGSize(width: 100, height: 60),
+      itemSize: CGSize(width: 20, height: 10)
+    )
+    XCTAssertEqual(placements[0].x, -10, accuracy: 0.001)
+    XCTAssertEqual(placements[0].y, -5, accuracy: 0.001)
+    XCTAssertEqual(placements[1].x, 30, accuracy: 0.001)
+    let secondRow = placements.filter { $0.y == 15 }
+    XCTAssertEqual(secondRow[0].x, 10, accuracy: 0.001)
+    XCTAssertEqual(secondRow[1].x, 50, accuracy: 0.001)
+
+    let dense = try ImageMarkerWatermarkLayout(dicOpts: ["type": "tile"])
+    XCTAssertThrowsError(
+      try dense.placements(
+        canvasSize: CGSize(width: 100, height: 100),
+        itemSize: CGSize(width: 1, height: 1)
+      )
+    ) { error in
+      XCTAssertEqual(
+        error.localizedDescription,
+        "tile layout exceeds the maximum of 4096 copies per layer"
+      )
+    }
+  }
+
+  func testTiledImageRepeatsAcrossCanvas() throws {
+    let background = makeSolidImage(size: CGSize(width: 12, height: 8), color: .red)
+    let marker = makeSolidImage(size: CGSize(width: 2, height: 2), color: .blue)
+    let layout = try ImageMarkerWatermarkLayout(dicOpts: [
+      "type": "tile",
+      "gapX": 2,
+      "gapY": 2,
+    ])
+
+    let rendered = try XCTUnwrap(
+      try ImageMarkerRenderer.renderImageWatermarks(
+        background: background,
+        watermarks: [
+          ImageMarkerImageWatermark(
+            image: marker,
+            position: .none,
+            offsetX: nil,
+            offsetY: nil,
+            scale: 1,
+            rotate: 0,
+            alpha: 1,
+            layout: layout
+          )
+        ],
+        backgroundScale: 1,
+        backgroundRotate: 0,
+        backgroundAlpha: 1
+      )
+    )
+
+    XCTAssertEqual(
+      bluePixelCount(in: rendered, xRange: 0..<12, yRange: 0..<8),
+      24
+    )
+  }
+
   func testPositionDefaultsAndEdgeInsetOverrides() throws {
     let canvasSize = CGSize(width: 100, height: 80)
     let itemSize = CGSize(width: 20, height: 10)
@@ -307,7 +378,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
   func testRotatesFortyFiveDegreesWithExpandedTransparentCanvas() throws {
     let background = makeSolidImage(size: CGSize(width: 40, height: 20), color: .red)
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [],
         backgroundScale: 1,
@@ -328,7 +399,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
   func testRotatesFortyFiveDegreesWithCroppedOriginalCanvas() throws {
     let background = makeSolidImage(size: CGSize(width: 40, height: 20), color: .red)
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [],
         backgroundScale: 1,
@@ -392,7 +463,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertEqual(trimmedWatermark.size.height, 4, accuracy: 0.001)
 
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [
           ImageMarkerImageWatermark(
@@ -592,7 +663,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
         "backgroundImage": background.merging(["scale": scenario.scale]) { _, new in new },
       ])
       let renderedImage = try XCTUnwrap(
-        ImageMarkerRenderer.renderImageWatermarks(
+        try ImageMarkerRenderer.renderImageWatermarks(
           background: backgroundImage,
           watermarks: [
             ImageMarkerImageWatermark(
@@ -651,7 +722,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
       XCTAssertEqual(retinaWatermark.size, CGSize(width: 2, height: 2))
 
       let renderedImage = try XCTUnwrap(
-        ImageMarkerRenderer.renderImageWatermarks(
+        try ImageMarkerRenderer.renderImageWatermarks(
           background: retinaImage,
           watermarks: [
             ImageMarkerImageWatermark(
@@ -852,7 +923,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
 
     for rotation in [CGFloat(45), CGFloat(90)] {
       let renderedImage = try XCTUnwrap(
-        ImageMarkerRenderer.renderImageWatermarks(
+        try ImageMarkerRenderer.renderImageWatermarks(
           background: background,
           watermarks: [
             ImageMarkerImageWatermark(
@@ -882,7 +953,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
     let watermark = makeSolidImage(size: CGSize(width: 10, height: 10), color: .blue)
 
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [
           ImageMarkerImageWatermark(
@@ -915,7 +986,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
     let watermark = makeSolidImage(size: CGSize(width: 5, height: 5), color: .blue)
 
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [
           ImageMarkerImageWatermark(
@@ -943,7 +1014,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
     let watermark = makeCheckerImage(size: CGSize(width: 4, height: 4))
 
     let renderedImage = try XCTUnwrap(
-      ImageMarkerRenderer.renderImageWatermarks(
+      try ImageMarkerRenderer.renderImageWatermarks(
         background: background,
         watermarks: [
           ImageMarkerImageWatermark(
@@ -986,7 +1057,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
       (name: "rotation=90", scale: CGFloat(1), rotation: CGFloat(90), expected: [UIColor.blue, .red, .yellow, .green]),
     ] {
       let renderedImage = try XCTUnwrap(
-        ImageMarkerRenderer.renderImageWatermarks(
+        try ImageMarkerRenderer.renderImageWatermarks(
           background: background,
           watermarks: [
             ImageMarkerImageWatermark(

--- a/expo-example/scripts/smoke-web.mjs
+++ b/expo-example/scripts/smoke-web.mjs
@@ -147,12 +147,13 @@ async function verifyBrowser(browserName, browserType) {
     const harnessResults = await page.evaluate(async (crossOriginUrl) => {
       const harness = window.__IMAGE_MARKER_SMOKE__;
       if (!harness) throw new Error('Web smoke harness was not installed.');
-      const [blobAndFile, largeCropped] = await Promise.all([
+      const [blobAndFile, largeCropped, tiledLayers] = await Promise.all([
         harness.renderBlobAndFile(),
         harness.renderLargeCropped(),
+        harness.renderTiledLayers(),
       ]);
       const corsMessage = await harness.renderCrossOrigin(crossOriginUrl);
-      return { blobAndFile, largeCropped, corsMessage };
+      return { blobAndFile, largeCropped, tiledLayers, corsMessage };
     }, `http://127.0.0.1:${crossOriginAddress.port}/fixture.jpeg`);
 
     assert.match(
@@ -172,6 +173,17 @@ async function verifyBrowser(browserName, browserType) {
       harnessResults.largeCropped.dataUrl,
       /^data:image\/png;base64,/
     );
+    assert.match(
+      harnessResults.tiledLayers.dataUrl,
+      /^data:image\/png;base64,/
+    );
+    assert(harnessResults.tiledLayers.width > 0);
+    assert(harnessResults.tiledLayers.height > 0);
+    await assertVisibleComposition(
+      page,
+      baselineSource,
+      harnessResults.tiledLayers.dataUrl
+    );
     assert.match(harnessResults.corsMessage, /Access-Control-Allow-Origin/i);
     assert.deepEqual(
       pageErrors,
@@ -180,7 +192,7 @@ async function verifyBrowser(browserName, browserType) {
     );
 
     console.log(
-      `Verified ${browserName}: Canvas pixels, JPG/PNG, Blob/File, CORS, rotation crop, alpha, and 4096px max-size rendering.`
+      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, JPG/PNG, Blob/File, CORS, rotation crop, alpha, and 4096px max-size rendering.`
     );
   } finally {
     await browser.close();

--- a/expo-example/smoke-harness.web.ts
+++ b/expo-example/smoke-harness.web.ts
@@ -18,6 +18,7 @@ interface ImageResult {
 interface WebSmokeHarness {
   renderBlobAndFile(): Promise<ImageResult>;
   renderLargeCropped(): Promise<ImageResult>;
+  renderTiledLayers(): Promise<ImageResult>;
   renderCrossOrigin(url: string): Promise<string>;
 }
 
@@ -127,6 +128,48 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
         ],
         maxSize: 1024,
         rotationCanvasMode: RotationCanvasMode.crop,
+        saveFormat: ImageFormat.png,
+      });
+      return getDimensions(dataUrl);
+    },
+
+    async renderTiledLayers() {
+      const dataUrl = await Marker.mark({
+        backgroundImage: { src: assets.backgroundUri },
+        watermarks: [
+          {
+            type: 'text',
+            text: 'IMAGE MARKER',
+            layout: {
+              type: 'tile',
+              gapX: '8%',
+              gapY: '10%',
+              offsetX: '-3%',
+              stagger: true,
+            },
+            style: {
+              color: '#FFFFFF88',
+              fontSize: 28,
+              bold: true,
+              rotate: -24,
+            },
+          },
+          {
+            type: 'image',
+            src: assets.logoUri,
+            layout: {
+              type: 'tile',
+              gapX: '28%',
+              gapY: '24%',
+              offsetY: '7%',
+              stagger: true,
+            },
+            scale: 0.08,
+            rotate: 18,
+            alpha: 0.75,
+            trimTransparentPadding: true,
+          },
+        ],
         saveFormat: ImageFormat.png,
       });
       return getDimensions(dataUrl);

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -150,8 +150,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         _ textOpts: TextOptions,
         in context: CGContext,
         canvasSize: CGSize
-    ) {
-        context.saveGState()
+    ) throws {
         let w = canvasSize.width
         let h = canvasSize.height
         let font = fontWithTraits(
@@ -203,71 +202,92 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             width: size.width + strokeWidth,
             height: size.height + strokeWidth
         )
-        let renderPosition = ImageMarkerRenderPosition(rawValue: textOpts.position.rawValue as String) ?? .none
-        let visualOrigin = ImageMarkerRenderer.markerOrigin(
-            position: renderPosition,
-            offsetX: textOpts.X,
-            offsetY: textOpts.Y,
-            canvasSize: canvasSize,
-            itemSize: visualSize,
-            edgeInset: textOpts.edgeInset
-        )
-        let posX = visualOrigin.x + outlineInset
-        let posY = visualOrigin.y + outlineInset
-
-        if textOpts.style.rotate != 0 {
-            let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style.rotate) * .pi / 180)
-            let textRectWithPos = CGRect(origin: visualOrigin, size: visualSize)
-            context.translateBy(x: textRectWithPos.midX, y: textRectWithPos.midY)
-            context.concatenate(rotation)
-            context.translateBy(x: -(textRectWithPos.midX), y: -(textRectWithPos.midY))
+        let origins: [CGPoint]
+        if let layout = textOpts.layout, layout.isTile {
+            let rotatedSize = ImageMarkerRenderer.rotatedBoundingSize(
+                visualSize,
+                rotation: textOpts.style.rotate
+            )
+            let visibleOrigins = try layout.placements(
+                canvasSize: canvasSize,
+                itemSize: rotatedSize
+            )
+            let insetX = (rotatedSize.width - visualSize.width) / 2
+            let insetY = (rotatedSize.height - visualSize.height) / 2
+            origins = visibleOrigins.map {
+                CGPoint(x: $0.x + insetX, y: $0.y + insetY)
+            }
+        } else {
+            let renderPosition = ImageMarkerRenderPosition(rawValue: textOpts.position.rawValue as String) ?? .none
+            origins = [ImageMarkerRenderer.markerOrigin(
+                position: renderPosition,
+                offsetX: textOpts.X,
+                offsetY: textOpts.Y,
+                canvasSize: canvasSize,
+                itemSize: visualSize,
+                edgeInset: textOpts.edgeInset
+            )]
         }
 
-        if let textBackground = textOpts.style.textBackground {
-            let bgEdgeInsets = textBackground.toEdgeInsets(width: w, height: h)
-            context.setFillColor((textBackground.colorBg ?? UIColor.clear).cgColor)
-            let stretchX = bgEdgeInsets.left + bgEdgeInsets.right
-            let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom
-            var bgRect = CGRect(
-                x: posX - outlineInset - bgEdgeInsets.left,
-                y: posY - outlineInset - bgEdgeInsets.top,
-                width: size.width + strokeWidth + stretchX,
-                height: size.height + strokeWidth + stretchY
-            )
-            if textBackground.typeBg == "stretchX" {
-                bgRect = CGRect(
-                    x: 0,
+        for origin in origins {
+            context.saveGState()
+            let posX = origin.x + outlineInset
+            let posY = origin.y + outlineInset
+
+            if textOpts.style.rotate != 0 {
+                let rotation = CGAffineTransform(rotationAngle: CGFloat(textOpts.style.rotate) * .pi / 180)
+                let textRectWithPos = CGRect(origin: origin, size: visualSize)
+                context.translateBy(x: textRectWithPos.midX, y: textRectWithPos.midY)
+                context.concatenate(rotation)
+                context.translateBy(x: -(textRectWithPos.midX), y: -(textRectWithPos.midY))
+            }
+
+            if let textBackground = textOpts.style.textBackground {
+                let bgEdgeInsets = textBackground.toEdgeInsets(width: w, height: h)
+                context.setFillColor((textBackground.colorBg ?? UIColor.clear).cgColor)
+                let stretchX = bgEdgeInsets.left + bgEdgeInsets.right
+                let stretchY = bgEdgeInsets.top + bgEdgeInsets.bottom
+                var bgRect = CGRect(
+                    x: posX - outlineInset - bgEdgeInsets.left,
                     y: posY - outlineInset - bgEdgeInsets.top,
-                    width: w,
+                    width: size.width + strokeWidth + stretchX,
                     height: size.height + strokeWidth + stretchY
                 )
-            } else if textBackground.typeBg == "stretchY" {
-                bgRect = CGRect(
-                    x: posX - outlineInset - bgEdgeInsets.left,
-                    y: 0,
-                    width: size.width + strokeWidth + stretchX,
-                    height: h
-                )
+                if textBackground.typeBg == "stretchX" {
+                    bgRect = CGRect(
+                        x: 0,
+                        y: posY - outlineInset - bgEdgeInsets.top,
+                        width: w,
+                        height: size.height + strokeWidth + stretchY
+                    )
+                } else if textBackground.typeBg == "stretchY" {
+                    bgRect = CGRect(
+                        x: posX - outlineInset - bgEdgeInsets.left,
+                        y: 0,
+                        width: size.width + strokeWidth + stretchX,
+                        height: h
+                    )
+                }
+
+                bgRect.inset(by: bgEdgeInsets)
+
+                if let cornerRadius = textBackground.cornerRadius {
+                    let path = cornerRadius.radiusPath(rect: bgRect)
+                    context.addPath(path.cgPath)
+                    context.fillPath()
+                } else {
+                    context.fill(bgRect)
+                }
             }
 
-            bgRect.inset(by: bgEdgeInsets)
-
-            if let cornerRadius = textBackground.cornerRadius {
-                let path = cornerRadius.radiusPath(rect: bgRect)
-                context.addPath(path.cgPath)
-                context.fillPath()
-            } else {
-                context.fill(bgRect)
-            }
+            let rect = CGRect(origin: CGPoint(x: posX, y: posY), size: size)
+            attributedText.draw(in: rect)
+            context.restoreGState()
         }
-
-        let rect = CGRect(origin: CGPoint(x: posX, y: posY), size: size)
-        attributedText.draw(in: rect)
-        context.restoreGState()
     }
 
-    func markImgWithText(_ image: UIImage, _ opts: MarkTextOptions) -> UIImage? {
-        return ImageMarkerRenderer.renderCanvas(
+    func markImgWithText(_ image: UIImage, _ opts: MarkTextOptions) throws -> UIImage? {
+        return try ImageMarkerRenderer.renderCanvas(
             background: image,
             backgroundScale: opts.backgroundImage.scale,
             backgroundRotate: opts.backgroundImage.rotate,
@@ -275,12 +295,12 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             rotationCanvasMode: opts.rotationCanvasMode
         ) { context, canvasSize in
             for textOpts in opts.watermarkTexts {
-                drawTextWatermark(textOpts, in: context, canvasSize: canvasSize)
+                try drawTextWatermark(textOpts, in: context, canvasSize: canvasSize)
             }
         }
     }
     
-    func markImage(with image: UIImage, waterImages: [UIImage], options: MarkImageOptions) -> UIImage? {
+    func markImage(with image: UIImage, waterImages: [UIImage], options: MarkImageOptions) throws -> UIImage? {
         let watermarks = waterImages.enumerated().compactMap { index, waterImage -> ImageMarkerImageWatermark? in
             guard options.watermarkImages.indices.contains(index) else {
                 return nil
@@ -297,11 +317,12 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 rotate: watermarkOptions.imageOption.rotate,
                 alpha: watermarkOptions.imageOption.alpha,
                 edgeInset: watermarkOptions.edgeInset,
-                trimTransparentPadding: watermarkOptions.trimTransparentPadding
+                trimTransparentPadding: watermarkOptions.trimTransparentPadding,
+                layout: watermarkOptions.layout
             )
         }
 
-        return ImageMarkerRenderer.renderImageWatermarks(
+        return try ImageMarkerRenderer.renderImageWatermarks(
             background: image,
             watermarks: watermarks,
             backgroundScale: options.backgroundImage.scale,
@@ -311,8 +332,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         )
     }
 
-    func markWatermarks(with image: UIImage, waterImages: [UIImage], options: MarkWatermarkOptions) -> UIImage? {
-        return ImageMarkerRenderer.renderCanvas(
+    func markWatermarks(with image: UIImage, waterImages: [UIImage], options: MarkWatermarkOptions) throws -> UIImage? {
+        return try ImageMarkerRenderer.renderCanvas(
             background: image,
             backgroundScale: options.backgroundImage.scale,
             backgroundRotate: options.backgroundImage.rotate,
@@ -323,7 +344,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             for layer in options.watermarkLayers {
                 switch layer {
                 case let .text(textOptions):
-                    drawTextWatermark(textOptions, in: context, canvasSize: canvasSize)
+                    try drawTextWatermark(textOptions, in: context, canvasSize: canvasSize)
                 case let .image(imageOptions):
                     guard waterImages.indices.contains(imageIndex) else {
                         continue
@@ -338,9 +359,10 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                         rotate: imageOptions.imageOption.rotate,
                         alpha: imageOptions.imageOption.alpha,
                         edgeInset: imageOptions.edgeInset,
-                        trimTransparentPadding: imageOptions.trimTransparentPadding
+                        trimTransparentPadding: imageOptions.trimTransparentPadding,
+                        layout: imageOptions.layout
                     )
-                    ImageMarkerRenderer.drawImageWatermark(context: context, canvasSize: canvasSize, watermark: watermark)
+                    try ImageMarkerRenderer.drawImageWatermark(context: context, canvasSize: canvasSize, watermark: watermark)
                     imageIndex += 1
                 }
             }
@@ -356,8 +378,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             do {
                 let result = try await self.operationLimiter.withPermit {
                     var images = try await self.loadImages(with: [markOpts.backgroundImage])
-                    let renderedImage = Utils.renderAndReleaseSources(&images) { sources in
-                        self.markImgWithText(sources[0], markOpts)
+                    let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
+                        try self.markImgWithText(sources[0], markOpts)
                     }
                     guard let renderedImage else {
                         throw self.markerError("Failed to render watermarked image")
@@ -382,8 +404,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 let result = try await self.operationLimiter.withPermit {
                     let waterImages = markOpts.watermarkImages.map { $0.imageOption }
                     var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages)
-                    let renderedImage = Utils.renderAndReleaseSources(&images) { sources in
-                        self.markImage(
+                    let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
+                        try self.markImage(
                             with: sources[0],
                             waterImages: Array(sources.dropFirst()),
                             options: markOpts
@@ -412,8 +434,8 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
                 let result = try await self.operationLimiter.withPermit {
                     let waterImages = markOpts.imageLayers.map { $0.imageOption }
                     var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages)
-                    let renderedImage = Utils.renderAndReleaseSources(&images) { sources in
-                        self.markWatermarks(
+                    let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
+                        try self.markWatermarks(
                             with: sources[0],
                             waterImages: Array(sources.dropFirst()),
                             options: markOpts

--- a/ios/RCTImageMarker/MarkImageOptions.swift
+++ b/ios/RCTImageMarker/MarkImageOptions.swift
@@ -39,13 +39,23 @@ class MarkImageOptions: Options {
                 singlePosition = positionOpts["position"] != nil ? RCTConvert.MarkerPosition(positionOpts["position"]) : .none
             }
             let trimTransparentPadding = watermarkImageOpts["trimTransparentPadding"] as? Bool ?? false
+            let layout = try (watermarkImageOpts["layout"] as? [AnyHashable: Any])
+                .map(ImageMarkerWatermarkLayout.init(dicOpts:))
+            if layout?.isTile == true, singleImagePositionOpts != nil {
+                throw NSError(
+                    domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                    code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "layout cannot be combined with position"]
+                )
+            }
             let watermarkImageOptions = WatermarkImageOptions(
                 watermarkImage: singleImageOptions,
                 X: singleX,
                 Y: singleY,
                 edgeInset: singleEdgeInset,
                 position: singlePosition,
-                trimTransparentPadding: trimTransparentPadding
+                trimTransparentPadding: trimTransparentPadding,
+                layout: layout
             )
             self.watermarkImages.append(watermarkImageOptions)
         }

--- a/ios/RCTImageMarker/TextOptions.swift
+++ b/ios/RCTImageMarker/TextOptions.swift
@@ -16,17 +16,30 @@ class TextOptions: NSObject {
     var position: MarkerPositionEnum = .none
     var text: String
     var style: TextStyle
+    var layout: ImageMarkerWatermarkLayout?
 
     init(dicOpts opts: [AnyHashable: Any]) throws {
         guard let text = opts["text"] as? String else {
             throw NSError(domain: ErrorDomainEnum.PARAMS_REQUIRED.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "text is required"])
         }
 
-        if let positionOpts = opts["position"] as? [AnyHashable: Any] {
+        let positionOpts = opts["position"] as? [AnyHashable: Any]
+        if let positionOpts {
             self.X = Utils.isNULL(positionOpts["X"]) ? nil : Utils.handleDynamicToString(v: positionOpts["X"])
             self.Y = Utils.isNULL(positionOpts["Y"]) ? nil : Utils.handleDynamicToString(v: positionOpts["Y"])
             self.edgeInset = Utils.isNULL(positionOpts["edgeInset"]) ? nil : Utils.handleDynamicToString(v: positionOpts["edgeInset"])
             self.position = positionOpts["position"] != nil ? RCTConvert.MarkerPosition(positionOpts["position"]) : .none
+        }
+
+        if let layoutOpts = opts["layout"] as? [AnyHashable: Any] {
+            self.layout = try ImageMarkerWatermarkLayout(dicOpts: layoutOpts)
+        }
+        if layout?.isTile == true, positionOpts != nil {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "layout cannot be combined with position"]
+            )
         }
 
         self.text = text

--- a/ios/RCTImageMarker/UIImageEdit.swift
+++ b/ios/RCTImageMarker/UIImageEdit.swift
@@ -5,6 +5,7 @@
 //  Created by Jimmydaddy on 2023/7/13.
 //
 
+import CoreFoundation
 import UIKit
 
 enum ImageMarkerRotationCanvasMode: String {
@@ -23,6 +24,143 @@ enum ImageMarkerRenderPosition: String {
     case none
 }
 
+struct ImageMarkerWatermarkLayout {
+    static let maximumCopies = 4096
+
+    let type: String
+    private let gapX: String?
+    private let gapY: String?
+    private let offsetX: String?
+    private let offsetY: String?
+    private let stagger: Bool
+
+    var isTile: Bool { type == "tile" }
+
+    init(dicOpts opts: [AnyHashable: Any]) throws {
+        if let value = opts["type"], !(value is NSNull) {
+            guard let type = value as? String else {
+                throw Self.invalid("layout.type must be single or tile")
+            }
+            self.type = type
+        } else {
+            self.type = "single"
+        }
+        guard type == "single" || type == "tile" else {
+            throw Self.invalid("layout.type must be single or tile")
+        }
+        self.gapX = try Self.spreadValue(opts["gapX"], label: "layout.gapX")
+        self.gapY = try Self.spreadValue(opts["gapY"], label: "layout.gapY")
+        self.offsetX = try Self.spreadValue(opts["offsetX"], label: "layout.offsetX")
+        self.offsetY = try Self.spreadValue(opts["offsetY"], label: "layout.offsetY")
+        if let value = opts["stagger"], !(value is NSNull) {
+            guard let stagger = value as? Bool else {
+                throw Self.invalid("layout.stagger must be a boolean")
+            }
+            self.stagger = stagger
+        } else {
+            self.stagger = false
+        }
+    }
+
+    func placements(canvasSize: CGSize, itemSize: CGSize) throws -> [CGPoint] {
+        guard isTile else {
+            throw Self.invalid("placements are only available for tile layouts")
+        }
+        guard canvasSize.width.isFinite, canvasSize.height.isFinite,
+              itemSize.width.isFinite, itemSize.height.isFinite,
+              canvasSize.width > 0, canvasSize.height > 0,
+              itemSize.width > 0, itemSize.height > 0 else {
+            throw Self.invalid("canvas and watermark dimensions must be finite and greater than zero")
+        }
+
+        let resolvedGapX = try Self.resolve(gapX, relativeTo: canvasSize.width, label: "layout.gapX")
+        let resolvedGapY = try Self.resolve(gapY, relativeTo: canvasSize.height, label: "layout.gapY")
+        guard resolvedGapX >= 0, resolvedGapY >= 0 else {
+            throw Self.invalid("layout gaps must be non-negative")
+        }
+        let stepX = itemSize.width + resolvedGapX
+        let stepY = itemSize.height + resolvedGapY
+        guard stepX.isFinite, stepY.isFinite, stepX > 0, stepY > 0 else {
+            throw Self.invalid("tile layout step must be finite and greater than zero")
+        }
+
+        let phaseX = Self.normalizedOffset(
+            try Self.resolve(offsetX, relativeTo: canvasSize.width, label: "layout.offsetX"),
+            step: stepX
+        )
+        let phaseY = Self.normalizedOffset(
+            try Self.resolve(offsetY, relativeTo: canvasSize.height, label: "layout.offsetY"),
+            step: stepY
+        )
+        var result: [CGPoint] = []
+        var row = -1
+        var y = phaseY - stepY
+        while y < canvasSize.height {
+            if y + itemSize.height > 0 {
+                let staggerOffset = stagger && row % 2 != 0 ? stepX / 2 : 0
+                let rowPhaseX = Self.normalizedOffset(phaseX + staggerOffset, step: stepX)
+                var x = rowPhaseX - stepX
+                while x < canvasSize.width {
+                    if x + itemSize.width > 0 {
+                        result.append(CGPoint(x: x, y: y))
+                        if result.count > Self.maximumCopies {
+                            throw Self.invalid(
+                                "tile layout exceeds the maximum of \(Self.maximumCopies) copies per layer"
+                            )
+                        }
+                    }
+                    x += stepX
+                }
+            }
+            row += 1
+            y += stepY
+        }
+        return result
+    }
+
+    private static func spreadValue(_ value: Any?, label: String) throws -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        let normalized: String
+        if let string = value as? String {
+            normalized = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else if let number = value as? NSNumber,
+                  CFGetTypeID(number) != CFBooleanGetTypeID() {
+            normalized = number.stringValue
+        } else {
+            throw invalid("\(label) must be a finite number or percentage")
+        }
+        guard normalized.range(
+            of: #"^[+-]?(?:\d+(?:\.\d+)?|\.\d+)%?$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw invalid("\(label) must be a finite number or percentage")
+        }
+        return normalized
+    }
+
+    private static func resolve(_ value: String?, relativeTo length: CGFloat, label: String) throws -> CGFloat {
+        guard let value else { return 0 }
+        let number = value.hasSuffix("%") ? String(value.dropLast()) : value
+        guard let parsed = Double(number), parsed.isFinite else {
+            throw invalid("\(label) must be a finite number or percentage")
+        }
+        return value.hasSuffix("%") ? length * CGFloat(parsed) / 100 : CGFloat(parsed)
+    }
+
+    private static func normalizedOffset(_ value: CGFloat, step: CGFloat) -> CGFloat {
+        return ((value.truncatingRemainder(dividingBy: step)) + step)
+            .truncatingRemainder(dividingBy: step)
+    }
+
+    private static func invalid(_ message: String) -> NSError {
+        return NSError(
+            domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}
+
 struct ImageMarkerImageWatermark {
     let image: UIImage
     let position: ImageMarkerRenderPosition
@@ -33,6 +171,7 @@ struct ImageMarkerImageWatermark {
     let alpha: CGFloat
     let edgeInset: String?
     let trimTransparentPadding: Bool
+    let layout: ImageMarkerWatermarkLayout?
 
     init(
         image: UIImage,
@@ -43,7 +182,8 @@ struct ImageMarkerImageWatermark {
         rotate: CGFloat,
         alpha: CGFloat,
         edgeInset: String? = nil,
-        trimTransparentPadding: Bool = false
+        trimTransparentPadding: Bool = false,
+        layout: ImageMarkerWatermarkLayout? = nil
     ) {
         self.image = image
         self.position = position
@@ -54,6 +194,7 @@ struct ImageMarkerImageWatermark {
         self.alpha = alpha
         self.edgeInset = edgeInset
         self.trimTransparentPadding = trimTransparentPadding
+        self.layout = layout
     }
 }
 
@@ -200,8 +341,8 @@ enum ImageMarkerRenderer {
         backgroundRotate: CGFloat,
         backgroundAlpha: CGFloat,
         rotationCanvasMode: ImageMarkerRotationCanvasMode,
-        drawLayers: (CGContext, CGSize) -> Void
-    ) -> UIImage? {
+        drawLayers: (CGContext, CGSize) throws -> Void
+    ) rethrows -> UIImage? {
         // Background scale changes the actual composition canvas, matching Android's
         // logical bitmap size. UIImage.scale describes pixel density, so both @1x and Retina
         // sources must use image.size here. Layer coordinates, font sizes and watermark sizes
@@ -223,6 +364,9 @@ enum ImageMarkerRenderer {
         }
 
         context.saveGState()
+        defer {
+            context.restoreGState()
+        }
         let radians = normalizedRotation(backgroundRotate)
         if radians != 0 {
             context.translateBy(x: renderedSize.width / 2, y: renderedSize.height / 2)
@@ -236,8 +380,7 @@ enum ImageMarkerRenderer {
             rect: CGRect(origin: .zero, size: canvasSize),
             alpha: backgroundAlpha
         )
-        drawLayers(context, canvasSize)
-        context.restoreGState()
+        try drawLayers(context, canvasSize)
 
         return UIGraphicsGetImageFromCurrentImageContext()
     }
@@ -249,8 +392,8 @@ enum ImageMarkerRenderer {
         backgroundRotate: CGFloat,
         backgroundAlpha: CGFloat,
         rotationCanvasMode: ImageMarkerRotationCanvasMode = .expand
-    ) -> UIImage? {
-        return renderCanvas(
+    ) throws -> UIImage? {
+        return try renderCanvas(
             background: image,
             backgroundScale: backgroundScale,
             backgroundRotate: backgroundRotate,
@@ -258,7 +401,7 @@ enum ImageMarkerRenderer {
             rotationCanvasMode: rotationCanvasMode
         ) { context, canvasSize in
             for watermark in watermarks {
-                drawImageWatermark(context: context, canvasSize: canvasSize, watermark: watermark)
+                try drawImageWatermark(context: context, canvasSize: canvasSize, watermark: watermark)
             }
         }
     }
@@ -291,7 +434,7 @@ enum ImageMarkerRenderer {
         context: CGContext,
         canvasSize: CGSize,
         watermark: ImageMarkerImageWatermark
-    ) {
+    ) throws {
         let sourceImage = watermark.trimTransparentPadding
             ? watermark.image.trimmingTransparentPadding()
             : watermark.image
@@ -299,59 +442,67 @@ enum ImageMarkerRenderer {
             return
         }
 
-        context.saveGState()
-        context.interpolationQuality = .none
         let scale = watermark.scale > 0 ? watermark.scale : 1
         let markerSize = CGSize(
             width: sourceImage.size.width * scale,
             height: sourceImage.size.height * scale
         )
         let rotatedSize = rotatedBoundingSize(markerSize, rotation: watermark.rotate)
-        let rotatedOrigin = markerOrigin(
-            position: watermark.position,
-            offsetX: watermark.offsetX,
-            offsetY: watermark.offsetY,
-            canvasSize: canvasSize,
-            itemSize: rotatedSize,
-            edgeInset: watermark.edgeInset
-        )
-        let markerCenter = CGPoint(
-            x: rotatedOrigin.x + rotatedSize.width / 2,
-            y: rotatedOrigin.y + rotatedSize.height / 2
-        )
-        let drawMarker = {
-            context.saveGState()
-            context.translateBy(x: markerCenter.x, y: markerCenter.y)
-            if watermark.rotate != 0 {
-                context.rotate(by: watermark.rotate * .pi / 180)
-            }
-            // UIGraphics contexts use a top-left origin while CGContext.draw(_:in:)
-            // interprets CGImage pixels in Quartz coordinates. Flip only the image's
-            // local coordinate system so its orientation is preserved after scaling
-            // and rotation without allocating an intermediate UIImage.
-            context.scaleBy(x: 1, y: -1)
-            context.draw(
-                watermarkImage,
-                in: CGRect(
-                    x: -markerSize.width / 2,
-                    y: -markerSize.height / 2,
-                    width: markerSize.width,
-                    height: markerSize.height
-                )
-            )
-            context.restoreGState()
+        let positions: [CGPoint]
+        if let layout = watermark.layout, layout.isTile {
+            positions = try layout.placements(canvasSize: canvasSize, itemSize: rotatedSize)
+        } else {
+            positions = [markerOrigin(
+                position: watermark.position,
+                offsetX: watermark.offsetX,
+                offsetY: watermark.offsetY,
+                canvasSize: canvasSize,
+                itemSize: rotatedSize,
+                edgeInset: watermark.edgeInset
+            )]
         }
 
-        if watermark.alpha != 1.0 {
-            context.beginTransparencyLayer(auxiliaryInfo: nil)
-            context.setAlpha(watermark.alpha)
-            context.setBlendMode(.multiply)
-            drawMarker()
-            context.endTransparencyLayer()
-        } else {
-            drawMarker()
+        for rotatedOrigin in positions {
+            context.saveGState()
+            context.interpolationQuality = .none
+            let markerCenter = CGPoint(
+                x: rotatedOrigin.x + rotatedSize.width / 2,
+                y: rotatedOrigin.y + rotatedSize.height / 2
+            )
+            let drawMarker = {
+                context.saveGState()
+                context.translateBy(x: markerCenter.x, y: markerCenter.y)
+                if watermark.rotate != 0 {
+                    context.rotate(by: watermark.rotate * .pi / 180)
+                }
+                // UIGraphics contexts use a top-left origin while CGContext.draw(_:in:)
+                // interprets CGImage pixels in Quartz coordinates. Flip only the image's
+                // local coordinate system so its orientation is preserved after scaling
+                // and rotation without allocating an intermediate UIImage.
+                context.scaleBy(x: 1, y: -1)
+                context.draw(
+                    watermarkImage,
+                    in: CGRect(
+                        x: -markerSize.width / 2,
+                        y: -markerSize.height / 2,
+                        width: markerSize.width,
+                        height: markerSize.height
+                    )
+                )
+                context.restoreGState()
+            }
+
+            if watermark.alpha != 1.0 {
+                context.beginTransparencyLayer(auxiliaryInfo: nil)
+                context.setAlpha(watermark.alpha)
+                context.setBlendMode(.multiply)
+                drawMarker()
+                context.endTransparencyLayer()
+            } else {
+                drawMarker()
+            }
+            context.restoreGState()
         }
-        context.restoreGState()
     }
 
     static func encodedData(

--- a/ios/RCTImageMarker/WatermarkImageOptions.swift
+++ b/ios/RCTImageMarker/WatermarkImageOptions.swift
@@ -16,6 +16,7 @@ class WatermarkImageOptions: NSObject {
     var edgeInset: String?
     var position: MarkerPositionEnum = .none
     var trimTransparentPadding: Bool = false
+    var layout: ImageMarkerWatermarkLayout?
 
     init(dicOpts opts: [AnyHashable: Any]) throws {
         self.imageOption = try ImageOptions(dicOpts: opts)
@@ -27,15 +28,26 @@ class WatermarkImageOptions: NSObject {
             self.edgeInset = Utils.isNULL(positionOpts["edgeInset"]) ? nil : Utils.handleDynamicToString(v: positionOpts["edgeInset"])
             self.position = positionOpts["position"] != nil ? RCTConvert.MarkerPosition(positionOpts["position"]) : .none
         }
+        if let layoutOpts = opts["layout"] as? [AnyHashable: Any] {
+            self.layout = try ImageMarkerWatermarkLayout(dicOpts: layoutOpts)
+        }
+        if layout?.isTile == true, positionOpts != nil {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "layout cannot be combined with position"]
+            )
+        }
     }
 
-    init(watermarkImage: ImageOptions, X: String?, Y: String?, edgeInset: String?, position: MarkerPositionEnum, trimTransparentPadding: Bool = false) {
+    init(watermarkImage: ImageOptions, X: String?, Y: String?, edgeInset: String?, position: MarkerPositionEnum, trimTransparentPadding: Bool = false, layout: ImageMarkerWatermarkLayout? = nil) {
         self.imageOption = watermarkImage
         self.X = X
         self.Y = Y
         self.edgeInset = edgeInset
         self.position = position
         self.trimTransparentPadding = trimTransparentPadding
+        self.layout = layout
     }
 
     static func checkWatermarkImageParams(_ opts: [AnyHashable: Any], rejecter reject: @escaping RCTPromiseRejectBlock) -> WatermarkImageOptions? {

--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -2,6 +2,7 @@ import Marker, {
   type ImageMarkOptions,
   type TextMarkOptions,
   type TextStrokeStyle,
+  type WatermarkLayout,
 } from '../index';
 
 // The deprecated single-watermark shape remains source-compatible for users
@@ -43,4 +44,17 @@ export const outlinedText: TextMarkOptions = {
       style: { color: '#FFFFFF', strokeStyle: textStroke },
     },
   ],
+};
+
+export const tiledLayout: WatermarkLayout = {
+  type: 'tile',
+  gapX: '8%',
+  gapY: 24,
+  offsetX: '-2.5%',
+  stagger: true,
+};
+
+export const tiledText: TextMarkOptions = {
+  backgroundImage: { src: 'file:///tmp/background.png' },
+  watermarkTexts: [{ text: 'CONFIDENTIAL', layout: tiledLayout }],
 };

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -421,6 +421,125 @@ describe('Marker JS wrapper', () => {
     ).resolves.toBe('/tmp/boundary-watermarks.png');
   });
 
+  it('preserves tiled layouts without mutating caller input', async () => {
+    nativeModule.markWithWatermarks.mockResolvedValue('/tmp/tiled.png');
+    const options = {
+      backgroundImage: { src: 'file:///tmp/background.png' },
+      watermarks: [
+        {
+          type: 'text' as const,
+          text: 'CONFIDENTIAL',
+          layout: {
+            type: 'tile' as const,
+            gapX: '8%',
+            gapY: 24,
+            stagger: true,
+          },
+        },
+      ],
+    };
+    deepFreeze(options);
+
+    await expect(Marker.mark(options)).resolves.toBe('/tmp/tiled.png');
+
+    const nativeLayout =
+      nativeModule.markWithWatermarks.mock.calls[0][0].watermarks[0].layout;
+    expect(nativeLayout).toEqual(options.watermarks[0].layout);
+    expect(nativeLayout).not.toBe(options.watermarks[0].layout);
+    expect(
+      nativeModule.markWithWatermarks.mock.calls[0][0].watermarks[0]
+    ).not.toHaveProperty('position');
+
+    nativeModule.markWithText.mockResolvedValue('/tmp/tiled-text.png');
+    await Marker.markText({
+      backgroundImage: { src: 'file:///tmp/background.png' },
+      watermarkTexts: [
+        { text: 'Tiled text', layout: { type: 'tile', gapX: 12 } },
+      ],
+    });
+    expect(
+      nativeModule.markWithText.mock.calls[0][0].watermarkTexts[0]
+    ).not.toHaveProperty('position');
+  });
+
+  it('rejects tiled layouts combined with position or invalid spacing', () => {
+    expect(() =>
+      Marker.markText({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarkTexts: [
+          {
+            text: 'Conflict',
+            position: { position: Position.center },
+            layout: { type: 'tile' },
+          },
+        ],
+      })
+    ).toThrow('watermarkTexts[0].layout cannot be combined with position.');
+
+    expect(() =>
+      Marker.markImage({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarkImages: [
+          {
+            src: 'file:///tmp/logo.png',
+            layout: { type: 'tile', gapX: '-1%' },
+          },
+        ],
+      })
+    ).toThrow('watermarkImages[0].layout.gapX must be non-negative.');
+
+    expect(() =>
+      Marker.markImage({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarkImage: {
+          src: 'file:///tmp/logo.png',
+          layout: { type: 'tile' },
+        },
+        watermarkPositions: { position: Position.center },
+      })
+    ).toThrow('watermarkImage.layout cannot be combined with position.');
+
+    expect(() =>
+      Marker.mark({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarks: [
+          {
+            type: 'image',
+            src: 'file:///tmp/logo.png',
+            layout: { type: 'tile', offsetY: 'not-a-number' },
+          },
+        ],
+      })
+    ).toThrow(
+      'watermarks[0].layout.offsetY must be a finite number or percentage.'
+    );
+
+    expect(() =>
+      Marker.markText({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarkTexts: [
+          {
+            text: 'Single',
+            layout: { type: 'single', gapX: 'not-a-number' } as any,
+          },
+        ],
+      })
+    ).toThrow(
+      'watermarkTexts[0].layout.gapX must be a finite number or percentage.'
+    );
+
+    expect(() =>
+      Marker.markText({
+        backgroundImage: { src: 'file:///tmp/background.png' },
+        watermarkTexts: [{ text: 'Array', layout: [] as any }],
+      })
+    ).toThrow('watermarkTexts[0].layout must be an object.');
+
+    expect(nativeModule.markWithText).not.toHaveBeenCalled();
+    expect(nativeModule.markWithImage).not.toHaveBeenCalled();
+    expect(nativeModule.markWithWatermarks).not.toHaveBeenCalled();
+  });
+
   it('rejects invalid alpha values at every nested image location', () => {
     const invalidCases = [
       {

--- a/src/__tests__/layout.test.ts
+++ b/src/__tests__/layout.test.ts
@@ -1,0 +1,76 @@
+import {
+  MAX_TILE_COPIES,
+  resolveLayoutValue,
+  resolveTilePlacements,
+} from '../layout';
+
+describe('tile layout', () => {
+  it('resolves pixel and percentage values', () => {
+    expect(resolveLayoutValue(12, 200, 'value')).toBe(12);
+    expect(resolveLayoutValue('12.5%', 200, 'value')).toBe(25);
+    expect(resolveLayoutValue(' -4 ', 200, 'value')).toBe(-4);
+  });
+
+  it('covers the canvas with stable row-major placements', () => {
+    const placements = resolveTilePlacements(
+      { type: 'tile', gapX: 10, gapY: 10 },
+      { width: 100, height: 80 },
+      { width: 20, height: 10 }
+    );
+
+    expect(placements).toHaveLength(16);
+    expect(placements.slice(0, 4)).toEqual([
+      { x: 0, y: 0 },
+      { x: 30, y: 0 },
+      { x: 60, y: 0 },
+      { x: 90, y: 0 },
+    ]);
+    expect(placements.at(-1)).toEqual({ x: 90, y: 60 });
+  });
+
+  it('normalizes offsets and staggers every other row', () => {
+    const placements = resolveTilePlacements(
+      {
+        type: 'tile',
+        gapX: 20,
+        gapY: 10,
+        offsetX: '10%',
+        offsetY: -5,
+        stagger: true,
+      },
+      { width: 100, height: 60 },
+      { width: 20, height: 10 }
+    );
+
+    expect(placements.slice(0, 3)).toEqual([
+      { x: -10, y: -5 },
+      { x: 30, y: -5 },
+      { x: 70, y: -5 },
+    ]);
+    expect(placements.filter((point) => point.y === 15).slice(0, 3)).toEqual([
+      { x: 10, y: 15 },
+      { x: 50, y: 15 },
+      { x: 90, y: 15 },
+    ]);
+  });
+
+  it('rejects invalid gaps and excessive copy counts', () => {
+    expect(() =>
+      resolveTilePlacements(
+        { type: 'tile', gapX: -1 },
+        { width: 100, height: 100 },
+        { width: 10, height: 10 }
+      )
+    ).toThrow('layout gaps must be non-negative.');
+
+    expect(() =>
+      resolveTilePlacements(
+        { type: 'tile' },
+        { width: 100, height: 100 },
+        { width: 1, height: 1 }
+      )
+    ).toThrow(
+      `tile layout exceeds the maximum of ${MAX_TILE_COPIES} copies per layer.`
+    );
+  });
+});

--- a/src/__tests__/web-marker-render.test.ts
+++ b/src/__tests__/web-marker-render.test.ts
@@ -282,6 +282,90 @@ describe('WebMarker browser render integration', () => {
     expect(context.moveTo).toHaveBeenCalledWith(0, 0);
   });
 
+  it('tiles outlined text using percentage gaps and staggered rows', async () => {
+    const canvases = installFakeBrowserRuntime();
+
+    await WebMarker.markText({
+      backgroundImage: { src: '/background.jpg' },
+      watermarkTexts: [
+        {
+          text: 'Tile',
+          layout: {
+            type: 'tile',
+            gapX: 40,
+            gapY: 24,
+            stagger: true,
+          },
+          style: {
+            rotate: -20,
+            strokeStyle: { color: '#111827', width: 2 },
+          },
+        },
+      ],
+      saveFormat: ImageFormat.png,
+    });
+
+    const { context } = canvases[0]!;
+    expect(context.fillText.mock.calls.length).toBeGreaterThan(10);
+    expect(context.strokeText).toHaveBeenCalledTimes(
+      context.fillText.mock.calls.length
+    );
+    expect(context.rotate).toHaveBeenCalledWith(expect.any(Number));
+    const xValues = context.fillText.mock.calls.map(([, x]) => x);
+    expect(new Set(xValues).size).toBeGreaterThan(4);
+  });
+
+  it('decodes a tiled image layer once and repeats it before the next layer', async () => {
+    const canvases = installFakeBrowserRuntime();
+
+    await WebMarker.mark({
+      backgroundImage: { src: '/background.jpg' },
+      watermarks: [
+        {
+          type: 'image',
+          src: '/logo.png',
+          scale: 0.1,
+          layout: { type: 'tile', gapX: 32, gapY: 20 },
+        },
+        {
+          type: 'text',
+          text: 'Top layer',
+          layout: { type: 'tile', gapX: 80, gapY: 40 },
+        },
+      ],
+      saveFormat: ImageFormat.png,
+    });
+
+    expect(FakeImage.instances).toHaveLength(2);
+    const { context } = canvases[0]!;
+    expect(context.drawImage).toHaveBeenCalledTimes(26);
+    expect(context.drawImage.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      context.fillText.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('fails before drawing a tile layer that exceeds the copy limit', async () => {
+    const canvases = installFakeBrowserRuntime();
+
+    await expect(
+      WebMarker.markText({
+        backgroundImage: { src: '/background.jpg', scale: 10 },
+        watermarkTexts: [
+          {
+            text: 'x',
+            layout: { type: 'tile' },
+            style: { fontSize: 1 },
+          },
+        ],
+        saveFormat: ImageFormat.png,
+      })
+    ).rejects.toThrow(
+      'tile layout exceeds the maximum of 4096 copies per layer.'
+    );
+
+    expect(canvases[0]?.context.fillText).not.toHaveBeenCalled();
+  });
+
   it('bounds large inputs before applying background and watermark scales', async () => {
     const canvases = installFakeBrowserRuntime();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -523,6 +523,13 @@ export interface TextOptions {
   position?: PositionOptions;
 
   /**
+   * Render this watermark once or repeat it across the image. Tiled layouts
+   * cannot be combined with `position` or the deprecated `positionOptions`.
+   * @defaultValue `{ type: 'single' }`
+   */
+  layout?: WatermarkLayout;
+
+  /**
    * text style
    * @example
    * style: {
@@ -759,12 +766,35 @@ export interface ImageOptions {
 export interface WatermarkImageOptions extends ImageOptions {
   position?: PositionOptions;
   /**
+   * Render this watermark once or repeat it across the image. Tiled layouts
+   * cannot be combined with `position`.
+   * @defaultValue `{ type: 'single' }`
+   */
+  layout?: WatermarkLayout;
+  /**
    * Remove fully transparent outer rows and columns before scaling, rotating,
    * and positioning the watermark.
    * @defaultValue false
    */
   trimTransparentPadding?: boolean;
 }
+
+/** Controls whether a watermark layer is drawn once or tiled over the image. */
+export type WatermarkLayout =
+  | { type?: 'single' }
+  | {
+      type: 'tile';
+      /** Horizontal space between rotated watermark bounds. */
+      gapX?: number | string;
+      /** Vertical space between rotated watermark bounds. */
+      gapY?: number | string;
+      /** Horizontal grid offset in pixels or as a percentage of canvas width. */
+      offsetX?: number | string;
+      /** Vertical grid offset in pixels or as a percentage of canvas height. */
+      offsetY?: number | string;
+      /** Shift every other row by half of its horizontal step. */
+      stagger?: boolean;
+    };
 
 /**
  * Options for rendering image-only watermark layers.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,120 @@
+import type { WatermarkLayout } from './index';
+
+export const MAX_TILE_COPIES = 4096;
+
+export interface LayoutSize {
+  width: number;
+  height: number;
+}
+
+export interface LayoutPoint {
+  x: number;
+  y: number;
+}
+
+export type TileWatermarkLayout = Extract<WatermarkLayout, { type: 'tile' }>;
+
+function assertSize(size: LayoutSize, label: string): void {
+  if (
+    !Number.isFinite(size.width) ||
+    !Number.isFinite(size.height) ||
+    size.width <= 0 ||
+    size.height <= 0
+  ) {
+    throw new Error(
+      `${label} dimensions must be finite numbers greater than 0.`
+    );
+  }
+}
+
+export function resolveLayoutValue(
+  value: number | string | undefined,
+  relativeTo: number,
+  label: string
+): number {
+  if (value === undefined) {
+    return 0;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`${label} must be a finite number or percentage.`);
+    }
+    return value;
+  }
+
+  const normalized = value.trim();
+  const match = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(%)?$/.exec(normalized);
+  if (!match) {
+    throw new Error(`${label} must be a finite number or percentage.`);
+  }
+  const parsed = Number(match[1]);
+  return match[2] ? (relativeTo * parsed) / 100 : parsed;
+}
+
+function normalizedOffset(value: number, step: number): number {
+  return ((value % step) + step) % step;
+}
+
+/**
+ * Resolve the top-left visible bounds for every tile. Rows and columns begin
+ * one step outside the canvas so partial edge tiles preserve the grid phase.
+ */
+export function resolveTilePlacements(
+  layout: TileWatermarkLayout,
+  canvas: LayoutSize,
+  item: LayoutSize
+): LayoutPoint[] {
+  assertSize(canvas, 'canvas');
+  assertSize(item, 'watermark');
+
+  const gapX = resolveLayoutValue(layout.gapX, canvas.width, 'layout.gapX');
+  const gapY = resolveLayoutValue(layout.gapY, canvas.height, 'layout.gapY');
+  if (gapX < 0 || gapY < 0) {
+    throw new Error('layout gaps must be non-negative.');
+  }
+
+  const offsetX = resolveLayoutValue(
+    layout.offsetX,
+    canvas.width,
+    'layout.offsetX'
+  );
+  const offsetY = resolveLayoutValue(
+    layout.offsetY,
+    canvas.height,
+    'layout.offsetY'
+  );
+  const stepX = item.width + gapX;
+  const stepY = item.height + gapY;
+  if (!Number.isFinite(stepX) || !Number.isFinite(stepY)) {
+    throw new Error('tile layout step must be finite.');
+  }
+
+  const phaseX = normalizedOffset(offsetX, stepX);
+  const phaseY = normalizedOffset(offsetY, stepY);
+  const placements: LayoutPoint[] = [];
+
+  for (
+    let row = -1, y = phaseY - stepY;
+    y < canvas.height;
+    row += 1, y += stepY
+  ) {
+    if (y + item.height <= 0) {
+      continue;
+    }
+    const staggerOffset = layout.stagger && row % 2 !== 0 ? stepX / 2 : 0;
+    const rowPhaseX = normalizedOffset(phaseX + staggerOffset, stepX);
+    for (let x = rowPhaseX - stepX; x < canvas.width; x += stepX) {
+      if (x + item.width <= 0) {
+        continue;
+      }
+      placements.push({ x, y });
+      if (placements.length > MAX_TILE_COPIES) {
+        throw new Error(
+          `tile layout exceeds the maximum of ${MAX_TILE_COPIES} copies per layer.`
+        );
+      }
+    }
+  }
+
+  return placements;
+}

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -12,6 +12,7 @@ import type {
   TextStyle,
   TextWatermarkLayer,
   WatermarkImageOptions,
+  WatermarkLayout,
   WatermarkLayer,
 } from './index';
 
@@ -35,6 +36,12 @@ function clonePositionOptions(
   position?: PositionOptions
 ): PositionOptions | undefined {
   return position ? { ...position } : position;
+}
+
+function cloneWatermarkLayout(
+  layout?: WatermarkLayout
+): WatermarkLayout | undefined {
+  return layout ? { ...layout } : layout;
 }
 
 function cloneCornerRadius(
@@ -88,12 +95,20 @@ function cloneTextStyle(style?: TextStyle): TextStyle | undefined {
 }
 
 function cloneTextWatermarks(watermarkTexts: TextOptions[]): TextOptions[] {
-  return watermarkTexts.map((textOptions) => ({
-    ...textOptions,
-    position: clonePositionOptions(textOptions.position),
-    positionOptions: clonePositionOptions(textOptions.positionOptions),
-    style: cloneTextStyle(textOptions.style),
-  }));
+  return watermarkTexts.map((textOptions) => {
+    const cloned: TextOptions = {
+      ...textOptions,
+      layout: cloneWatermarkLayout(textOptions.layout),
+      style: cloneTextStyle(textOptions.style),
+    };
+    const position = clonePositionOptions(textOptions.position);
+    const positionOptions = clonePositionOptions(textOptions.positionOptions);
+    if (position) cloned.position = position;
+    else delete cloned.position;
+    if (positionOptions) cloned.positionOptions = positionOptions;
+    else delete cloned.positionOptions;
+    return cloned;
+  });
 }
 
 function cloneImageOptions<T extends ImageOptions | undefined>(
@@ -105,10 +120,16 @@ function cloneImageOptions<T extends ImageOptions | undefined>(
 function cloneImageWatermarks(
   watermarkImages: WatermarkImageOptions[]
 ): WatermarkImageOptions[] {
-  return watermarkImages.map((imageOptions) => ({
-    ...imageOptions,
-    position: clonePositionOptions(imageOptions.position),
-  }));
+  return watermarkImages.map((imageOptions) => {
+    const cloned: WatermarkImageOptions = {
+      ...imageOptions,
+      layout: cloneWatermarkLayout(imageOptions.layout),
+    };
+    const position = clonePositionOptions(imageOptions.position);
+    if (position) cloned.position = position;
+    else delete cloned.position;
+    return cloned;
+  });
 }
 
 function getOutputOptions(options: MarkOptions): OutputOptions {
@@ -156,27 +177,41 @@ function resolveImageOptions<T extends ImageOptions>(
 }
 
 function createTextLayer(textOptions: TextOptions): TextWatermarkLayer {
-  return {
+  const layer: TextWatermarkLayer = {
     ...textOptions,
     type: 'text',
-    position:
-      clonePositionOptions(
-        textOptions.position || textOptions.positionOptions
-      ) || {},
+    layout: cloneWatermarkLayout(textOptions.layout),
     style: cloneTextStyle(textOptions.style),
   };
+  const position = clonePositionOptions(
+    textOptions.position || textOptions.positionOptions
+  );
+  if (position) {
+    layer.position = position;
+  } else {
+    delete layer.position;
+  }
+  delete layer.positionOptions;
+  return layer;
 }
 
 function createImageLayer(
   imageOptions: WatermarkImageOptions,
   assetResolver: AssetResolver
 ): ImageWatermarkLayer {
-  return {
+  const layer: ImageWatermarkLayer = {
     ...imageOptions,
     type: 'image',
     src: resolveImageSource(imageOptions.src, assetResolver),
-    position: clonePositionOptions(imageOptions.position) || {},
+    layout: cloneWatermarkLayout(imageOptions.layout),
   };
+  const position = clonePositionOptions(imageOptions.position);
+  if (position) {
+    layer.position = position;
+  } else {
+    delete layer.position;
+  }
+  return layer;
 }
 
 function createWatermarkLayers(
@@ -227,11 +262,11 @@ export function normalizeTextMarkOptions(
     watermarkTexts: cloneTextWatermarks(options.watermarkTexts).map(
       (textOptions) => {
         const nativeTextOptions = { ...textOptions };
+        const position = textOptions.position || textOptions.positionOptions;
         delete nativeTextOptions.positionOptions;
-        return {
-          ...nativeTextOptions,
-          position: textOptions.position || textOptions.positionOptions,
-        };
+        if (position) nativeTextOptions.position = position;
+        else delete nativeTextOptions.position;
+        return nativeTextOptions;
       }
     ),
     maxSize: options.maxSize ?? DEFAULT_MAX_SIZE,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -4,6 +4,8 @@ import type {
   MarkOptions,
   TextOptions,
   TextMarkOptions,
+  WatermarkImageOptions,
+  WatermarkLayout,
 } from './index';
 
 type MarkRequestOptions = TextMarkOptions | ImageMarkOptions | MarkOptions;
@@ -53,23 +55,97 @@ function validateCommonOptions(options: MarkRequestOptions): void {
   validateAlpha(options.backgroundImage, 'backgroundImage');
 }
 
-function validateTextOptions(textOptions: TextOptions, path: string): void {
-  const strokeStyle = textOptions.style?.strokeStyle;
-  if (!strokeStyle) {
+function validateLayoutValue(
+  value: number | string | undefined,
+  path: string,
+  nonNegative: boolean
+): void {
+  if (value === undefined) {
     return;
   }
-  if (!Number.isFinite(strokeStyle.width) || strokeStyle.width < 0) {
-    throw new Error(
-      `${path}.style.strokeStyle.width must be a non-negative finite number.`
-    );
+  const normalized = typeof value === 'string' ? value.trim() : value;
+  const valid =
+    typeof normalized === 'number'
+      ? Number.isFinite(normalized)
+      : /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(%)?$/.test(normalized);
+  if (!valid) {
+    throw new Error(`${path} must be a finite number or percentage.`);
   }
-  if (typeof strokeStyle.color !== 'string' || !strokeStyle.color.trim()) {
-    throw new Error(
-      `${path}.style.strokeStyle.color must be a non-empty string.`
-    );
+  if (nonNegative && Number.parseFloat(String(normalized)) < 0) {
+    throw new Error(`${path} must be non-negative.`);
   }
 }
 
+function validateWatermarkLayout(
+  layout: WatermarkLayout | undefined,
+  hasPosition: boolean,
+  path: string
+): void {
+  if (!layout) {
+    return;
+  }
+  if (typeof layout !== 'object' || Array.isArray(layout)) {
+    throw new Error(`${path} must be an object.`);
+  }
+  const type = layout.type ?? 'single';
+  if (type !== 'single' && type !== 'tile') {
+    throw new Error(`${path}.type must be "single" or "tile".`);
+  }
+  if (type === 'tile' && hasPosition) {
+    throw new Error(`${path} cannot be combined with position.`);
+  }
+  const runtimeLayout = layout as {
+    gapX?: number | string;
+    gapY?: number | string;
+    offsetX?: number | string;
+    offsetY?: number | string;
+    stagger?: boolean;
+  };
+  validateLayoutValue(runtimeLayout.gapX, `${path}.gapX`, true);
+  validateLayoutValue(runtimeLayout.gapY, `${path}.gapY`, true);
+  validateLayoutValue(runtimeLayout.offsetX, `${path}.offsetX`, false);
+  validateLayoutValue(runtimeLayout.offsetY, `${path}.offsetY`, false);
+  if (
+    runtimeLayout.stagger !== undefined &&
+    typeof runtimeLayout.stagger !== 'boolean'
+  ) {
+    throw new Error(`${path}.stagger must be a boolean.`);
+  }
+}
+
+function validateTextOptions(options: TextOptions, path: string): void {
+  const strokeStyle = options.style?.strokeStyle;
+  if (strokeStyle) {
+    if (!Number.isFinite(strokeStyle.width) || strokeStyle.width < 0) {
+      throw new Error(
+        `${path}.style.strokeStyle.width must be a non-negative finite number.`
+      );
+    }
+    if (typeof strokeStyle.color !== 'string' || !strokeStyle.color.trim()) {
+      throw new Error(
+        `${path}.style.strokeStyle.color must be a non-empty string.`
+      );
+    }
+  }
+  validateWatermarkLayout(
+    options.layout,
+    options.position !== undefined || options.positionOptions !== undefined,
+    `${path}.layout`
+  );
+}
+
+function validateImageOptions(
+  options: WatermarkImageOptions,
+  path: string,
+  hasExternalPosition = false
+): void {
+  validateAlpha(options, path);
+  validateWatermarkLayout(
+    options.layout,
+    options.position !== undefined || hasExternalPosition,
+    `${path}.layout`
+  );
+}
 export function validateTextMarkOptions(options: TextMarkOptions): void {
   validateCommonOptions(options);
   options.watermarkTexts.forEach((textOptions, index) => {
@@ -79,21 +155,33 @@ export function validateTextMarkOptions(options: TextMarkOptions): void {
 
 export function validateImageMarkOptions(options: ImageMarkOptions): void {
   validateCommonOptions(options);
-  validateAlpha(options.watermarkImage, 'watermarkImage');
+  if (options.watermarkImage) {
+    validateImageOptions(
+      options.watermarkImage,
+      'watermarkImage',
+      options.watermarkPositions !== undefined
+    );
+  }
   options.watermarkImages?.forEach((imageOptions, index) => {
-    validateAlpha(imageOptions, `watermarkImages[${index}]`);
+    validateImageOptions(imageOptions, `watermarkImages[${index}]`);
   });
 }
 
 export function validateMarkOptions(options: MarkOptions): void {
   validateCommonOptions(options);
-  validateAlpha(options.watermarkImage, 'watermarkImage');
+  if (options.watermarkImage) {
+    validateImageOptions(
+      options.watermarkImage,
+      'watermarkImage',
+      options.watermarkPositions !== undefined
+    );
+  }
   options.watermarkImages?.forEach((imageOptions, index) => {
-    validateAlpha(imageOptions, `watermarkImages[${index}]`);
+    validateImageOptions(imageOptions, `watermarkImages[${index}]`);
   });
   options.watermarks?.forEach((layer, index) => {
     if (layer.type === 'image') {
-      validateAlpha(layer, `watermarks[${index}]`);
+      validateImageOptions(layer, `watermarks[${index}]`);
     } else {
       validateTextOptions(layer, `watermarks[${index}]`);
     }

--- a/src/web/renderer.ts
+++ b/src/web/renderer.ts
@@ -30,6 +30,7 @@ import {
   resolveSpreadValue,
 } from './helpers';
 import type { Point, Size } from './helpers';
+import { resolveTilePlacements } from '../layout';
 
 export type WebRenderLayer =
   | { type: 'text'; options: TextOptions }
@@ -458,30 +459,25 @@ function drawTextDecorations(
   stroke.stroke();
 }
 
-function drawTextLayer(
+function drawTextAtPosition(
   context: WebCanvasContext,
   options: TextOptions,
-  canvas: Size
+  canvas: Size,
+  layout: TextLayout,
+  visualPosition: Point,
+  rotation: number
 ) {
   const style = options.style;
-  const layout = measureTextLayout(context, options.text, style, canvas.width);
   const strokeWidth = style?.strokeStyle?.width ?? 0;
   const outlineInset = strokeWidth / 2;
   const visualSize = {
     width: layout.width + outlineInset * 2,
     height: layout.height + outlineInset * 2,
   };
-  const visualPosition = resolveAnchoredPosition(
-    options.position ?? options.positionOptions,
-    canvas,
-    visualSize,
-    20
-  );
   const position = {
     x: visualPosition.x + outlineInset,
     y: visualPosition.y + outlineInset,
   };
-  const rotation = resolveRotation(style?.rotate, 'text rotation');
 
   context.save();
   try {
@@ -553,6 +549,62 @@ function drawTextLayer(
   } finally {
     context.restore();
   }
+}
+
+function drawTextLayer(
+  context: WebCanvasContext,
+  options: TextOptions,
+  canvas: Size
+) {
+  const style = options.style;
+  const textLayout = measureTextLayout(
+    context,
+    options.text,
+    style,
+    canvas.width
+  );
+  const rotation = resolveRotation(style?.rotate, 'text rotation');
+  const strokeWidth = style?.strokeStyle?.width ?? 0;
+  const outlineInset = strokeWidth / 2;
+  const visualSize = {
+    width: textLayout.width + outlineInset * 2,
+    height: textLayout.height + outlineInset * 2,
+  };
+
+  if (options.layout?.type === 'tile') {
+    const rotatedSize = getRotatedBounds(visualSize, rotation);
+    const placements = resolveTilePlacements(
+      options.layout,
+      canvas,
+      rotatedSize
+    );
+    const originInset = {
+      x: (rotatedSize.width - visualSize.width) / 2,
+      y: (rotatedSize.height - visualSize.height) / 2,
+    };
+    placements.forEach((placement) => {
+      drawTextAtPosition(
+        context,
+        options,
+        canvas,
+        textLayout,
+        {
+          x: placement.x + originInset.x,
+          y: placement.y + originInset.y,
+        },
+        rotation
+      );
+    });
+    return;
+  }
+
+  const position = resolveAnchoredPosition(
+    options.position ?? options.positionOptions,
+    canvas,
+    visualSize,
+    20
+  );
+  drawTextAtPosition(context, options, canvas, textLayout, position, rotation);
 }
 
 function fullSourceBounds(image: LoadedWebImage): SourceBounds {
@@ -629,37 +681,37 @@ async function drawImageLayer(
       height: sourceBounds.height * scale,
     };
     const rotatedBounds = getRotatedBounds(scaledSize, rotation);
-    const position = resolveAnchoredPosition(
-      options.position,
-      canvas,
-      rotatedBounds,
-      0
-    );
+    const positions =
+      options.layout?.type === 'tile'
+        ? resolveTilePlacements(options.layout, canvas, rotatedBounds)
+        : [resolveAnchoredPosition(options.position, canvas, rotatedBounds, 0)];
 
-    context.save();
-    try {
-      context.globalAlpha = alpha;
-      context.imageSmoothingEnabled = false;
-      context.translate(
-        position.x - rotatedBounds.left,
-        position.y - rotatedBounds.top
-      );
-      context.rotate(degreesToRadians(rotation));
-      context.scale(scale, scale);
-      context.drawImage(
-        image.image,
-        sourceBounds.x,
-        sourceBounds.y,
-        sourceBounds.width,
-        sourceBounds.height,
-        0,
-        0,
-        sourceBounds.width,
-        sourceBounds.height
-      );
-    } finally {
-      context.restore();
-    }
+    positions.forEach((position) => {
+      context.save();
+      try {
+        context.globalAlpha = alpha;
+        context.imageSmoothingEnabled = false;
+        context.translate(
+          position.x - rotatedBounds.left,
+          position.y - rotatedBounds.top
+        );
+        context.rotate(degreesToRadians(rotation));
+        context.scale(scale, scale);
+        context.drawImage(
+          image.image,
+          sourceBounds.x,
+          sourceBounds.y,
+          sourceBounds.width,
+          sourceBounds.height,
+          0,
+          0,
+          sourceBounds.width,
+          sourceBounds.height
+        );
+      } finally {
+        context.restore();
+      }
+    });
   } finally {
     image.cleanup();
   }


### PR DESCRIPTION
## Summary

- add single and tile watermark layout options for text and image layers
- render tiled layouts consistently on iOS, Android, and Web, including rotation, offsets, staggered rows, and a 4096-copy safety limit
- cover normalization, validation, native renderers, Web rendering, and the Expo three-browser smoke harness

## Verification

- npm run typecheck
- npm run lint
- npm test -- --runInBand
- npm run prepack
- npm run typecheck:example
- npm run typecheck:expo-example
- npm run docs
- Android library unit tests and Android test source compilation
- iOS react-native-image-marker simulator build
- Expo Web bundle verification and Chromium, Firefox, WebKit smoke tests