### PR TITLE
chore: release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.7.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.6.0...v1.7.0) (2026-07-18)
+
+### Features
+
+* add text stroke rendering ([#322](https://github.com/JimmyDaddy/react-native-image-marker/issues/322)) ([e98cdfd](https://github.com/JimmyDaddy/react-native-image-marker/commit/e98cdfd96d35dbfa58a416bc2c7388edc4927b8f))
+* add tiled watermark layouts ([#323](https://github.com/JimmyDaddy/react-native-image-marker/issues/323)) ([42511fd](https://github.com/JimmyDaddy/react-native-image-marker/commit/42511fdd452d049bd6385338c1053627a9a7d509))
+* showcase v1.7 watermark layouts ([#324](https://github.com/JimmyDaddy/react-native-image-marker/issues/324)) ([4d0c1c1](https://github.com/JimmyDaddy/react-native-image-marker/commit/4d0c1c15d643775bb0bf2c21bfe4eab3482c5931))
+
 ## [1.6.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.5.0...v1.6.0) (2026-07-18)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "packageManager": "npm@10.9.4",
   "description": "Add text and image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
## Summary

- bump the package version to 1.7.0
- add release notes for text outlines, tiled watermark layouts, and the updated examples/docs
- keep npm publication delegated to the trusted-publishing workflow after the GitHub Release is created

## Verification

- full CI passed on #324 across iOS, Android, modern RN/Expo, and Chromium/Firefox/WebKit
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` (53 tests)
- `npm run docs`
- `npm pack --dry-run --json`
- `npm audit --omit=dev --audit-level=moderate` (0 vulnerabilities)