### PR TITLE
fix(ios): honor maxSize while decoding images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,8 @@ jobs:
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testJPEGUsesExplicitMatteWhilePNGPreservesTransparency \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTrimsTransparentWatermarkPaddingBeforeAnchoredPositioning \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testOptionsPreferFilenameAndProvideRenderingDefaults \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testMaxSizeDefaultsValidatesAndBuildsBoundedLoadRequests \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testImageIODownsamplesDataAndBase64BeforeRendering \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testRejectsInvalidQualityAlphaAndUnsafeFilenames \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testParsesShadowHexColorAndRejectsInvalidValues \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testBackgroundScaleChangesCanvasWithoutImplicitlyScalingLayers \

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -581,6 +581,63 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertEqual(Utils.canonicalOutputFilename("output.JPEG", ext: ".png"), "output.png")
   }
 
+  func testMaxSizeDefaultsValidatesAndBuildsBoundedLoadRequests() throws {
+    let background: [AnyHashable: Any] = [
+      "src": ["uri": "file:///tmp/background.png"],
+    ]
+    XCTAssertEqual(try Options(dicOpts: ["backgroundImage": background]).maxSize, 2048)
+    XCTAssertEqual(
+      try Options(dicOpts: ["backgroundImage": background, "maxSize": 1024]).maxSize,
+      1024
+    )
+    for maxSize: Any in [0, -1, 10.5, Double.nan, Double.infinity, true, "1024"] {
+      assertInvalidParams {
+        _ = try Options(dicOpts: ["backgroundImage": background, "maxSize": maxSize])
+      }
+    }
+
+    let small = Utils.imageLoadRequest(
+      for: RNImageSRC(dicOpts: ["width": CGFloat(100), "height": CGFloat(50), "scale": CGFloat(2)]),
+      maxSize: 512
+    )
+    XCTAssertEqual(small.size, CGSize(width: 100, height: 50))
+    XCTAssertEqual(small.scale, 2, accuracy: 0.001)
+    XCTAssertEqual(small.resizeMode, .cover)
+
+    let large = Utils.imageLoadRequest(
+      for: RNImageSRC(dicOpts: ["width": CGFloat(2000), "height": CGFloat(1000), "scale": CGFloat(2)]),
+      maxSize: 1000
+    )
+    XCTAssertEqual(large.size, CGSize(width: 1000, height: 500))
+    XCTAssertEqual(large.scale, 1, accuracy: 0.001)
+    XCTAssertEqual(large.resizeMode, .contain)
+
+    let unknown = Utils.imageLoadRequest(
+      for: RNImageSRC(dicOpts: ["uri": "https://example.com/image.jpg"]),
+      maxSize: 768
+    )
+    XCTAssertEqual(unknown.size, CGSize(width: 768, height: 768))
+    XCTAssertEqual(unknown.scale, 1, accuracy: 0.001)
+    XCTAssertEqual(unknown.resizeMode, .contain)
+  }
+
+  func testImageIODownsamplesDataAndBase64BeforeRendering() throws {
+    let source = makeSolidImage(size: CGSize(width: 400, height: 200), color: .blue)
+    let data = try XCTUnwrap(source.pngData())
+
+    let downsampled = try XCTUnwrap(Utils.downsampleImageData(data, maxSize: 100))
+    XCTAssertEqual(downsampled.imageOrientation, .up)
+    XCTAssertEqual(downsampled.scale, 1, accuracy: 0.001)
+    XCTAssertEqual(downsampled.cgImage?.width, 100)
+    XCTAssertEqual(downsampled.cgImage?.height, 50)
+
+    let dataURI = "data:image/png;base64,\(data.base64EncodedString())"
+    let base64Image = try XCTUnwrap(Utils.downsampleBase64Image(dataURI, maxSize: 80))
+    XCTAssertEqual(base64Image.cgImage?.width, 80)
+    XCTAssertEqual(base64Image.cgImage?.height, 40)
+    XCTAssertNil(Utils.downsampleBase64Image("data:image/png,not-base64", maxSize: 80))
+  }
+
   func testRejectsInvalidQualityAlphaAndUnsafeFilenames() throws {
     let background: [AnyHashable: Any] = [
       "src": ["uri": "file:///tmp/background.png"],

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -17,7 +17,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
     public var bridge: RCTBridge!
     private let operationLimiter = ImageMarkerAsyncLimiter(limit: 1)
     
-    func loadImages(with imageOptions: [ImageOptions]) async throws -> [UIImage] {
+    func loadImages(with imageOptions: [ImageOptions], maxSize: Int) async throws -> [UIImage] {
         let className = "RCTImageLoader"
         let classType: AnyClass? = NSClassFromString(className)
         guard let bridge = self.bridge,
@@ -25,14 +25,14 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             throw NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to get ImageLoader module"])
         }
         return try await Utils.sequentialAsyncMap(imageOptions) { img in
-            try await self.loadImage(img, using: imageLoader)
+            try await self.loadImage(img, maxSize: maxSize, using: imageLoader)
         }
     }
 
-    private func loadImage(_ imageOptions: ImageOptions, using imageLoader: RCTImageLoader) async throws -> UIImage {
+    private func loadImage(_ imageOptions: ImageOptions, maxSize: Int, using imageLoader: RCTImageLoader) async throws -> UIImage {
         if Utils.isBase64(imageOptions.uri) {
             try Task.checkCancellation()
-            guard let image = UIImage.transBase64(imageOptions.uri) else {
+            guard let image = Utils.downsampleBase64Image(imageOptions.uri, maxSize: maxSize) else {
                 throw NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to load image"])
             }
             try Task.checkCancellation()
@@ -42,13 +42,14 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         guard let request = RCTConvert.nsurlRequest(imageOptions.src) else {
             throw NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create URL request for image: \(imageOptions.uri)"])
         }
+        let loadRequest = Utils.imageLoadRequest(for: imageOptions.rnSrc, maxSize: maxSize)
         let loadedImage: UIImage = try await ImageMarkerCancellableContinuation.run { completion in
             return imageLoader.loadImage(
                 with: request,
-                size: CGSizeMake(imageOptions.rnSrc.width, imageOptions.rnSrc.height),
-                scale: imageOptions.rnSrc.scale,
+                size: loadRequest.size,
+                scale: loadRequest.scale,
                 clipped: false,
-                resizeMode: RCTResizeMode.cover
+                resizeMode: loadRequest.resizeMode
             ) { _, _ in
                 // Progress is intentionally ignored.
             } partialLoad: { _ in
@@ -377,7 +378,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
         Task(priority: .userInitiated) {
             do {
                 let result = try await self.operationLimiter.withPermit {
-                    var images = try await self.loadImages(with: [markOpts.backgroundImage])
+                    var images = try await self.loadImages(with: [markOpts.backgroundImage], maxSize: markOpts.maxSize)
                     let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
                         try self.markImgWithText(sources[0], markOpts)
                     }
@@ -403,7 +404,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             do {
                 let result = try await self.operationLimiter.withPermit {
                     let waterImages = markOpts.watermarkImages.map { $0.imageOption }
-                    var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages)
+                    var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages, maxSize: markOpts.maxSize)
                     let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
                         try self.markImage(
                             with: sources[0],
@@ -433,7 +434,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
             do {
                 let result = try await self.operationLimiter.withPermit {
                     let waterImages = markOpts.imageLayers.map { $0.imageOption }
-                    var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages)
+                    var images = try await self.loadImages(with: [markOpts.backgroundImage] + waterImages, maxSize: markOpts.maxSize)
                     let renderedImage = try Utils.renderAndReleaseSources(&images) { sources in
                         try self.markWatermarks(
                             with: sources[0],

--- a/ios/RCTImageMarker/Options.swift
+++ b/ios/RCTImageMarker/Options.swift
@@ -13,7 +13,7 @@ class Options: NSObject {
     var backgroundImage: ImageOptions
     var quality: Int = 100
     var saveFormat: String?
-    var maxSize: Int?
+    var maxSize: Int = 2048
     var filename: String?
     var matteColor: UIColor = .white
     var rotationCanvasMode: ImageMarkerRotationCanvasMode = .expand
@@ -37,7 +37,20 @@ class Options: NSObject {
             self.quality = Int(qualityValue)
         }
         self.saveFormat = opts["saveFormat"] as? String
-        self.maxSize = opts["maxSize"] as? Int
+        if let rawMaxSize = opts["maxSize"], !Utils.isNULL(rawMaxSize) {
+            guard let maxSizeNumber = rawMaxSize as? NSNumber,
+                  CFGetTypeID(maxSizeNumber) != CFBooleanGetTypeID() else {
+                throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "maxSize must be a positive finite integer"])
+            }
+            let maxSizeValue = maxSizeNumber.doubleValue
+            guard maxSizeValue.isFinite,
+                  maxSizeValue.rounded(.towardZero) == maxSizeValue,
+                  let parsedMaxSize = Int(exactly: maxSizeValue),
+                  parsedMaxSize > 0 else {
+                throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "maxSize must be a positive finite integer"])
+            }
+            self.maxSize = parsedMaxSize
+        }
         self.filename = opts["filename"] as? String ?? opts["fileName"] as? String
         if let filename = self.filename, !Utils.isSafeOutputFilename(filename) {
             throw NSError(domain: ErrorDomainEnum.PARAMS_INVALID.rawValue, code: 0, userInfo: [NSLocalizedDescriptionKey: "filename must be a safe basename"])

--- a/ios/RCTImageMarker/UIImageEdit.swift
+++ b/ios/RCTImageMarker/UIImageEdit.swift
@@ -622,14 +622,4 @@ extension UIImage {
         return UIImage(cgImage: croppedImage, scale: sourceImage.scale, orientation: .up)
     }
 
-    static func transBase64(_ base64Str: String) -> UIImage? {
-        let trimmedString = base64Str.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let encodedString = trimmedString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-            let imgURL = URL(string: encodedString),
-            let imageData = try? Data(contentsOf: imgURL),
-            let image = UIImage(data: imageData) else {
-            return nil
-        }
-        return image
-    }
 }

--- a/ios/RCTImageMarker/Utils.swift
+++ b/ios/RCTImageMarker/Utils.swift
@@ -7,8 +7,15 @@
 //
 
 import Foundation
+import ImageIO
 import UIKit
 import React
+
+struct ImageMarkerImageLoadRequest {
+    let size: CGSize
+    let scale: CGFloat
+    let resizeMode: RCTResizeMode
+}
 
 actor ImageMarkerAsyncLimiter {
     private struct Waiter {
@@ -183,6 +190,77 @@ enum ImageMarkerCancellableContinuation {
 }
 
 class Utils: NSObject {
+    static func imageLoadRequest(for source: RNImageSRC, maxSize: Int) -> ImageMarkerImageLoadRequest {
+        let width = source.width
+        let height = source.height
+        let sourceScale = source.scale
+        let hasKnownSize = width.isFinite && height.isFinite && sourceScale.isFinite
+            && width > 0 && height > 0 && sourceScale > 0
+
+        guard hasKnownSize else {
+            let boundedSize = CGFloat(maxSize)
+            return ImageMarkerImageLoadRequest(
+                size: CGSize(width: boundedSize, height: boundedSize),
+                scale: 1,
+                resizeMode: .contain
+            )
+        }
+
+        let pixelWidth = width * sourceScale
+        let pixelHeight = height * sourceScale
+        let largestPixelDimension = max(pixelWidth, pixelHeight)
+        if largestPixelDimension <= CGFloat(maxSize) {
+            return ImageMarkerImageLoadRequest(
+                size: CGSize(width: width, height: height),
+                scale: sourceScale,
+                resizeMode: .cover
+            )
+        }
+
+        let ratio = CGFloat(maxSize) / largestPixelDimension
+        return ImageMarkerImageLoadRequest(
+            size: CGSize(
+                width: max((pixelWidth * ratio).rounded(), 1),
+                height: max((pixelHeight * ratio).rounded(), 1)
+            ),
+            scale: 1,
+            resizeMode: .contain
+        )
+    }
+
+    static func downsampleImageData(_ data: Data, maxSize: Int) -> UIImage? {
+        let sourceOptions = [
+            kCGImageSourceShouldCache: false,
+        ] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxSize,
+            kCGImageSourceShouldCacheImmediately: true,
+        ] as CFDictionary
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+            return nil
+        }
+        return UIImage(cgImage: thumbnail, scale: 1, orientation: .up)
+    }
+
+    static func downsampleBase64Image(_ value: String, maxSize: Int) -> UIImage? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let comma = trimmed.firstIndex(of: ","),
+              trimmed[..<comma].lowercased().contains(";base64") else {
+            return nil
+        }
+        let encoded = String(trimmed[trimmed.index(after: comma)...])
+        let decodedValue = encoded.removingPercentEncoding ?? encoded
+        guard let data = Data(base64Encoded: decodedValue, options: .ignoreUnknownCharacters) else {
+            return nil
+        }
+        return downsampleImageData(data, maxSize: maxSize)
+    }
+
     static func resolvedTextColor(_ value: String?) -> UIColor {
         guard let value else {
             return .black

--- a/src/index.ts
+++ b/src/index.ts
@@ -700,8 +700,8 @@ export interface TextMarkOptions {
    */
   rotationCanvasMode?: RotationCanvasMode;
   /**
-   * Maximum width or height used while decoding on Android and rendering on
-   * Web. Larger images keep their aspect ratio. Currently ignored on iOS.
+   * Maximum width or height used while decoding or rendering source images.
+   * Larger images keep their aspect ratio on iOS, Android, and Web.
    * @defaultValue 2048
    * @example
    * maxSize: 2048
@@ -903,8 +903,8 @@ export interface ImageMarkOptions {
    */
   rotationCanvasMode?: RotationCanvasMode;
   /**
-   * Maximum width or height used while decoding on Android and rendering on
-   * Web. Larger images keep their aspect ratio. Currently ignored on iOS.
+   * Maximum width or height used while decoding or rendering source images.
+   * Larger images keep their aspect ratio on iOS, Android, and Web.
    * @defaultValue 2048
    * @example
    * maxSize: 2048
@@ -1027,8 +1027,8 @@ export interface MarkOptions {
    */
   rotationCanvasMode?: RotationCanvasMode;
   /**
-   * Maximum width or height used while decoding on Android and rendering on
-   * Web. Larger images keep their aspect ratio. Currently ignored on iOS.
+   * Maximum width or height used while decoding or rendering source images.
+   * Larger images keep their aspect ratio on iOS, Android, and Web.
    * @defaultValue 2048
    */
   maxSize?: number;


### PR DESCRIPTION
## Summary

- enforce the existing `maxSize` option on iOS with a 2048 default and native validation
- request bounded decodes from React Native image loaders and downsample base64 input through ImageIO
- preserve existing small-asset scale semantics while bounding large and unknown-size sources
- add focused iOS tests and include them in CI

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run docs`
- Xcode simulator: `testMaxSizeDefaultsValidatesAndBuildsBoundedLoadRequests`
- Xcode simulator: `testImageIODownsamplesDataAndBase64BeforeRendering`