### PR TITLE
feat: add reusable watermark recipes

### DIFF
--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -1,8 +1,10 @@
 import Marker, {
+  ImageFormat,
   type ImageMarkOptions,
   type TextMarkOptions,
   type TextStrokeStyle,
   type WatermarkLayout,
+  type WatermarkRecipe,
 } from '../index';
 
 // The deprecated single-watermark shape remains source-compatible for users
@@ -58,3 +60,11 @@ export const tiledText: TextMarkOptions = {
   backgroundImage: { src: 'file:///tmp/background.png' },
   watermarkTexts: [{ text: 'CONFIDENTIAL', layout: tiledLayout }],
 };
+
+export const reusableRecipe: WatermarkRecipe = Marker.createRecipe({
+  watermarks: [
+    { type: 'text', text: 'Reusable' },
+    { type: 'image', src: 'file:///tmp/logo.png' },
+  ],
+  saveFormat: ImageFormat.jpg,
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -58,6 +58,31 @@ describe('Marker JS wrapper', () => {
     });
   });
 
+  it('creates reusable native recipes through the public Marker API', async () => {
+    nativeModule.markWithWatermarks.mockResolvedValue('/tmp/recipe.jpg');
+    const recipe = Marker.createRecipe({
+      watermarks: [{ type: 'text', text: 'Reusable' }],
+      quality: 88,
+    });
+
+    await expect(
+      recipe.apply({
+        backgroundImage: { src: 'file:///tmp/background.jpg' },
+        filename: 'recipe-output',
+      })
+    ).resolves.toBe('/tmp/recipe.jpg');
+    expect(nativeModule.markWithWatermarks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quality: 88,
+        filename: 'recipe-output',
+        maxSize: 2048,
+        watermarks: [
+          expect.objectContaining({ type: 'text', text: 'Reusable' }),
+        ],
+      })
+    );
+  });
+
   it('normalizes markText options before calling the native module', async () => {
     nativeModule.markWithText.mockResolvedValue('/tmp/text.png');
     const options = {

--- a/src/__tests__/recipe.test.ts
+++ b/src/__tests__/recipe.test.ts
@@ -1,0 +1,132 @@
+import type { MarkOptions } from '../index';
+import { createWatermarkRecipe, type WatermarkRecipeOptions } from '../recipe';
+
+describe('watermark recipes', () => {
+  it('snapshots nested settings while retaining source references', async () => {
+    const logoSource = { uri: 'logo.png' };
+    const options: WatermarkRecipeOptions = {
+      watermarks: [
+        {
+          type: 'text',
+          text: 'ORIGINAL',
+          positionOptions: { X: 12, Y: 18 },
+          layout: { type: 'single' },
+          style: {
+            color: '#FFFFFF',
+            strokeStyle: { color: '#000000', width: 2 },
+            textBackgroundStyle: {
+              color: '#111111',
+              cornerRadius: { all: { x: 6, y: 6 } },
+            },
+          },
+        },
+        { type: 'image', src: logoSource, layout: { type: 'tile', gapX: 20 } },
+      ],
+      quality: 90,
+    };
+    const renderer = jest.fn<Promise<string>, [MarkOptions]>(
+      async () => 'done'
+    );
+    const recipe = createWatermarkRecipe(options, renderer);
+
+    const textLayer = options.watermarks[0];
+    const imageLayer = options.watermarks[1];
+    if (textLayer?.type === 'text') {
+      textLayer.text = 'MUTATED';
+      if (textLayer.positionOptions) textLayer.positionOptions.X = 999;
+      if (textLayer.style?.strokeStyle) textLayer.style.strokeStyle.width = 9;
+      const all = textLayer.style?.textBackgroundStyle?.cornerRadius?.all;
+      if (all) all.x = 99;
+    }
+    if (imageLayer?.type === 'image' && imageLayer.layout) {
+      imageLayer.layout.gapX = 999;
+    }
+    options.quality = 1;
+
+    await expect(
+      recipe.apply({
+        backgroundImage: { src: 'background.jpg' },
+        filename: 'first',
+      })
+    ).resolves.toBe('done');
+
+    const rendered = renderer.mock.calls[0]?.[0];
+    expect(rendered).toEqual(
+      expect.objectContaining({
+        backgroundImage: { src: 'background.jpg' },
+        filename: 'first',
+        quality: 90,
+      })
+    );
+    expect(rendered?.watermarks?.[0]).toEqual(
+      expect.objectContaining({
+        text: 'ORIGINAL',
+        positionOptions: { X: 12, Y: 18 },
+        style: expect.objectContaining({
+          strokeStyle: { color: '#000000', width: 2 },
+          textBackgroundStyle: expect.objectContaining({
+            cornerRadius: { all: { x: 6, y: 6 } },
+          }),
+        }),
+      })
+    );
+    expect(rendered?.watermarks?.[1]).toEqual(
+      expect.objectContaining({ layout: { type: 'tile', gapX: 20 } })
+    );
+    expect(
+      rendered?.watermarks?.[1]?.type === 'image'
+        ? rendered.watermarks[1].src
+        : undefined
+    ).toBe(logoSource);
+  });
+
+  it('snapshots each input wrapper before rendering', async () => {
+    const recipe = createWatermarkRecipe(
+      { watermarks: [{ type: 'text', text: 'Reusable' }] },
+      async (options) => String(options.backgroundImage.src)
+    );
+    const input = {
+      backgroundImage: { src: 'before.jpg', alpha: 0.5 },
+      filename: 'before',
+    };
+
+    const output = recipe.apply(input);
+    input.backgroundImage.src = 'after.jpg';
+    input.filename = 'after';
+
+    await expect(output).resolves.toBe('before.jpg');
+  });
+
+  it('validates modern ordered layers and each apply input', async () => {
+    expect(() =>
+      createWatermarkRecipe({ watermarks: [] }, async () => 'done')
+    ).toThrow('createRecipe requires at least one watermark layer.');
+    expect(() =>
+      createWatermarkRecipe(
+        {
+          watermarks: [{ type: 'image', src: '' }],
+        },
+        async () => 'done'
+      )
+    ).toThrow('please set mark image!');
+    expect(() =>
+      createWatermarkRecipe(
+        {
+          watermarks: [{ type: 'text', text: 'Modern' }],
+          watermarkTexts: [{ text: 'Legacy' }],
+        } as unknown as WatermarkRecipeOptions,
+        async () => 'done'
+      )
+    ).toThrow(
+      'createRecipe does not accept "watermarkTexts"; use ordered watermarks and pass per-image fields to apply().'
+    );
+
+    const recipe = createWatermarkRecipe(
+      { watermarks: [{ type: 'text', text: 'Reusable' }] },
+      async () => 'done'
+    );
+    await expect(
+      recipe.apply({ backgroundImage: { src: '' } })
+    ).rejects.toThrow('please set image!');
+  });
+});

--- a/src/__tests__/web-marker-api.test.ts
+++ b/src/__tests__/web-marker-api.test.ts
@@ -38,6 +38,24 @@ describe('WebMarker public API', () => {
     );
   });
 
+  it('creates reusable Web recipes through the public Marker API', async () => {
+    const recipe = WebMarker.createRecipe({
+      watermarks: [{ type: 'text', text: 'Reusable' }],
+      saveFormat: 'png' as ImageMarkOptions['saveFormat'],
+    });
+
+    await expect(
+      recipe.apply({ backgroundImage: { src: '/background.jpg' } })
+    ).resolves.toBe('data:image/png;base64,result');
+    expect(mockRenderWebComposition).toHaveBeenCalledTimes(1);
+    expect(mockRenderWebComposition.mock.calls[0]?.[1]).toEqual([
+      {
+        type: 'text',
+        options: expect.objectContaining({ type: 'text', text: 'Reusable' }),
+      },
+    ]);
+  });
+
   it('keeps image arrays before the legacy image compatibility layer', async () => {
     const options: ImageMarkOptions = {
       backgroundImage: { src: '/background.jpg' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import Marker from './marker';
 
+export type {
+  WatermarkRecipe,
+  WatermarkRecipeInput,
+  WatermarkRecipeOptions,
+} from './recipe';
+
 /**
  * Position enum for text watermark and image watermark
  * @enum

--- a/src/marker.native.ts
+++ b/src/marker.native.ts
@@ -7,6 +7,8 @@ import {
   normalizeTextMarkOptions,
 } from './normalize';
 import type { ImageMarkOptions, MarkOptions, TextMarkOptions } from './index';
+import { createWatermarkRecipe } from './recipe';
+import type { WatermarkRecipe, WatermarkRecipeOptions } from './recipe';
 import {
   validateImageMarkOptions,
   validateMarkOptions,
@@ -34,6 +36,13 @@ function getImageMarker(): Spec {
 
 /** Native iOS and Android implementation of the public Marker API. */
 class Marker {
+  /** Save ordered layers and output settings for reuse across one or many images. */
+  static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
+    return createWatermarkRecipe(options, (markOptions) =>
+      Marker.mark(markOptions)
+    );
+  }
+
   /** Mark text-only watermarks on an image. */
   static markText(options: TextMarkOptions): Promise<string> {
     const { backgroundImage, watermarkTexts } = options;

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -1,0 +1,214 @@
+import type {
+  CornerRadius,
+  ImageOptions,
+  MarkOptions,
+  PositionOptions,
+  TextBackgroundStyle,
+  TextStyle,
+  WatermarkLayer,
+  WatermarkLayout,
+} from './index';
+import { validateMarkOptions } from './validate';
+
+export type WatermarkRecipeOptions = Omit<
+  MarkOptions,
+  | 'backgroundImage'
+  | 'filename'
+  | 'watermarks'
+  | 'watermarkTexts'
+  | 'watermarkImage'
+  | 'watermarkPositions'
+  | 'watermarkImages'
+> & {
+  /** Ordered layers reused for every input image. */
+  watermarks: readonly WatermarkLayer[];
+};
+
+export interface WatermarkRecipeInput {
+  /** Source image processed by this recipe invocation. */
+  backgroundImage: ImageOptions;
+  /** Optional output basename for this input. */
+  filename?: string;
+}
+
+export interface WatermarkRecipe<Result = string> {
+  /** Apply the saved layers and output settings to one source image. */
+  apply(input: WatermarkRecipeInput): Promise<Result>;
+}
+
+type RecipeRenderer<Result> = (options: MarkOptions) => Promise<Result>;
+
+function clonePosition(
+  position: PositionOptions | undefined
+): PositionOptions | undefined {
+  return position ? { ...position } : position;
+}
+
+function cloneLayout(
+  layout: WatermarkLayout | undefined
+): WatermarkLayout | undefined {
+  return layout ? { ...layout } : layout;
+}
+
+function cloneCornerRadius(
+  cornerRadius: CornerRadius | undefined
+): CornerRadius | undefined {
+  if (!cornerRadius) {
+    return cornerRadius;
+  }
+  return {
+    topLeft: cornerRadius.topLeft ? { ...cornerRadius.topLeft } : undefined,
+    topRight: cornerRadius.topRight ? { ...cornerRadius.topRight } : undefined,
+    bottomLeft: cornerRadius.bottomLeft
+      ? { ...cornerRadius.bottomLeft }
+      : undefined,
+    bottomRight: cornerRadius.bottomRight
+      ? { ...cornerRadius.bottomRight }
+      : undefined,
+    all: cornerRadius.all ? { ...cornerRadius.all } : undefined,
+  };
+}
+
+function cloneTextBackgroundStyle(
+  style: TextBackgroundStyle | null | undefined
+): TextBackgroundStyle | null | undefined {
+  if (!style) {
+    return style;
+  }
+  return {
+    ...style,
+    cornerRadius: cloneCornerRadius(style.cornerRadius),
+  };
+}
+
+function cloneTextStyle(style: TextStyle | undefined): TextStyle | undefined {
+  if (!style) {
+    return style;
+  }
+  return {
+    ...style,
+    shadowStyle: style.shadowStyle
+      ? { ...style.shadowStyle }
+      : style.shadowStyle,
+    strokeStyle: style.strokeStyle
+      ? { ...style.strokeStyle }
+      : style.strokeStyle,
+    textBackgroundStyle: cloneTextBackgroundStyle(style.textBackgroundStyle),
+  };
+}
+
+function cloneLayers(layers: readonly WatermarkLayer[]): WatermarkLayer[] {
+  return layers.map((layer) => {
+    if (layer.type === 'text') {
+      return {
+        ...layer,
+        position: clonePosition(layer.position),
+        positionOptions: clonePosition(layer.positionOptions),
+        layout: cloneLayout(layer.layout),
+        style: cloneTextStyle(layer.style),
+      };
+    }
+    return {
+      ...layer,
+      position: clonePosition(layer.position),
+      layout: cloneLayout(layer.layout),
+    };
+  });
+}
+
+function snapshotRecipeOptions(options: WatermarkRecipeOptions): MarkOptions {
+  if (!options || !Array.isArray(options.watermarks)) {
+    throw new Error('createRecipe requires an ordered watermarks array.');
+  }
+  const runtimeOptions = options as WatermarkRecipeOptions &
+    Record<string, unknown>;
+  const unsupportedKey = [
+    'backgroundImage',
+    'filename',
+    'watermarkTexts',
+    'watermarkImage',
+    'watermarkPositions',
+    'watermarkImages',
+  ].find((key) => Object.prototype.hasOwnProperty.call(runtimeOptions, key));
+  if (unsupportedKey) {
+    throw new Error(
+      `createRecipe does not accept "${unsupportedKey}"; use ordered watermarks and pass per-image fields to apply().`
+    );
+  }
+  if (options.watermarks.length === 0) {
+    throw new Error('createRecipe requires at least one watermark layer.');
+  }
+  for (const layer of options.watermarks) {
+    if (
+      !layer ||
+      typeof layer !== 'object' ||
+      (layer.type !== 'text' && layer.type !== 'image')
+    ) {
+      throw new Error('watermark type must be either "text" or "image".');
+    }
+    if (layer.type === 'text' && typeof layer.text !== 'string') {
+      throw new Error('text is required.');
+    }
+    if (layer.type === 'image' && !layer.src) {
+      throw new Error('please set mark image!');
+    }
+  }
+
+  const snapshot: MarkOptions = {
+    backgroundImage: { src: 'recipe-validation-placeholder' },
+    watermarks: cloneLayers(options.watermarks),
+  };
+  if (options.quality !== undefined) snapshot.quality = options.quality;
+  if (options.saveFormat !== undefined)
+    snapshot.saveFormat = options.saveFormat;
+  if (options.matteColor !== undefined)
+    snapshot.matteColor = options.matteColor;
+  if (options.rotationCanvasMode !== undefined) {
+    snapshot.rotationCanvasMode = options.rotationCanvasMode;
+  }
+  if (options.maxSize !== undefined) snapshot.maxSize = options.maxSize;
+
+  validateMarkOptions(snapshot);
+  return snapshot;
+}
+
+function snapshotInput(input: WatermarkRecipeInput): WatermarkRecipeInput {
+  return {
+    backgroundImage: input?.backgroundImage
+      ? { ...input.backgroundImage }
+      : input?.backgroundImage,
+    filename: input?.filename,
+  };
+}
+
+function createMarkOptions(
+  recipe: MarkOptions,
+  input: WatermarkRecipeInput
+): MarkOptions {
+  return {
+    ...recipe,
+    backgroundImage: { ...input.backgroundImage },
+    watermarks: cloneLayers(recipe.watermarks ?? []),
+    filename: input.filename,
+  };
+}
+
+export function createWatermarkRecipe<Result>(
+  options: WatermarkRecipeOptions,
+  renderer: RecipeRenderer<Result>
+): WatermarkRecipe<Result> {
+  const recipe = snapshotRecipeOptions(options);
+
+  const applySnapshot = (input: WatermarkRecipeInput): Promise<Result> => {
+    if (!input?.backgroundImage?.src) {
+      return Promise.reject(new Error('please set image!'));
+    }
+    return renderer(createMarkOptions(recipe, input));
+  };
+
+  return {
+    apply(input) {
+      return applySnapshot(snapshotInput(input));
+    },
+  };
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -6,6 +6,8 @@ import type {
   WatermarkImageOptions,
   WatermarkLayer,
 } from '../index';
+import { createWatermarkRecipe } from '../recipe';
+import type { WatermarkRecipe, WatermarkRecipeOptions } from '../recipe';
 import { renderWebComposition } from './renderer';
 import type { WebRenderLayer } from './renderer';
 import {
@@ -62,6 +64,13 @@ function appendCompatibilityLayers(
  * 2D implementation, which only touches DOM globals when a method is called.
  */
 class Marker {
+  /** Save ordered layers and output settings for reuse across one or many images. */
+  static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
+    return createWatermarkRecipe(options, (markOptions) =>
+      Marker.mark(markOptions)
+    );
+  }
+
   /** Render one or more text watermark layers. */
   static async markText(options: TextMarkOptions): Promise<string> {
     if (!options?.backgroundImage?.src) {


### PR DESCRIPTION
## Summary
- add `Marker.createRecipe()` for reusable ordered watermark layers
- snapshot recipe and input options to avoid mutation races
- expose single-image `apply()` with native and Web parity

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run typecheck:expo-example