### PR TITLE
feat: add controlled watermark batches

### DIFF
--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -1,0 +1,234 @@
+import { ImageFormat, type MarkOptions } from '../index';
+import {
+  createWatermarkRecipe,
+  type WatermarkBatchProgress,
+  type WatermarkRecipeOptions,
+} from '../recipe';
+
+const textRecipe: WatermarkRecipeOptions = {
+  watermarks: [{ type: 'text', text: 'CONFIDENTIAL' }],
+  saveFormat: ImageFormat.jpg,
+};
+
+describe('watermark recipe batches', () => {
+  it('runs serially by default and respects the Web concurrency cap', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const renderer = async (options: MarkOptions) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return String(options.backgroundImage.src);
+    };
+    const recipe = createWatermarkRecipe(textRecipe, renderer, 4);
+    const inputs = Array.from({ length: 10 }, (_, index) => ({
+      backgroundImage: { src: `image-${index}` },
+    }));
+
+    const serial = await recipe.applyMany(inputs);
+    expect(maximumActive).toBe(1);
+    expect(serial).toHaveLength(10);
+    expect(serial.every((result) => result.status === 'fulfilled')).toBe(true);
+
+    maximumActive = 0;
+    const concurrent = await recipe.applyMany(inputs.slice(0, 8), {
+      concurrency: 20,
+    });
+    expect(maximumActive).toBe(4);
+    expect(concurrent).toHaveLength(8);
+  });
+
+  it('caps native recipes at one active render', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const recipe = createWatermarkRecipe(
+      textRecipe,
+      async () => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        active -= 1;
+        return 'done';
+      },
+      1
+    );
+
+    await recipe.applyMany(
+      [1, 2, 3].map((value) => ({ backgroundImage: { src: value } })),
+      { concurrency: 3 }
+    );
+    expect(maximumActive).toBe(1);
+  });
+
+  it('keeps input order, isolates failures, and reports progress counts', async () => {
+    const progress: Array<WatermarkBatchProgress<string>> = [];
+    const recipe = createWatermarkRecipe(
+      textRecipe,
+      async (options) => {
+        const source = String(options.backgroundImage.src);
+        await new Promise((resolve) =>
+          setTimeout(resolve, source === 'slow' ? 12 : 1)
+        );
+        if (source === 'broken') {
+          throw new Error('decode failed');
+        }
+        return `done:${source}`;
+      },
+      4
+    );
+
+    const results = await recipe.applyMany(
+      ['slow', 'broken', 'fast'].map((src) => ({ backgroundImage: { src } })),
+      { concurrency: 3, onProgress: (event) => progress.push(event) }
+    );
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 'done:slow' });
+    expect(results[1]).toEqual({
+      status: 'rejected',
+      reason: expect.objectContaining({ message: 'decode failed' }),
+    });
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 'done:fast' });
+    expect(progress.map((event) => event.index).sort()).toEqual([0, 1, 2]);
+    expect(progress.at(-1)).toEqual(
+      expect.objectContaining({
+        total: 3,
+        settled: 3,
+        succeeded: 2,
+        failed: 1,
+        aborted: 0,
+      })
+    );
+  });
+
+  it('stops dispatching after abort while allowing running work to finish', async () => {
+    const controller = new AbortController();
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+    const progress: Array<WatermarkBatchProgress<string>> = [];
+    const recipe = createWatermarkRecipe(
+      textRecipe,
+      async (options) => {
+        started.push(String(options.backgroundImage.src));
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return String(options.backgroundImage.src);
+      },
+      4
+    );
+
+    const batch = recipe.applyMany(
+      ['one', 'two', 'three', 'four'].map((src) => ({
+        backgroundImage: { src },
+      })),
+      {
+        concurrency: 2,
+        signal: controller.signal,
+        onProgress: (event) => progress.push(event),
+      }
+    );
+    await Promise.resolve();
+    expect(started).toEqual(['one', 'two']);
+    controller.abort();
+    releases.forEach((release) => release());
+
+    const results = await batch;
+    expect(results.map((result) => result.status)).toEqual([
+      'fulfilled',
+      'fulfilled',
+      'aborted',
+      'aborted',
+    ]);
+    expect(progress.at(-1)).toEqual(
+      expect.objectContaining({
+        settled: 4,
+        succeeded: 2,
+        failed: 0,
+        aborted: 2,
+      })
+    );
+  });
+
+  it('returns all items as aborted without dispatch when already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const renderer = jest.fn<Promise<string>, [MarkOptions]>(
+      async () => 'done'
+    );
+    const recipe = createWatermarkRecipe(textRecipe, renderer, 4);
+
+    const results = await recipe.applyMany(
+      [1, 2, 3].map((src) => ({ backgroundImage: { src } })),
+      { concurrency: 3, signal: controller.signal }
+    );
+
+    expect(results.map((result) => result.status)).toEqual([
+      'aborted',
+      'aborted',
+      'aborted',
+    ]);
+    expect(renderer).not.toHaveBeenCalled();
+  });
+
+  it('snapshots queued inputs before serial dispatch', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const recipe = createWatermarkRecipe(
+      textRecipe,
+      async (options) => {
+        const source = String(options.backgroundImage.src);
+        if (source === 'first') await firstGate;
+        return source;
+      },
+      4
+    );
+    const inputs = [
+      { backgroundImage: { src: 'first' } },
+      { backgroundImage: { src: 'second-before' } },
+    ];
+
+    const batch = recipe.applyMany(inputs);
+    inputs[1]!.backgroundImage.src = 'second-after';
+    releaseFirst?.();
+
+    await expect(batch).resolves.toEqual([
+      { status: 'fulfilled', value: 'first' },
+      { status: 'fulfilled', value: 'second-before' },
+    ]);
+  });
+
+  it('preflights canonical filename collisions before rendering', async () => {
+    const renderer = jest.fn<Promise<string>, [MarkOptions]>(
+      async () => 'done'
+    );
+    const recipe = createWatermarkRecipe(textRecipe, renderer, 4);
+
+    await expect(
+      recipe.applyMany([
+        { backgroundImage: { src: 'one' }, filename: 'photo' },
+        { backgroundImage: { src: 'two' }, filename: 'PHOTO.png' },
+      ])
+    ).rejects.toThrow(
+      'Duplicate output filename "photo.jpg" for inputs 0 and 1.'
+    );
+    expect(renderer).not.toHaveBeenCalled();
+  });
+
+  it('validates concurrency and isolates progress callback errors', async () => {
+    const recipe = createWatermarkRecipe(textRecipe, async () => 'done', 4);
+
+    await expect(
+      recipe.applyMany([{ backgroundImage: { src: 'one' } }], {
+        concurrency: 1.5,
+      })
+    ).rejects.toThrow('concurrency must be a positive finite integer.');
+    await expect(
+      recipe.applyMany([{ backgroundImage: { src: 'one' } }], {
+        onProgress() {
+          throw new Error('observer failed');
+        },
+      })
+    ).resolves.toEqual([{ status: 'fulfilled', value: 'done' }]);
+  });
+});

--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -68,3 +68,23 @@ export const reusableRecipe: WatermarkRecipe = Marker.createRecipe({
   ],
   saveFormat: ImageFormat.jpg,
 });
+
+export const recipeBatch = reusableRecipe.applyMany(
+  [
+    {
+      backgroundImage: { src: 'file:///tmp/one.jpg' },
+      filename: 'one',
+    },
+    {
+      backgroundImage: { src: 'file:///tmp/two.jpg' },
+      filename: 'two',
+    },
+  ],
+  {
+    concurrency: 2,
+    onProgress(progress) {
+      const settled: number = progress.settled;
+      settled.toFixed(0);
+    },
+  }
+);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -83,6 +83,33 @@ describe('Marker JS wrapper', () => {
     );
   });
 
+  it('keeps public native recipe batches serial', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    nativeModule.markWithWatermarks.mockImplementation(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return '/tmp/recipe.jpg';
+    });
+    const recipe = Marker.createRecipe({
+      watermarks: [{ type: 'text', text: 'Reusable' }],
+    });
+
+    const results = await recipe.applyMany(
+      [1, 2, 3].map((src) => ({ backgroundImage: { src } })),
+      { concurrency: 3 }
+    );
+
+    expect(maximumActive).toBe(1);
+    expect(
+      results.every(
+        (result: { status: string }) => result.status === 'fulfilled'
+      )
+    ).toBe(true);
+  });
+
   it('normalizes markText options before calling the native module', async () => {
     nativeModule.markWithText.mockResolvedValue('/tmp/text.png');
     const options = {

--- a/src/__tests__/web-marker-api.test.ts
+++ b/src/__tests__/web-marker-api.test.ts
@@ -56,6 +56,30 @@ describe('WebMarker public API', () => {
     ]);
   });
 
+  it('caps public Web recipe batches at four active renders', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    mockRenderWebComposition.mockImplementation(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return 'data:image/png;base64,result';
+    });
+    const recipe = WebMarker.createRecipe({
+      watermarks: [{ type: 'text', text: 'Reusable' }],
+    });
+
+    await recipe.applyMany(
+      Array.from({ length: 8 }, (_, index) => ({
+        backgroundImage: { src: `/background-${index}.jpg` },
+      })),
+      { concurrency: 8 }
+    );
+
+    expect(maximumActive).toBe(4);
+  });
+
   it('keeps image arrays before the legacy image compatibility layer', async () => {
     const options: ImageMarkOptions = {
       backgroundImage: { src: '/background.jpg' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import Marker from './marker';
 
 export type {
+  WatermarkBatchAbortedResult,
+  WatermarkBatchFulfilledResult,
+  WatermarkBatchOptions,
+  WatermarkBatchProgress,
+  WatermarkBatchRejectedResult,
+  WatermarkBatchResult,
   WatermarkRecipe,
   WatermarkRecipeInput,
   WatermarkRecipeOptions,

--- a/src/marker.native.ts
+++ b/src/marker.native.ts
@@ -38,8 +38,10 @@ function getImageMarker(): Spec {
 class Marker {
   /** Save ordered layers and output settings for reuse across one or many images. */
   static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
-    return createWatermarkRecipe(options, (markOptions) =>
-      Marker.mark(markOptions)
+    return createWatermarkRecipe(
+      options,
+      (markOptions) => Marker.mark(markOptions),
+      1
     );
   }
 

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -31,9 +31,54 @@ export interface WatermarkRecipeInput {
   filename?: string;
 }
 
+export interface WatermarkBatchFulfilledResult<Result> {
+  status: 'fulfilled';
+  value: Result;
+}
+
+export interface WatermarkBatchRejectedResult {
+  status: 'rejected';
+  reason: unknown;
+}
+
+export interface WatermarkBatchAbortedResult {
+  status: 'aborted';
+  reason: Error;
+}
+
+export type WatermarkBatchResult<Result> =
+  | WatermarkBatchFulfilledResult<Result>
+  | WatermarkBatchRejectedResult
+  | WatermarkBatchAbortedResult;
+
+export interface WatermarkBatchProgress<Result> {
+  total: number;
+  settled: number;
+  succeeded: number;
+  failed: number;
+  aborted: number;
+  /** Index of the item that produced this progress update. */
+  index: number;
+  result: WatermarkBatchResult<Result>;
+}
+
+export interface WatermarkBatchOptions<Result> {
+  /** Requested worker count. Web is capped at 4 and native targets at 1. */
+  concurrency?: number;
+  /** Stops new items from starting. Already-running items are allowed to finish. */
+  signal?: AbortSignal;
+  /** Called once when each item is fulfilled, rejected, or skipped after abort. */
+  onProgress?: (progress: WatermarkBatchProgress<Result>) => void;
+}
+
 export interface WatermarkRecipe<Result = string> {
   /** Apply the saved layers and output settings to one source image. */
   apply(input: WatermarkRecipeInput): Promise<Result>;
+  /** Apply the recipe to many images while preserving input result order. */
+  applyMany(
+    inputs: readonly WatermarkRecipeInput[],
+    options?: WatermarkBatchOptions<Result>
+  ): Promise<Array<WatermarkBatchResult<Result>>>;
 }
 
 type RecipeRenderer<Result> = (options: MarkOptions) => Promise<Result>;
@@ -193,9 +238,62 @@ function createMarkOptions(
   };
 }
 
+function canonicalOutputFilename(
+  filename: string,
+  saveFormat: MarkOptions['saveFormat']
+): string | undefined {
+  const trimmed = filename.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const knownExtension = ['.jpeg', '.jpg', '.png'].find((extension) =>
+    trimmed.toLowerCase().endsWith(extension)
+  );
+  const stem = knownExtension
+    ? trimmed.slice(0, -knownExtension.length)
+    : trimmed;
+  const extension = saveFormat === 'png' ? '.png' : '.jpg';
+  return `${stem}${extension}`.toLowerCase();
+}
+
+function validateUniqueFilenames(
+  inputs: readonly WatermarkRecipeInput[],
+  saveFormat: MarkOptions['saveFormat']
+): void {
+  const seen = new Map<string, number>();
+  inputs.forEach((input, index) => {
+    if (input.filename === undefined) {
+      return;
+    }
+    if (typeof input.filename !== 'string') {
+      throw new Error(`inputs[${index}].filename must be a string.`);
+    }
+    const canonical = canonicalOutputFilename(input.filename, saveFormat);
+    if (!canonical) {
+      return;
+    }
+    const previousIndex = seen.get(canonical);
+    if (previousIndex !== undefined) {
+      throw new Error(
+        `Duplicate output filename "${canonical}" for inputs ${previousIndex} and ${index}.`
+      );
+    }
+    seen.set(canonical, index);
+  });
+}
+
+function abortResult<Result>(): WatermarkBatchResult<Result> {
+  const reason = new Error(
+    'Batch item was not started because the operation was aborted.'
+  );
+  reason.name = 'AbortError';
+  return { status: 'aborted', reason };
+}
+
 export function createWatermarkRecipe<Result>(
   options: WatermarkRecipeOptions,
-  renderer: RecipeRenderer<Result>
+  renderer: RecipeRenderer<Result>,
+  maximumConcurrency = 1
 ): WatermarkRecipe<Result> {
   const recipe = snapshotRecipeOptions(options);
 
@@ -209,6 +307,99 @@ export function createWatermarkRecipe<Result>(
   return {
     apply(input) {
       return applySnapshot(snapshotInput(input));
+    },
+
+    async applyMany(inputs, batchOptions = {}) {
+      if (!Array.isArray(inputs)) {
+        throw new Error('applyMany inputs must be an array.');
+      }
+      const requestedConcurrency = batchOptions.concurrency ?? 1;
+      if (
+        !Number.isFinite(requestedConcurrency) ||
+        !Number.isInteger(requestedConcurrency) ||
+        requestedConcurrency <= 0
+      ) {
+        throw new Error('concurrency must be a positive finite integer.');
+      }
+
+      const queuedInputs = inputs.map(snapshotInput);
+      validateUniqueFilenames(queuedInputs, recipe.saveFormat);
+      if (queuedInputs.length === 0) {
+        return [];
+      }
+
+      const concurrency = Math.min(
+        requestedConcurrency,
+        maximumConcurrency,
+        queuedInputs.length
+      );
+      const results: Array<WatermarkBatchResult<Result> | undefined> =
+        new Array(queuedInputs.length);
+      let cursor = 0;
+      let settled = 0;
+      let succeeded = 0;
+      let failed = 0;
+      let aborted = 0;
+
+      const report = (
+        index: number,
+        result: WatermarkBatchResult<Result>
+      ): void => {
+        settled += 1;
+        if (result.status === 'fulfilled') succeeded += 1;
+        else if (result.status === 'rejected') failed += 1;
+        else aborted += 1;
+        try {
+          batchOptions.onProgress?.({
+            total: queuedInputs.length,
+            settled,
+            succeeded,
+            failed,
+            aborted,
+            index,
+            result,
+          });
+        } catch {
+          // Progress observers must not interrupt the batch or change results.
+        }
+      };
+
+      const worker = async (): Promise<void> => {
+        while (!batchOptions.signal?.aborted) {
+          const index = cursor;
+          cursor += 1;
+          if (index >= queuedInputs.length) {
+            return;
+          }
+          const input = queuedInputs[index];
+          if (!input) {
+            return;
+          }
+          let result: WatermarkBatchResult<Result>;
+          try {
+            result = {
+              status: 'fulfilled',
+              value: await applySnapshot(input),
+            };
+          } catch (reason) {
+            result = { status: 'rejected', reason };
+          }
+          results[index] = result;
+          report(index, result);
+        }
+      };
+
+      await Promise.all(Array.from({ length: concurrency }, worker));
+
+      for (let index = 0; index < queuedInputs.length; index += 1) {
+        if (!results[index]) {
+          const result = abortResult<Result>();
+          results[index] = result;
+          report(index, result);
+        }
+      }
+
+      return results as Array<WatermarkBatchResult<Result>>;
     },
   };
 }

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -66,8 +66,10 @@ function appendCompatibilityLayers(
 class Marker {
   /** Save ordered layers and output settings for reuse across one or many images. */
   static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
-    return createWatermarkRecipe(options, (markOptions) =>
-      Marker.mark(markOptions)
+    return createWatermarkRecipe(
+      options,
+      (markOptions) => Marker.mark(markOptions),
+      4
     );
   }
 


### PR DESCRIPTION
## Summary
- add ordered `applyMany()` results with per-item failure isolation
- enforce Web/native concurrency caps and reject duplicate output filenames before work starts
- report progress and support cooperative AbortSignal cancellation without interrupting active native renders

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm test -- --coverage --runInBand