### PR TITLE
feat(web): add blob recipe output

### DIFF
--- a/expo-example/scripts/smoke-web.mjs
+++ b/expo-example/scripts/smoke-web.mjs
@@ -147,13 +147,21 @@ async function verifyBrowser(browserName, browserType) {
     const harnessResults = await page.evaluate(async (crossOriginUrl) => {
       const harness = window.__IMAGE_MARKER_SMOKE__;
       if (!harness) throw new Error('Web smoke harness was not installed.');
-      const [blobAndFile, largeCropped, tiledLayers] = await Promise.all([
-        harness.renderBlobAndFile(),
-        harness.renderLargeCropped(),
-        harness.renderTiledLayers(),
-      ]);
+      const [blobAndFile, recipeBlobs, largeCropped, tiledLayers] =
+        await Promise.all([
+          harness.renderBlobAndFile(),
+          harness.renderRecipeBlobs(),
+          harness.renderLargeCropped(),
+          harness.renderTiledLayers(),
+        ]);
       const corsMessage = await harness.renderCrossOrigin(crossOriginUrl);
-      return { blobAndFile, largeCropped, tiledLayers, corsMessage };
+      return {
+        blobAndFile,
+        recipeBlobs,
+        largeCropped,
+        tiledLayers,
+        corsMessage,
+      };
     }, `http://127.0.0.1:${crossOriginAddress.port}/fixture.jpeg`);
 
     assert.match(
@@ -162,6 +170,10 @@ async function verifyBrowser(browserName, browserType) {
     );
     assert(harnessResults.blobAndFile.width > 0);
     assert(harnessResults.blobAndFile.height > 0);
+    assert.equal(harnessResults.recipeBlobs.pngType, 'image/png');
+    assert.equal(harnessResults.recipeBlobs.jpegType, 'image/jpeg');
+    assert(harnessResults.recipeBlobs.pngSize > 1_000);
+    assert(harnessResults.recipeBlobs.jpegSize > 1_000);
     assert.deepEqual(
       {
         width: harnessResults.largeCropped.width,
@@ -192,7 +204,7 @@ async function verifyBrowser(browserName, browserType) {
     );
 
     console.log(
-      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, JPG/PNG, Blob/File, CORS, rotation crop, alpha, and 4096px max-size rendering.`
+      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, JPG/PNG, Blob/File, Blob recipe output, CORS, rotation crop, alpha, and 4096px max-size rendering.`
     );
   } finally {
     await browser.close();

--- a/expo-example/smoke-harness.web.ts
+++ b/expo-example/smoke-harness.web.ts
@@ -17,6 +17,12 @@ interface ImageResult {
 
 interface WebSmokeHarness {
   renderBlobAndFile(): Promise<ImageResult>;
+  renderRecipeBlobs(): Promise<{
+    pngType: string;
+    pngSize: number;
+    jpegType: string;
+    jpegSize: number;
+  }>;
   renderLargeCropped(): Promise<ImageResult>;
   renderTiledLayers(): Promise<ImageResult>;
   renderCrossOrigin(url: string): Promise<string>;
@@ -102,6 +108,42 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
         saveFormat: ImageFormat.png,
       });
       return getDimensions(dataUrl);
+    },
+
+    async renderRecipeBlobs() {
+      const commonOptions = {
+        watermarks: [
+          {
+            type: 'text' as const,
+            text: 'BLOB RECIPE',
+            position: { position: Position.bottomRight, X: 24, Y: 24 },
+            style: {
+              color: '#FFFFFF',
+              fontSize: 32,
+              bold: true,
+              strokeStyle: { color: '#111827', width: 2 },
+            },
+          },
+        ],
+      };
+      const pngRecipe = Marker.createRecipe(
+        { ...commonOptions, saveFormat: ImageFormat.png },
+        { resultType: 'blob' }
+      );
+      const jpegRecipe = Marker.createRecipe(
+        { ...commonOptions, saveFormat: ImageFormat.jpg, quality: 86 },
+        { resultType: 'blob' }
+      );
+      const [png, jpeg] = await Promise.all([
+        pngRecipe.apply({ backgroundImage: { src: assets.backgroundUri } }),
+        jpegRecipe.apply({ backgroundImage: { src: assets.backgroundUri } }),
+      ]);
+      return {
+        pngType: png.type,
+        pngSize: png.size,
+        jpegType: jpeg.type,
+        jpegSize: jpeg.size,
+      };
     },
 
     async renderLargeCropped() {

--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -69,6 +69,14 @@ export const reusableRecipe: WatermarkRecipe = Marker.createRecipe({
   saveFormat: ImageFormat.jpg,
 });
 
+export const reusableBlobRecipe: WatermarkRecipe<Blob> = Marker.createRecipe(
+  {
+    watermarks: [{ type: 'text', text: 'Reusable Web bytes' }],
+    saveFormat: ImageFormat.png,
+  },
+  { resultType: 'blob' }
+);
+
 export const recipeBatch = reusableRecipe.applyMany(
   [
     {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -83,6 +83,15 @@ describe('Marker JS wrapper', () => {
     );
   });
 
+  it('rejects Web-only Blob recipe output on native targets', () => {
+    expect(() =>
+      Marker.createRecipe(
+        { watermarks: [{ type: 'text', text: 'Reusable' }] },
+        { resultType: 'blob' }
+      )
+    ).toThrow('Blob recipe output is only supported on Web.');
+  });
+
   it('keeps public native recipe batches serial', async () => {
     let active = 0;
     let maximumActive = 0;

--- a/src/__tests__/web-marker-api.test.ts
+++ b/src/__tests__/web-marker-api.test.ts
@@ -1,10 +1,21 @@
 import type { ImageMarkOptions, MarkOptions, TextMarkOptions } from '../index';
 
 const mockRenderWebComposition = jest.fn<Promise<string>, unknown[]>();
+const mockRenderWebCompositionToCanvas = jest.fn<
+  Promise<{
+    width: number;
+    height: number;
+    toDataURL: jest.Mock;
+    toBlob: jest.Mock;
+  }>,
+  unknown[]
+>();
 
 jest.mock('../web/renderer', () => ({
   renderWebComposition: (...args: unknown[]) =>
     mockRenderWebComposition(...args),
+  renderWebCompositionToCanvas: (...args: unknown[]) =>
+    mockRenderWebCompositionToCanvas(...args),
 }));
 
 const WebMarker = require('../web').default as typeof import('../web').default;
@@ -13,6 +24,15 @@ describe('WebMarker public API', () => {
   beforeEach(() => {
     mockRenderWebComposition.mockReset();
     mockRenderWebComposition.mockResolvedValue('data:image/png;base64,result');
+    mockRenderWebCompositionToCanvas.mockReset();
+    mockRenderWebCompositionToCanvas.mockResolvedValue({
+      width: 100,
+      height: 50,
+      toDataURL: jest.fn(),
+      toBlob: jest.fn((callback, type = 'image/png') =>
+        callback(new Blob(['blob-result'], { type }))
+      ),
+    });
   });
 
   it('maps markText options to ordered web text layers', async () => {
@@ -54,6 +74,35 @@ describe('WebMarker public API', () => {
         options: expect.objectContaining({ type: 'text', text: 'Reusable' }),
       },
     ]);
+  });
+
+  it('returns encoded bytes only for explicitly requested Blob recipes', async () => {
+    const recipe = WebMarker.createRecipe(
+      {
+        watermarks: [{ type: 'text', text: 'Reusable' }],
+        saveFormat: 'jpg' as ImageMarkOptions['saveFormat'],
+        quality: 84,
+      },
+      { resultType: 'blob' }
+    );
+
+    const result = await recipe.apply({
+      backgroundImage: { src: '/background.jpg' },
+    });
+
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe('image/jpeg');
+    expect(mockRenderWebComposition).not.toHaveBeenCalled();
+    expect(mockRenderWebCompositionToCanvas).toHaveBeenCalledWith(
+      { src: '/background.jpg' },
+      [
+        {
+          type: 'text',
+          options: expect.objectContaining({ type: 'text', text: 'Reusable' }),
+        },
+      ],
+      expect.objectContaining({ quality: 84, saveFormat: 'jpg' })
+    );
   });
 
   it('caps public Web recipe batches at four active renders', async () => {

--- a/src/__tests__/web-marker-render.test.ts
+++ b/src/__tests__/web-marker-render.test.ts
@@ -36,6 +36,10 @@ function createFakeCanvas() {
     width: 0,
     height: 0,
     toDataURL: jest.fn((type = 'image/png') => `data:${type};base64,rendered`),
+    toBlob: jest.fn(
+      (callback: (blob: Blob | null) => void, type = 'image/png') =>
+        callback(new Blob(['rendered'], { type }))
+    ),
     getContext: jest.fn(),
   };
   const context = {

--- a/src/__tests__/web-marker.test.ts
+++ b/src/__tests__/web-marker.test.ts
@@ -1,5 +1,6 @@
 import {
   encodeCanvas,
+  encodeCanvasToBlob,
   fitSizeWithinMax,
   getExpandedCanvasSize,
   getRotatedBounds,
@@ -127,6 +128,95 @@ describe('WebMarker pure helpers', () => {
       'data:image/png;base64,abc'
     );
     expect(canvas.toDataURL).toHaveBeenCalledWith('image/png', 1);
+  });
+
+  it('encodes PNG and JPEG recipes as browser Blobs', async () => {
+    const canvas = {
+      width: 100,
+      height: 50,
+      toDataURL: jest.fn(),
+      toBlob: jest.fn(
+        (
+          callback: (blob: Blob | null) => void,
+          type = 'image/png',
+          _quality?: number
+        ) => callback(new Blob(['encoded'], { type }))
+      ),
+    };
+
+    await expect(encodeCanvasToBlob(canvas, 'png', undefined)).resolves.toEqual(
+      expect.objectContaining({ type: 'image/png' })
+    );
+    expect(canvas.toBlob).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      'image/png',
+      1
+    );
+
+    await expect(encodeCanvasToBlob(canvas, 'jpg', 82)).resolves.toEqual(
+      expect.objectContaining({ type: 'image/jpeg' })
+    );
+    expect(canvas.toBlob).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      'image/jpeg',
+      0.82
+    );
+  });
+
+  it('reports unsupported, failed, and unexpected Blob encoders', async () => {
+    const baseCanvas = {
+      width: 100,
+      height: 50,
+      toDataURL: jest.fn(),
+    };
+
+    await expect(encodeCanvasToBlob(baseCanvas, 'png', 100)).rejects.toThrow(
+      'does not support Canvas toBlob'
+    );
+    await expect(
+      encodeCanvasToBlob(
+        {
+          ...baseCanvas,
+          toBlob: (callback) => callback(null),
+        },
+        'png',
+        100
+      )
+    ).rejects.toThrow('could not encode');
+    await expect(
+      encodeCanvasToBlob(
+        {
+          ...baseCanvas,
+          toBlob: (callback) =>
+            callback(new Blob(['wrong'], { type: 'image/webp' })),
+        },
+        'png',
+        100
+      )
+    ).rejects.toThrow('unexpected MIME type: image/webp');
+  });
+
+  it('reports tainted Blob exports as a CORS problem', async () => {
+    const securityError = Object.assign(new Error('Tainted canvases'), {
+      name: 'SecurityError',
+    });
+
+    await expect(
+      encodeCanvasToBlob(
+        {
+          width: 100,
+          height: 50,
+          toDataURL: jest.fn(),
+          toBlob: () => {
+            throw securityError;
+          },
+        },
+        'png',
+        100
+      )
+    ).rejects.toThrow(/tainted.*CORS|CORS.*tainted/i);
   });
 
   it('reports tainted canvas exports as a CORS problem', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,11 @@ export type {
   WatermarkBatchRejectedResult,
   WatermarkBatchResult,
   WatermarkRecipe,
+  WatermarkBlobRecipeResultOptions,
   WatermarkRecipeInput,
   WatermarkRecipeOptions,
+  WatermarkRecipeResultOptions,
+  WatermarkStringRecipeResultOptions,
 } from './recipe';
 
 /**

--- a/src/marker.native.ts
+++ b/src/marker.native.ts
@@ -8,7 +8,12 @@ import {
 } from './normalize';
 import type { ImageMarkOptions, MarkOptions, TextMarkOptions } from './index';
 import { createWatermarkRecipe } from './recipe';
-import type { WatermarkRecipe, WatermarkRecipeOptions } from './recipe';
+import type {
+  WatermarkBlobRecipeResultOptions,
+  WatermarkRecipe,
+  WatermarkRecipeOptions,
+  WatermarkRecipeResultOptions,
+} from './recipe';
 import {
   validateImageMarkOptions,
   validateMarkOptions,
@@ -37,12 +42,32 @@ function getImageMarker(): Spec {
 /** Native iOS and Android implementation of the public Marker API. */
 class Marker {
   /** Save ordered layers and output settings for reuse across one or many images. */
-  static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
+  static createRecipe<
+    ResultOptions extends WatermarkRecipeResultOptions | undefined = undefined
+  >(
+    options: WatermarkRecipeOptions,
+    resultOptions?: ResultOptions
+  ): WatermarkRecipe<
+    ResultOptions extends WatermarkBlobRecipeResultOptions ? Blob : string
+  > {
+    if (resultOptions?.resultType === 'blob') {
+      throw new Error('Blob recipe output is only supported on Web.');
+    }
+    if (
+      resultOptions?.resultType !== undefined &&
+      resultOptions.resultType !== 'string'
+    ) {
+      throw new Error(
+        `Unsupported recipe result type: ${resultOptions.resultType}.`
+      );
+    }
     return createWatermarkRecipe(
       options,
       (markOptions) => Marker.mark(markOptions),
       1
-    );
+    ) as WatermarkRecipe<
+      ResultOptions extends WatermarkBlobRecipeResultOptions ? Blob : string
+    >;
   }
 
   /** Mark text-only watermarks on an image. */

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -24,6 +24,20 @@ export type WatermarkRecipeOptions = Omit<
   watermarks: readonly WatermarkLayer[];
 };
 
+/** Keep the existing string result used by native paths and Web data URLs. */
+export interface WatermarkStringRecipeResultOptions {
+  resultType?: 'string';
+}
+
+/** Return encoded browser bytes without creating an object URL. Web only. */
+export interface WatermarkBlobRecipeResultOptions {
+  resultType: 'blob';
+}
+
+export type WatermarkRecipeResultOptions =
+  | WatermarkStringRecipeResultOptions
+  | WatermarkBlobRecipeResultOptions;
+
 export interface WatermarkRecipeInput {
   /** Source image processed by this recipe invocation. */
   backgroundImage: ImageOptions;

--- a/src/web/browser.ts
+++ b/src/web/browser.ts
@@ -3,6 +3,11 @@ export interface WebCanvas {
   height: number;
   getContext(contextId: '2d'): WebCanvasContext | null;
   toDataURL(type?: string, quality?: number): string;
+  toBlob(
+    callback: (blob: Blob | null) => void,
+    type?: string,
+    quality?: number
+  ): void;
 }
 
 export interface WebCanvasContext {

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -19,6 +19,11 @@ export interface CanvasEncoder {
   width: number;
   height: number;
   toDataURL(type?: string, quality?: number): string;
+  toBlob?(
+    callback: (blob: Blob | null) => void,
+    type?: string,
+    quality?: number
+  ): void;
 }
 
 export type WebOutputFormat = 'png' | 'jpg' | 'base64';
@@ -280,4 +285,62 @@ export function encodeCanvas(
     }
     throw error;
   }
+}
+
+/** Encode a rendered canvas without expanding its bytes into a data URL. */
+export function encodeCanvasToBlob(
+  canvas: CanvasEncoder,
+  format: string | undefined,
+  quality: number | undefined
+): Promise<Blob> {
+  const normalizedFormat = normalizeOutputFormat(format);
+  const normalizedQuality = normalizeQuality(quality);
+  const mimeType = normalizedFormat === 'jpg' ? 'image/jpeg' : 'image/png';
+  if (typeof canvas.toBlob !== 'function') {
+    return Promise.reject(
+      new Error('This browser does not support Canvas toBlob() encoding.')
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      canvas.toBlob!(
+        (blob) => {
+          if (!blob) {
+            reject(
+              new Error('The browser could not encode the rendered canvas.')
+            );
+            return;
+          }
+          if (blob.type !== mimeType) {
+            reject(
+              new Error(
+                `The browser encoded an unexpected MIME type: ${
+                  blob.type || 'empty'
+                }.`
+              )
+            );
+            return;
+          }
+          resolve(blob);
+        },
+        mimeType,
+        normalizedQuality / 100
+      );
+    } catch (error) {
+      const errorName =
+        error && typeof error === 'object' && 'name' in error
+          ? String((error as { name?: unknown }).name)
+          : '';
+      if (errorName === 'SecurityError') {
+        reject(
+          new Error(
+            'Unable to export the canvas because an image tainted it. Configure CORS on remote images (Access-Control-Allow-Origin) or use a local file/data URL.'
+          )
+        );
+        return;
+      }
+      reject(error);
+    }
+  });
 }

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -7,9 +7,15 @@ import type {
   WatermarkLayer,
 } from '../index';
 import { createWatermarkRecipe } from '../recipe';
-import type { WatermarkRecipe, WatermarkRecipeOptions } from '../recipe';
-import { renderWebComposition } from './renderer';
+import type {
+  WatermarkBlobRecipeResultOptions,
+  WatermarkRecipe,
+  WatermarkRecipeOptions,
+  WatermarkRecipeResultOptions,
+} from '../recipe';
+import { renderWebComposition, renderWebCompositionToCanvas } from './renderer';
 import type { WebRenderLayer } from './renderer';
+import { encodeCanvasToBlob } from './helpers';
 import {
   validateImageMarkOptions,
   validateMarkOptions,
@@ -56,6 +62,28 @@ function appendCompatibilityLayers(
   }
 }
 
+function createMarkLayers(options: MarkOptions): WebRenderLayer[] {
+  if (!options?.backgroundImage?.src) {
+    throw new Error('please set image!');
+  }
+
+  const layers =
+    (options.watermarks?.length ?? 0) > 0
+      ? options.watermarks!.map(createOrderedLayer)
+      : [];
+  if (layers.length === 0) {
+    appendCompatibilityLayers(layers, options);
+  }
+  if (layers.length === 0) {
+    throw new Error('please set watermark text or image!');
+  }
+  if (layers.some((layer) => layer.type === 'image' && !layer.options.src)) {
+    throw new Error('please set mark image!');
+  }
+  validateMarkOptions(options);
+  return layers;
+}
+
 /**
  * Public image-marking API shared by native and Web targets.
  *
@@ -65,12 +93,49 @@ function appendCompatibilityLayers(
  */
 class Marker {
   /** Save ordered layers and output settings for reuse across one or many images. */
-  static createRecipe(options: WatermarkRecipeOptions): WatermarkRecipe {
+  static createRecipe<
+    ResultOptions extends WatermarkRecipeResultOptions | undefined = undefined
+  >(
+    options: WatermarkRecipeOptions,
+    resultOptions?: ResultOptions
+  ): WatermarkRecipe<
+    ResultOptions extends WatermarkBlobRecipeResultOptions ? Blob : string
+  > {
+    if (resultOptions?.resultType === 'blob') {
+      return createWatermarkRecipe(
+        options,
+        async (markOptions) => {
+          const canvas = await renderWebCompositionToCanvas(
+            markOptions.backgroundImage,
+            createMarkLayers(markOptions),
+            markOptions
+          );
+          return encodeCanvasToBlob(
+            canvas,
+            markOptions.saveFormat,
+            markOptions.quality
+          );
+        },
+        4
+      ) as WatermarkRecipe<
+        ResultOptions extends WatermarkBlobRecipeResultOptions ? Blob : string
+      >;
+    }
+    if (
+      resultOptions?.resultType !== undefined &&
+      resultOptions.resultType !== 'string'
+    ) {
+      throw new Error(
+        `Unsupported recipe result type: ${resultOptions.resultType}.`
+      );
+    }
     return createWatermarkRecipe(
       options,
       (markOptions) => Marker.mark(markOptions),
       4
-    );
+    ) as WatermarkRecipe<
+      ResultOptions extends WatermarkBlobRecipeResultOptions ? Blob : string
+    >;
   }
 
   /** Render one or more text watermark layers. */
@@ -111,26 +176,11 @@ class Marker {
 
   /** Render ordered mixed text and image watermark layers. */
   static async mark(options: MarkOptions): Promise<string> {
-    if (!options?.backgroundImage?.src) {
-      throw new Error('please set image!');
-    }
-
-    const layers =
-      (options.watermarks?.length ?? 0) > 0
-        ? options.watermarks!.map(createOrderedLayer)
-        : [];
-    if (layers.length === 0) {
-      appendCompatibilityLayers(layers, options);
-    }
-    if (layers.length === 0) {
-      throw new Error('please set watermark text or image!');
-    }
-    if (layers.some((layer) => layer.type === 'image' && !layer.options.src)) {
-      throw new Error('please set mark image!');
-    }
-    validateMarkOptions(options);
-
-    return renderWebComposition(options.backgroundImage, layers, options);
+    return renderWebComposition(
+      options.backgroundImage,
+      createMarkLayers(options),
+      options
+    );
   }
 }
 
@@ -138,6 +188,7 @@ export { Marker, Marker as WebMarker };
 export {
   degreesToRadians,
   encodeCanvas,
+  encodeCanvasToBlob,
   fitSizeWithinMax,
   getExpandedCanvasSize,
   getRotatedBounds,

--- a/src/web/renderer.ts
+++ b/src/web/renderer.ts
@@ -15,6 +15,7 @@ import {
 } from './browser';
 import type {
   LoadedWebImage,
+  WebCanvas,
   WebCanvasContext,
   WebTextMetrics,
 } from './browser';
@@ -745,12 +746,12 @@ function normalizeMatteColor(value: string | undefined): string {
   return `#${expanded.slice(0, 6).toUpperCase()}`;
 }
 
-/** Render a complete composition into a data URL. */
-export async function renderWebComposition(
+/** Render a complete composition into a browser canvas. */
+export async function renderWebCompositionToCanvas(
   backgroundImage: ImageOptions,
   layers: WebRenderLayer[],
   output: OutputOptions
-): Promise<string> {
+): Promise<WebCanvas> {
   if (!backgroundImage?.src) {
     throw new Error('please set image!');
   }
@@ -841,8 +842,22 @@ export async function renderWebComposition(
       context.restore();
     }
 
-    return encodeCanvas(canvas, format, output.quality);
+    return canvas;
   } finally {
     background.cleanup();
   }
+}
+
+/** Render a complete composition into a data URL. */
+export async function renderWebComposition(
+  backgroundImage: ImageOptions,
+  layers: WebRenderLayer[],
+  output: OutputOptions
+): Promise<string> {
+  const canvas = await renderWebCompositionToCanvas(
+    backgroundImage,
+    layers,
+    output
+  );
+  return encodeCanvas(canvas, output.saveFormat, output.quality);
 }


### PR DESCRIPTION
## Summary
- keep existing Marker methods and default Recipes returning strings
- add explicit Web-only `{ resultType: "blob" }` Recipes without creating object URLs
- split Canvas rendering from encoding and validate PNG/JPEG Blob MIME types
- reject Blob mode immediately on native targets with a clear error

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run typecheck:expo-example
- npm --prefix expo-example run bundle:web
- npm --prefix expo-example run smoke:web (Chromium, Firefox, WebKit)