### PR TITLE
feat: complete v1.8 examples and text opacity

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,6 +58,7 @@ const result = await Marker.markText({
   watermarkTexts: [
     {
       text: '© Acme Studio',
+      alpha: 0.85,
       position: {
         position: Position.bottomRight,
         X: 24,
@@ -87,6 +88,7 @@ const result = await Marker.markText({
   watermarkTexts: [
     {
       text: 'CONFIDENTIAL',
+      alpha: 0.55,
       layout: {
         type: 'tile',
         gapX: '8%',
@@ -108,6 +110,46 @@ const result = await Marker.markText({
 ```
 
 Use the same `layout` object on `watermarkImages` to repeat a logo. A tiled layer cannot also set `position`; invalid combinations fail with a clear error.
+
+### Reuse one recipe across a batch
+
+Save ordered layers once, then apply them to one image or an entire queue. Results stay in input order; one failed image does not stop the others. Native rendering stays serial, while Web can run up to four jobs at once.
+
+```ts
+const recipe = Marker.createRecipe({
+  watermarks: [
+    {
+      type: 'text',
+      text: '© Acme Studio',
+      position: { position: Position.bottomRight, X: 24, Y: 24 },
+      style: { color: '#FFFFFF', fontSize: 28 },
+    },
+  ],
+  saveFormat: ImageFormat.jpg,
+  quality: 90,
+});
+
+const controller = new AbortController();
+const results = await recipe.applyMany(
+  photos.map((src) => ({ backgroundImage: { src } })),
+  {
+    concurrency: 2,
+    signal: controller.signal,
+    onProgress: ({ settled, total }) => console.log(`${settled}/${total}`),
+  }
+);
+```
+
+On Web, request `Blob` results explicitly when processing many files without Data URL expansion:
+
+```ts
+const blobRecipe = Marker.createRecipe(recipeOptions, {
+  resultType: 'blob',
+});
+const blob = await blobRecipe.apply({ backgroundImage: { src: file } });
+```
+
+Blob mode is Web-only and does not create object URLs. The caller controls `URL.createObjectURL()` and `URL.revokeObjectURL()` when a preview is needed.
 
 ## Live Web SDK
 

--- a/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/base/TextOptions.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.assets.ReactFontManager
 import com.jimmydaddy.imagemarker.ImageProcess
 import kotlin.math.ceil
+import kotlin.math.roundToInt
 
 @Suppress("DEPRECATION")
 data class TextOptions(val options: ReadableMap) {
@@ -27,11 +28,24 @@ data class TextOptions(val options: ReadableMap) {
   private var positionEnum: PositionEnum?
   private var style: TextStyle
   private var layout: WatermarkLayout?
+  internal var alpha: Double = 1.0
+    private set
 
   init {
     try {
       if (text == null) {
         throw MarkerError(ErrorCode.PARAMS_REQUIRED, "mark text is required")
+      }
+      alpha = if (options.hasKey("alpha") && !options.isNull("alpha")) {
+        options.getDouble("alpha")
+      } else {
+        1.0
+      }
+      if (!alpha.isFinite() || alpha !in 0.0..1.0) {
+        throw MarkerError(
+          ErrorCode.INVALID_PARAMS,
+          "text alpha must be finite and between zero and one"
+        )
       }
       val positionOptions = if (options.hasKey("position") && !options.isNull("position")) {
         options.getMap("position")
@@ -87,7 +101,7 @@ data class TextOptions(val options: ReadableMap) {
         style.shadowLayerStyle!!.radius,
         style.shadowLayerStyle!!.dx,
         style.shadowLayerStyle!!.dy,
-        style.shadowLayerStyle!!.color
+        colorWithLayerAlpha(style.shadowLayerStyle!!.color)
       )
     }
 
@@ -111,7 +125,7 @@ data class TextOptions(val options: ReadableMap) {
     textPaint.isAntiAlias = true
     textPaint.textSize = textSize
     Log.i(Constants.IMAGE_MARKER_TAG, "textSize: " + textSize + " fontSize: " + style.fontSize + " displayMetrics: " + context.resources.displayMetrics)
-    textPaint.color = Color.parseColor(Utils.transRGBColor(style.color))
+    textPaint.color = colorWithLayerAlpha(Color.parseColor(Utils.transRGBColor(style.color)))
     textPaint.isUnderlineText = style.underline
     textPaint.textSkewX = style.skewX
     var typeface = Typeface.create(typefaceFamily, Typeface.NORMAL)
@@ -205,7 +219,7 @@ data class TextOptions(val options: ReadableMap) {
       if (null != style.textBackgroundStyle) {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.LINEAR_TEXT_FLAG)
         paint.style = Paint.Style.FILL
-        paint.color = style.textBackgroundStyle!!.color
+        paint.color = colorWithLayerAlpha(style.textBackgroundStyle!!.color)
         val bgInsets = style.textBackgroundStyle!!.toEdgeInsets(maxWidth, maxHeight)
         var bgRect = RectF(
           drawX - outlineInset - bgInsets.left,
@@ -250,13 +264,15 @@ data class TextOptions(val options: ReadableMap) {
             style.shadowLayerStyle!!.radius,
             style.shadowLayerStyle!!.dx,
             style.shadowLayerStyle!!.dy,
-            style.shadowLayerStyle!!.color
+            colorWithLayerAlpha(style.shadowLayerStyle!!.color)
           )
         }
         textPaint.style = Paint.Style.STROKE
         textPaint.strokeWidth = strokeWidth
         textPaint.strokeJoin = Paint.Join.ROUND
-        textPaint.color = Color.parseColor(Utils.transRGBColor(style.strokeStyle!!.color))
+        textPaint.color = colorWithLayerAlpha(
+          Color.parseColor(Utils.transRGBColor(style.strokeStyle!!.color))
+        )
         textLayout.draw(canvas)
         textPaint.clearShadowLayer()
         textPaint.style = Paint.Style.FILL
@@ -265,6 +281,11 @@ data class TextOptions(val options: ReadableMap) {
       textLayout.draw(canvas)
       canvas.restore()
     }
+  }
+
+  private fun colorWithLayerAlpha(color: Int): Int {
+    val combinedAlpha = (Color.alpha(color) * alpha).roundToInt().coerceIn(0, 255)
+    return Color.argb(combinedAlpha, Color.red(color), Color.green(color), Color.blue(color))
   }
 
   companion object {

--- a/android/src/test/java/com/jimmydaddy/imagemarker/base/TextOptionsTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/base/TextOptionsTest.kt
@@ -16,6 +16,21 @@ class TextOptionsTest {
   }
 
   @Test
+  fun parsesTextAlphaAndRejectsValuesOutsideTheUnitInterval() {
+    val options = Mockito.mock(ReadableMap::class.java)
+    Mockito.`when`(options.getString("text")).thenReturn("watermark")
+    Mockito.`when`(options.hasKey("alpha")).thenReturn(true)
+    Mockito.`when`(options.isNull("alpha")).thenReturn(false)
+    Mockito.`when`(options.getDouble("alpha")).thenReturn(0.35)
+
+    assertEquals(0.35, TextOptions(options).alpha, 0.0001)
+
+    Mockito.`when`(options.getDouble("alpha")).thenReturn(1.01)
+    val error = assertThrows(MarkerError::class.java) { TextOptions(options) }
+    assertEquals(ErrorCode.INVALID_PARAMS.value, error.getErrorCode())
+  }
+
+  @Test
   fun invalidStyleMapBecomesMarkerError() {
     val options = Mockito.mock(ReadableMap::class.java)
     Mockito.`when`(options.getString("text")).thenReturn("watermark")

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -668,6 +668,14 @@ final class ImageMarkerExampleUITests: XCTestCase {
       }
     }
 
+    XCTAssertEqual(try Utils.resolvedAlpha(0.35, fieldName: "text"), 0.35, accuracy: 0.001)
+    XCTAssertEqual(try Utils.resolvedAlpha(nil, fieldName: "text"), 1, accuracy: 0.001)
+    for alpha: Any in [-0.01, 1.01, Double.nan, Double.infinity, true, "0.5"] {
+      assertInvalidParams {
+        _ = try Utils.resolvedAlpha(alpha, fieldName: "text")
+      }
+    }
+
     for filename in [".", "..", ".png", ".jpg", ".jpeg", "../escape", "nested/file", "nested\\file", "bad\nname"] {
       assertInvalidParams {
         _ = try Options(dicOpts: ["backgroundImage": background, "filename": filename])

--- a/example/src/ImageMarkerLab.tsx
+++ b/example/src/ImageMarkerLab.tsx
@@ -843,6 +843,7 @@ function useViewModel(props: ImageMarkerLabProps) {
           {
             type: 'text',
             text: 'Mixed watermark',
+            alpha: 0.85,
             position: {
               position: Position.bottomCenter,
               X: 0,
@@ -924,6 +925,7 @@ function useViewModel(props: ImageMarkerLabProps) {
         watermarkTexts: [
           {
             text: 'CONFIDENTIAL',
+            alpha: 0.55,
             layout: {
               type: 'tile',
               gapX: '8%',
@@ -932,13 +934,13 @@ function useViewModel(props: ImageMarkerLabProps) {
               stagger: true,
             },
             style: {
-              color: '#FFFFFF88',
+              color: '#FFFFFF',
               fontName: exampleFontName,
               fontSize: 30,
               bold: true,
               rotate: -24,
               strokeStyle: {
-                color: '#0F172A88',
+                color: '#0F172A',
                 width: 2,
               },
             },
@@ -1011,6 +1013,96 @@ function useViewModel(props: ImageMarkerLabProps) {
         type: 'error',
         text1: 'tiled logo failed',
         text2: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function runBatchRecipeFeature() {
+    setBackgroundFormat('normal image');
+    setLastRun('Batch 0/3');
+    setUri('');
+    setShow(false);
+    setFileSize('0 B');
+    setResultContract('Preparing three native images with one recipe');
+    setLoading(true);
+
+    try {
+      const recipe = Marker.createRecipe({
+        watermarks: [
+          {
+            type: 'text',
+            text: 'BATCH RECIPE',
+            position: {
+              position: Position.bottomRight,
+              X: 28,
+              Y: 28,
+            },
+            style: {
+              color: '#FFFFFF',
+              fontName: exampleFontName,
+              fontSize: 30,
+              bold: true,
+              strokeStyle: { color: '#0F172ACC', width: 2 },
+            },
+          },
+          {
+            type: 'image',
+            src: assets.icon,
+            position: { position: Position.topRight, X: 28, Y: 28 },
+            scale: 0.38,
+            alpha: 0.9,
+          },
+        ],
+        quality: 92,
+        saveFormat: ImageFormat.jpg,
+        maxSize: 1600,
+      });
+      const batchId = Date.now();
+      const results = await recipe.applyMany(
+        [
+          { backgroundImage: { src: assets.bg } },
+          {
+            backgroundImage: {
+              src: assets.orientationBg ?? assets.bg,
+            },
+          },
+          { backgroundImage: { src: assets.base64Bg } },
+        ].map((input, index) => ({
+          ...input,
+          filename: `batch-${batchId}-${index + 1}`,
+        })),
+        {
+          concurrency: 3,
+          onProgress(progress) {
+            setLastRun(`Batch ${progress.settled}/${progress.total}`);
+            setResultContract(
+              `${progress.succeeded} succeeded · ${progress.failed} failed · ${progress.aborted} aborted`
+            );
+          },
+        }
+      );
+      const outputs = results.flatMap((result) =>
+        result.status === 'fulfilled' ? [result.value] : []
+      );
+      if (outputs.length === 0) {
+        throw new Error('The batch did not produce an image.');
+      }
+
+      setUri(formatResultUri(outputs[0], ImageFormat.jpg));
+      setShow(true);
+      await updateFileSize(outputs[0], ImageFormat.jpg);
+      setResultContract(
+        `Batch complete: ${outputs.length}/${results.length} succeeded · native renderer stayed serial`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setResultContract(`Batch failed: ${message}`);
+      Toast.show({
+        type: 'error',
+        text1: 'batch recipe failed',
+        text2: message,
       });
     } finally {
       setLoading(false);
@@ -1685,6 +1777,7 @@ function useViewModel(props: ImageMarkerLabProps) {
       runMixedWatermarkFeature,
       runTiledTextFeature,
       runTiledLogoFeature,
+      runBatchRecipeFeature,
       runSharpScaledWatermarkFeature,
       runRotationOutputPolicyFeature,
       runWatermarkOrientationFeature,
@@ -1812,7 +1905,7 @@ function ImageMarkerLab(props: ImageMarkerLabProps) {
                 <FeatureCard
                   badge="Tile"
                   title="Tiled text + outline"
-                  meta="stagger + percent gaps"
+                  meta="opacity + stagger + percent gaps"
                   tone="orange"
                   testID="feature-tiled-text"
                   onPress={actions.runTiledTextFeature}
@@ -1824,6 +1917,14 @@ function ImageMarkerLab(props: ImageMarkerLabProps) {
                   tone="green"
                   testID="feature-tiled-logo"
                   onPress={actions.runTiledLogoFeature}
+                />
+                <FeatureCard
+                  badge="Batch"
+                  title="Reusable batch recipe"
+                  meta="3 inputs · progress · stable order"
+                  tone="blue"
+                  testID="feature-batch-recipe"
+                  onPress={actions.runBatchRecipeFeature}
                 />
                 <FeatureCard
                   badge="Sharp"

--- a/ios/RCTImageMarker/ImageMarker.swift
+++ b/ios/RCTImageMarker/ImageMarker.swift
@@ -232,6 +232,7 @@ public final class ImageMarker: NSObject, RCTBridgeModule {
 
         for origin in origins {
             context.saveGState()
+            context.setAlpha(textOpts.alpha)
             let posX = origin.x + outlineInset
             let posY = origin.y + outlineInset
 

--- a/ios/RCTImageMarker/TextOptions.swift
+++ b/ios/RCTImageMarker/TextOptions.swift
@@ -15,6 +15,7 @@ class TextOptions: NSObject {
     var edgeInset: String?
     var position: MarkerPositionEnum = .none
     var text: String
+    var alpha: CGFloat = 1.0
     var style: TextStyle
     var layout: ImageMarkerWatermarkLayout?
 
@@ -45,5 +46,6 @@ class TextOptions: NSObject {
         self.text = text
         let styleOpts = opts["style"] as? [AnyHashable: Any] ?? [:]
         self.style = try TextStyle(dicOpts: styleOpts)
+        self.alpha = try Utils.resolvedAlpha(opts["alpha"], fieldName: "text")
     }
 }

--- a/ios/RCTImageMarker/Utils.swift
+++ b/ios/RCTImageMarker/Utils.swift
@@ -268,6 +268,30 @@ class Utils: NSObject {
         return UIColor(hex: value) ?? .clear
     }
 
+    static func resolvedAlpha(_ rawValue: Any?, fieldName: String) throws -> CGFloat {
+        guard let rawValue, !isNULL(rawValue) else {
+            return 1
+        }
+        guard let alphaNumber = rawValue as? NSNumber,
+              CFGetTypeID(alphaNumber) != CFBooleanGetTypeID() else {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "\(fieldName) alpha must be between zero and one"]
+            )
+        }
+
+        let alpha = CGFloat(truncating: alphaNumber)
+        guard alpha.isFinite, (0...1).contains(alpha) else {
+            throw NSError(
+                domain: ErrorDomainEnum.PARAMS_INVALID.rawValue,
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "\(fieldName) alpha must be between zero and one"]
+            )
+        }
+        return alpha
+    }
+
     static func getShadowStyle(_ shadowStyle: [AnyHashable: Any]?) throws -> NSShadow? {
         if let shadowStyle = shadowStyle {
             guard let colorValue = shadowStyle["color"] as? String,

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -449,7 +449,7 @@ describe('Marker JS wrapper', () => {
           src: 'file:///tmp/background.png',
           alpha: 0,
         },
-        watermarkTexts: [{ text: 'boundary' }],
+        watermarkTexts: [{ text: 'boundary', alpha: 0 }],
         quality: 0,
       })
     ).resolves.toBe('/tmp/boundary-text.png');
@@ -475,6 +475,11 @@ describe('Marker JS wrapper', () => {
             type: 'image',
             src: 'file:///tmp/mixed-watermark.png',
             alpha: 0,
+          },
+          {
+            type: 'text',
+            text: 'boundary',
+            alpha: 1,
           },
         ],
         quality: 100,
@@ -601,7 +606,7 @@ describe('Marker JS wrapper', () => {
     expect(nativeModule.markWithWatermarks).not.toHaveBeenCalled();
   });
 
-  it('rejects invalid alpha values at every nested image location', () => {
+  it('rejects invalid alpha values at every image and text layer location', () => {
     const invalidCases = [
       {
         invoke: () =>
@@ -652,6 +657,24 @@ describe('Marker JS wrapper', () => {
             ],
           }),
         path: 'watermarks[1]',
+      },
+      {
+        invoke: () =>
+          Marker.markText({
+            backgroundImage: { src: 'file:///tmp/background.png' },
+            watermarkTexts: [{ text: 'transparent text', alpha: Number.NaN }],
+          }),
+        path: 'watermarkTexts[0]',
+      },
+      {
+        invoke: () =>
+          Marker.mark({
+            backgroundImage: { src: 'file:///tmp/background.png' },
+            watermarks: [
+              { type: 'text', text: 'transparent text', alpha: -0.01 },
+            ],
+          }),
+        path: 'watermarks[0]',
       },
     ];
 

--- a/src/__tests__/web-marker-render.test.ts
+++ b/src/__tests__/web-marker-render.test.ts
@@ -32,6 +32,7 @@ class FakeImage {
 }
 
 function createFakeCanvas() {
+  const globalAlphaHistory = [1];
   const canvas = {
     width: 0,
     height: 0,
@@ -85,8 +86,17 @@ function createFakeCanvas() {
       data: new Uint8ClampedArray(320 * 200 * 4).fill(255),
     })),
   };
+  let globalAlpha = 1;
+  Object.defineProperty(context, 'globalAlpha', {
+    configurable: true,
+    get: () => globalAlpha,
+    set: (value: number) => {
+      globalAlpha = value;
+      globalAlphaHistory.push(value);
+    },
+  });
   canvas.getContext.mockReturnValue(context);
-  return { canvas, context };
+  return { canvas, context, globalAlphaHistory };
 }
 
 function installFakeBrowserRuntime() {
@@ -284,6 +294,40 @@ describe('WebMarker browser render integration', () => {
       context.fillText.mock.invocationCallOrder[0]
     );
     expect(context.moveTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('applies text alpha to the complete text layer and restores the canvas', async () => {
+    const canvases = installFakeBrowserRuntime();
+
+    await WebMarker.markText({
+      backgroundImage: { src: '/background.jpg' },
+      watermarkTexts: [
+        {
+          text: 'Translucent',
+          alpha: 0.35,
+          style: {
+            strokeStyle: { color: '#111827', width: 2 },
+            textBackgroundStyle: { color: '#F97316' },
+          },
+        },
+      ],
+      saveFormat: ImageFormat.png,
+    });
+
+    const { context, globalAlphaHistory } = canvases[0]!;
+    expect(globalAlphaHistory).toContain(0.35);
+    expect(context.globalAlpha).toBe(1);
+    expect(context.fillText).toHaveBeenCalledWith(
+      'Translucent',
+      expect.any(Number),
+      expect.any(Number)
+    );
+    expect(context.strokeText).toHaveBeenCalledWith(
+      'Translucent',
+      expect.any(Number),
+      expect.any(Number)
+    );
+    expect(context.fill).toHaveBeenCalled();
   });
 
   it('tiles outlined text using percentage gaps and staggered rows', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -512,6 +512,15 @@ export interface TextOptions {
    * text: 'hello world'
    **/
   text: string;
+
+  /**
+   * Opacity applied to the complete text layer, including its fill, outline,
+   * shadow, and background.
+   * @defaultValue 1
+   * @example
+   * alpha: 0.65
+   */
+  alpha?: number;
   /**
    * @deprecated since 1.2.4 use position instead
    * text position options

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -36,10 +36,10 @@ function validateMaxSize(options: MarkRequestOptions): void {
 }
 
 function validateAlpha(
-  imageOptions: ImageOptions | undefined,
+  options: Pick<ImageOptions, 'alpha'> | undefined,
   path: string
 ): void {
-  const alpha = imageOptions?.alpha;
+  const alpha = options?.alpha;
 
   if (
     alpha !== undefined &&
@@ -114,6 +114,7 @@ function validateWatermarkLayout(
 }
 
 function validateTextOptions(options: TextOptions, path: string): void {
+  validateAlpha(options, path);
   const strokeStyle = options.style?.strokeStyle;
   if (strokeStyle) {
     if (!Number.isFinite(strokeStyle.width) || strokeStyle.width < 0) {

--- a/src/web/renderer.ts
+++ b/src/web/renderer.ts
@@ -552,7 +552,7 @@ function drawTextAtPosition(
   }
 }
 
-function drawTextLayer(
+function drawTextLayerContent(
   context: WebCanvasContext,
   options: TextOptions,
   canvas: Size
@@ -606,6 +606,23 @@ function drawTextLayer(
     20
   );
   drawTextAtPosition(context, options, canvas, textLayout, position, rotation);
+}
+
+function drawTextLayer(
+  context: WebCanvasContext,
+  options: TextOptions,
+  canvas: Size
+) {
+  const previousAlpha = context.globalAlpha;
+  const alpha = resolveAlpha(options.alpha, 'watermark text alpha');
+  context.save();
+  try {
+    context.globalAlpha = previousAlpha * alpha;
+    drawTextLayerContent(context, options, canvas);
+  } finally {
+    context.globalAlpha = previousAlpha;
+    context.restore();
+  }
 }
 
 function fullSourceBounds(image: LoadedWebImage): SourceBounds {

--- a/website/scripts/smoke-playground.mjs
+++ b/website/scripts/smoke-playground.mjs
@@ -93,6 +93,7 @@ try {
   await assertVisibleLogo(playground);
   await assertCustomSelects(playground);
   await assertLayoutControlsAndCode(page, playground);
+  await assertBatchRecipe(page, playground);
 
   const code = await playground.locator('[data-web-code]').textContent();
   assert.match(
@@ -137,7 +138,11 @@ try {
     page: document.documentElement.scrollWidth,
     viewport: window.innerWidth,
   }));
-  assert.equal(mobileWidth.page, mobileWidth.viewport, 'Mobile playground should not overflow.');
+  assert.equal(
+    mobileWidth.page,
+    mobileWidth.viewport,
+    'Mobile playground should not overflow.'
+  );
   assert.deepEqual(
     pageErrors,
     [],
@@ -145,7 +150,7 @@ try {
   );
 
   console.log(
-    'Verified top navigation, custom selectors, first-viewport layout, tiled/single and outline controls, preview-to-code parity, both playground routes, downloads, and the HTML sitemap.'
+    'Verified navigation, responsive layout, watermark controls, preview-to-code parity, batch Blob results, cancellation, both playground routes, downloads, and the HTML sitemap.'
   );
 } finally {
   await browser?.close();
@@ -167,70 +172,180 @@ async function assertPreviewMime(playground, mimeType) {
 }
 
 async function assertVisibleLogo(playground) {
-  const orangePixels = await playground.locator('[data-preview]').evaluate(async (image) => {
-    await image.decode();
-    const canvas = document.createElement('canvas');
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalHeight;
-    const context = canvas.getContext('2d');
-    if (!context) return 0;
-    context.drawImage(image, 0, 0);
-    const size = Math.min(240, canvas.width, canvas.height);
-    const pixels = context.getImageData(canvas.width - size, 0, size, size).data;
-    let count = 0;
-    for (let index = 0; index < pixels.length; index += 4) {
-      if (pixels[index] > 220 && pixels[index + 1] < 130 && pixels[index + 2] < 100) {
-        count += 1;
+  const orangePixels = await playground
+    .locator('[data-preview]')
+    .evaluate(async (image) => {
+      await image.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext('2d');
+      if (!context) return 0;
+      context.drawImage(image, 0, 0);
+      const size = Math.min(240, canvas.width, canvas.height);
+      const pixels = context.getImageData(
+        canvas.width - size,
+        0,
+        size,
+        size
+      ).data;
+      let count = 0;
+      for (let index = 0; index < pixels.length; index += 4) {
+        if (
+          pixels[index] > 220 &&
+          pixels[index + 1] < 130 &&
+          pixels[index + 2] < 100
+        ) {
+          count += 1;
+        }
       }
-    }
-    return count;
-  });
+      return count;
+    });
 
-  assert(orangePixels > 100, 'Default image watermark should be visible over the background.');
+  assert(
+    orangePixels > 100,
+    'Default image watermark should be visible over the background.'
+  );
+}
+
+async function assertBatchRecipe(page, playground) {
+  const batchFiles = playground.locator('[data-batch-files]');
+  const fixtureNames = [
+    'playground-background.jpg',
+    'watermark-coast.jpg',
+    'watermark-after-dark.jpg',
+  ];
+  const fixturePaths = fixtureNames.map((name) =>
+    path.join(websiteRoot, 'public', 'media', name)
+  );
+  await batchFiles.setInputFiles(fixturePaths);
+  await playground.getByText('3 images queued').waitFor();
+  await playground.locator('[data-batch-run]').click();
+  await page.waitForFunction(() =>
+    document
+      .querySelector('[data-batch-status]')
+      ?.textContent?.includes('Batch complete')
+  );
+
+  const results = playground.locator('[data-batch-result]');
+  assert.equal(await results.count(), 3);
+  assert.deepEqual(
+    await results.locator('strong').allTextContents(),
+    fixtureNames
+  );
+  assert.equal(
+    await playground.locator('[data-batch-result="fulfilled"]').count(),
+    3
+  );
+  const sources = await results
+    .locator('img')
+    .evaluateAll((images) => images.map((image) => image.getAttribute('src')));
+  assert(sources.every((source) => source?.startsWith('blob:')));
+
+  const cancelFixtures = [
+    ...fixturePaths,
+    path.join(websiteRoot, 'public', 'media', 'watermark-tiled.jpg'),
+    path.join(websiteRoot, 'public', 'media', 'watermark-waypoint.jpg'),
+  ];
+  await batchFiles.setInputFiles(cancelFixtures);
+  await playground.locator('[data-batch-run]').click();
+  await playground.locator('[data-batch-cancel]').click();
+  await page.waitForFunction(() =>
+    document
+      .querySelector('[data-batch-status]')
+      ?.textContent?.includes('Batch complete')
+  );
+  assert.equal(await results.count(), 5);
+  assert(
+    (await playground.locator('[data-batch-result="aborted"]').count()) > 0,
+    'Cancelling should leave at least one not-yet-dispatched image aborted.'
+  );
 }
 
 async function assertLayoutControlsAndCode(page, playground) {
+  const textTile = playground.locator(
+    '[data-layout-layer="text"][data-layout="tile"]'
+  );
+  const textSingle = playground.locator(
+    '[data-layout-layer="text"][data-layout="single"]'
+  );
+  const imageTile = playground.locator(
+    '[data-layout-layer="image"][data-layout="tile"]'
+  );
+  const imageSingle = playground.locator(
+    '[data-layout-layer="image"][data-layout="single"]'
+  );
+  const preview = playground.locator('[data-preview]');
+
+  assert.equal(await playground.locator('[data-example]').count(), 6);
+  assert.equal(await playground.locator('.capability-index li').count(), 8);
+  assert(
+    await textSingle.isVisible(),
+    'Text layout switch should be visible without opening advanced controls.'
+  );
+  assert(
+    await imageSingle.isVisible(),
+    'Logo layout switch should be visible without opening advanced controls.'
+  );
+  assert.equal(await textSingle.getAttribute('aria-pressed'), 'true');
+  assert.equal(await imageSingle.getAttribute('aria-pressed'), 'true');
+
+  let code = await playground.locator('[data-web-code]').textContent();
+  assert.match(code ?? '', /alpha: 0\.85/);
+  assert.match(
+    code ?? '',
+    /position: \{ position: Position\.bottomLeft, X: 48, Y: 48 \}/
+  );
+  assert.doesNotMatch(code ?? '', /layout:/);
+  assert.match(code ?? '', /strokeStyle: \{ color: '#101828', width: 2 \}/);
+
+  let previousSource = await preview.getAttribute('src');
+  await playground.locator('[data-example="outline"]').click();
+  await waitForPreviewChange(page, playground, previousSource);
+  code = await playground.locator('[data-web-code]').textContent();
+  assert.match(code ?? '', /Marker\.markText/);
+  assert.match(code ?? '', /text: ["']IMAGE MARKER["']/);
+  assert.match(code ?? '', /alpha: 1/);
+  assert.match(code ?? '', /strokeStyle: \{ color: '#101828', width: 4 \}/);
+
+  previousSource = await preview.getAttribute('src');
+  await playground.locator('[data-example="opacity"]').click();
+  await waitForPreviewChange(page, playground, previousSource);
+  code = await playground.locator('[data-web-code]').textContent();
+  assert.match(code ?? '', /text: ["']PRIVATE PREVIEW["']/);
+  assert.match(code ?? '', /alpha: 0\.4/);
+
+  previousSource = await preview.getAttribute('src');
+  await playground.locator('[data-example="mixed"]').click();
+  await waitForPreviewChange(page, playground, previousSource);
+
+  previousSource = await preview.getAttribute('src');
+  await playground.locator('[data-text-opacity]').fill('0.45');
+  await playground.locator('[data-stroke-width]').fill('4');
+  await waitForPreviewChange(page, playground, previousSource);
+
+  code = await playground.locator('[data-web-code]').textContent();
+  assert.match(code ?? '', /alpha: 0\.45/);
+  assert.match(code ?? '', /strokeStyle: \{ color: '#101828', width: 4 \}/);
+
   await playground
     .locator('[data-text-controls] details.advanced-controls summary')
     .click();
   await playground
     .locator('[data-image-controls] details.advanced-controls summary')
     .click();
-  const textTile = playground.locator('[data-layout-layer="text"][data-layout="tile"]');
-  const textSingle = playground.locator('[data-layout-layer="text"][data-layout="single"]');
-  const imageTile = playground.locator('[data-layout-layer="image"][data-layout="tile"]');
-  const imageSingle = playground.locator('[data-layout-layer="image"][data-layout="single"]');
-  const preview = playground.locator('[data-preview]');
-
-  assert.equal(await textTile.getAttribute('aria-pressed'), 'true');
-  assert.equal(await imageSingle.getAttribute('aria-pressed'), 'true');
-
-  let code = await playground.locator('[data-web-code]').textContent();
-  assert.match(code ?? '', /layout: \{\s*type: 'tile'/);
-  assert.match(code ?? '', /gapX: ["']8%["']/);
-  assert.match(code ?? '', /strokeStyle: \{ color: '#101828', width: 2 \}/);
-
-  let previousSource = await preview.getAttribute('src');
-  await playground.locator('[data-text-gap-x]').fill('12%');
-  await playground.locator('[data-stroke-width]').fill('4');
-  await playground.locator('[data-text-stagger]').uncheck();
-  await waitForPreviewChange(page, playground, previousSource);
-
-  code = await playground.locator('[data-web-code]').textContent();
-  assert.match(code ?? '', /gapX: ["']12%["']/);
-  assert.match(code ?? '', /stagger: false/);
-  assert.match(code ?? '', /strokeStyle: \{ color: '#101828', width: 4 \}/);
-
-  previousSource = await preview.getAttribute('src');
-  await textSingle.click();
-  await waitForPreviewChange(page, playground, previousSource);
-  code = await playground.locator('[data-web-code]').textContent();
-  assert.match(code ?? '', /position: \{ position: Position\.bottomLeft, X: 48, Y: 48 \}/);
-  assert.doesNotMatch(code ?? '', /layout:/);
-
   previousSource = await preview.getAttribute('src');
   await textTile.click();
   await waitForPreviewChange(page, playground, previousSource);
+  previousSource = await preview.getAttribute('src');
+  await playground.locator('[data-text-gap-x]').fill('12%');
+  await playground.locator('[data-text-stagger]').uncheck();
+  await waitForPreviewChange(page, playground, previousSource);
+  code = await playground.locator('[data-web-code]').textContent();
+  assert.match(code ?? '', /layout: \{\s*type: 'tile'/);
+  assert.match(code ?? '', /gapX: ["']12%["']/);
+  assert.match(code ?? '', /stagger: false/);
+
   previousSource = await preview.getAttribute('src');
   await imageTile.click();
   await waitForPreviewChange(page, playground, previousSource);
@@ -240,18 +355,18 @@ async function assertLayoutControlsAndCode(page, playground) {
   previousSource = await preview.getAttribute('src');
   await imageSingle.click();
   await waitForPreviewChange(page, playground, previousSource);
+  previousSource = await preview.getAttribute('src');
+  await textSingle.click();
+  await waitForPreviewChange(page, playground, previousSource);
 }
 
 async function waitForPreviewChange(page, playground, previousSource) {
-  await page.waitForFunction(
-    (previous) => {
-      const preview = document.querySelector(
-        '[data-marker-playground] [data-preview]'
-      );
-      return preview instanceof HTMLImageElement && preview.src !== previous;
-    },
-    previousSource
-  );
+  await page.waitForFunction((previous) => {
+    const preview = document.querySelector(
+      '[data-marker-playground] [data-preview]'
+    );
+    return preview instanceof HTMLImageElement && preview.src !== previous;
+  }, previousSource);
   await waitForRendered(playground);
 }
 
@@ -287,16 +402,46 @@ async function assertWorkbenchLayout(page) {
     };
   });
 
-  assert.equal(layout.heroCount, 0, 'Playground should not render a separate hero.');
-  assert.equal(layout.h1Count, 1, 'Playground should have one visible page title.');
-  assert.equal(layout.pageWidth, layout.viewportWidth, 'Playground should not overflow horizontally.');
+  assert.equal(
+    layout.heroCount,
+    0,
+    'Playground should not render a separate hero.'
+  );
+  assert.equal(
+    layout.h1Count,
+    1,
+    'Playground should have one visible page title.'
+  );
+  assert.equal(
+    layout.pageWidth,
+    layout.viewportWidth,
+    'Playground should not overflow horizontally.'
+  );
   assert(layout.marker && layout.controls && layout.preview && layout.textGrid);
-  assert(layout.marker.x >= 20 && layout.marker.x <= 28, 'Workbench should keep a small page margin.');
-  assert(layout.marker.width >= 940, 'Workbench should use the available desktop width.');
-  assert(layout.controls.y < 280, 'Controls should be visible in the first viewport.');
-  assert(Math.abs(layout.controls.y - layout.preview.y) < 1, 'Controls and preview should align.');
-  assert(layout.controls.scrollWidth <= layout.controls.clientWidth, 'Controls should not overflow.');
-  assert(layout.textGrid.scrollWidth <= layout.textGrid.clientWidth, 'Text controls should fit their panel.');
+  assert(
+    layout.marker.x >= 20 && layout.marker.x <= 28,
+    'Workbench should keep a small page margin.'
+  );
+  assert(
+    layout.marker.width >= 940,
+    'Workbench should use the available desktop width.'
+  );
+  assert(
+    layout.controls.y < 280,
+    'Controls should be visible in the first viewport.'
+  );
+  assert(
+    Math.abs(layout.controls.y - layout.preview.y) < 1,
+    'Controls and preview should align.'
+  );
+  assert(
+    layout.controls.scrollWidth <= layout.controls.clientWidth,
+    'Controls should not overflow.'
+  );
+  assert(
+    layout.textGrid.scrollWidth <= layout.textGrid.clientWidth,
+    'Text controls should fit their panel.'
+  );
   assert.equal(layout.tabDisplay, 'flex');
   assert.equal(layout.tabAlign, 'center');
   assert.equal(layout.tabJustify, 'center');
@@ -306,9 +451,12 @@ async function assertWideHomepageLayout(page, origin) {
   await page.setViewportSize({ width: 2048, height: 1100 });
   await page.goto(`${origin}/zh-cn/`, { waitUntil: 'networkidle' });
   const layout = await page.evaluate(() => {
-    const container = document.querySelector(':root[data-has-hero] main > .content-panel > .sl-container');
+    const container = document.querySelector(
+      ':root[data-has-hero] main > .content-panel > .sl-container'
+    );
     const stage = document.querySelector('.product-stage');
-    if (!(container instanceof HTMLElement) || !(stage instanceof HTMLElement)) return null;
+    if (!(container instanceof HTMLElement) || !(stage instanceof HTMLElement))
+      return null;
     const containerRect = container.getBoundingClientRect();
     const stageRect = stage.getBoundingClientRect();
     return {
@@ -323,10 +471,24 @@ async function assertWideHomepageLayout(page, origin) {
   });
 
   assert(layout, 'Wide homepage layout should render.');
-  assert.equal(layout.pageWidth, layout.viewportWidth, 'Wide homepage should not overflow.');
-  assert(Math.abs(layout.containerLeft - layout.containerRight) < 1, 'Homepage should be centered.');
-  assert.equal(Math.round(layout.containerWidth), 1440, 'Homepage should use its own maximum width.');
-  assert(Math.abs(layout.stageLeft - layout.stageRight) < 1, 'Homepage feature stage should stay centered.');
+  assert.equal(
+    layout.pageWidth,
+    layout.viewportWidth,
+    'Wide homepage should not overflow.'
+  );
+  assert(
+    Math.abs(layout.containerLeft - layout.containerRight) < 1,
+    'Homepage should be centered.'
+  );
+  assert.equal(
+    Math.round(layout.containerWidth),
+    1440,
+    'Homepage should use its own maximum width.'
+  );
+  assert(
+    Math.abs(layout.stageLeft - layout.stageRight) < 1,
+    'Homepage feature stage should stay centered.'
+  );
 }
 
 async function assertWideWorkbenchLayout(page, origin) {
@@ -336,7 +498,11 @@ async function assertWideWorkbenchLayout(page, origin) {
     const marker = document.querySelector('.marker-playground');
     const controls = document.querySelector('.controls-panel');
     const preview = document.querySelector('.preview-panel');
-    if (!(marker instanceof HTMLElement) || !(controls instanceof HTMLElement) || !(preview instanceof HTMLElement)) {
+    if (
+      !(marker instanceof HTMLElement) ||
+      !(controls instanceof HTMLElement) ||
+      !(preview instanceof HTMLElement)
+    ) {
       return null;
     }
     const markerRect = marker.getBoundingClientRect();
@@ -354,12 +520,32 @@ async function assertWideWorkbenchLayout(page, origin) {
   });
 
   assert(layout, 'Wide playground layout should render.');
-  assert.equal(layout.pageWidth, layout.viewportWidth, 'Wide playground should not overflow.');
-  assert(Math.abs(layout.markerLeft - layout.markerRight) < 1, 'Workbench should be centered in the viewport.');
-  assert(layout.markerLeft >= 200, 'Wide screens should keep balanced side margins.');
-  assert.equal(Math.round(layout.markerWidth), 1600, 'Workbench should respect its maximum width.');
-  assert(layout.controlsLeft >= layout.markerLeft, 'Controls must stay inside the workbench.');
-  assert(layout.previewLeft > layout.controlsLeft, 'Preview must remain to the right of controls.');
+  assert.equal(
+    layout.pageWidth,
+    layout.viewportWidth,
+    'Wide playground should not overflow.'
+  );
+  assert(
+    Math.abs(layout.markerLeft - layout.markerRight) < 1,
+    'Workbench should be centered in the viewport.'
+  );
+  assert(
+    layout.markerLeft >= 200,
+    'Wide screens should keep balanced side margins.'
+  );
+  assert.equal(
+    Math.round(layout.markerWidth),
+    1600,
+    'Workbench should respect its maximum width.'
+  );
+  assert(
+    layout.controlsLeft >= layout.markerLeft,
+    'Controls must stay inside the workbench.'
+  );
+  assert(
+    layout.previewLeft > layout.controlsLeft,
+    'Preview must remain to the right of controls.'
+  );
 }
 
 async function assertLanguageMenu(page) {
@@ -367,12 +553,20 @@ async function assertLanguageMenu(page) {
   await menu.locator('summary').click();
   const popover = menu.locator('.preference-popover');
   await popover.waitFor();
-  assert.equal(await menu.locator('select').count(), 0, 'Language menu should not use a native select.');
   assert.equal(
-    await popover.getByRole('menuitem', { name: /English/ }).getAttribute('href'),
+    await menu.locator('select').count(),
+    0,
+    'Language menu should not use a native select.'
+  );
+  assert.equal(
+    await popover
+      .getByRole('menuitem', { name: /English/ })
+      .getAttribute('href'),
     '/playground/'
   );
-  const borderRadius = await popover.evaluate((element) => getComputedStyle(element).borderRadius);
+  const borderRadius = await popover.evaluate(
+    (element) => getComputedStyle(element).borderRadius
+  );
   assert.notEqual(borderRadius, '0px');
   await menu.press('Escape');
 }
@@ -382,33 +576,58 @@ async function assertThemeMenu(page) {
   await menu.locator('summary').click();
   const popover = menu.locator('.preference-popover');
   await popover.waitFor();
-  assert.equal(await menu.locator('select').count(), 0, 'Theme menu should not use a native select.');
+  assert.equal(
+    await menu.locator('select').count(),
+    0,
+    'Theme menu should not use a native select.'
+  );
 
   await popover.getByRole('menuitemradio', { name: /深色/ }).click();
   assert.equal(await page.locator('html').getAttribute('data-theme'), 'dark');
-  assert.equal(await page.evaluate(() => localStorage.getItem('starlight-theme')), 'dark');
+  assert.equal(
+    await page.evaluate(() => localStorage.getItem('starlight-theme')),
+    'dark'
+  );
 
   await menu.locator('summary').click();
   await popover.getByRole('menuitemradio', { name: /自动/ }).click();
-  assert.equal(await page.evaluate(() => localStorage.getItem('starlight-theme')), '');
+  assert.equal(
+    await page.evaluate(() => localStorage.getItem('starlight-theme')),
+    ''
+  );
 }
 
 async function assertCustomSelects(playground) {
   const customSelects = playground.locator('[data-custom-select]');
-  assert.equal(await customSelects.count(), 3, 'Playground should render three custom selectors.');
+  assert.equal(
+    await customSelects.count(),
+    3,
+    'Playground should render three custom selectors.'
+  );
   for (const select of await playground.locator('select').all()) {
-    assert.equal(await select.isVisible(), false, 'Native select should only be a hidden form value.');
+    assert.equal(
+      await select.isVisible(),
+      false,
+      'Native select should only be a hidden form value.'
+    );
   }
 }
 
 async function selectCustomOptionWithKeyboard(playground, name, expectedValue) {
-  const customSelect = playground.locator(`[data-custom-select][data-select-name="${name}"]`);
+  const customSelect = playground.locator(
+    `[data-custom-select][data-select-name="${name}"]`
+  );
   const trigger = customSelect.locator('[data-select-trigger]');
   await trigger.focus();
   await trigger.press('Enter');
-  await customSelect.locator('[role="option"][aria-selected="true"]').press('End');
+  await customSelect
+    .locator('[role="option"][aria-selected="true"]')
+    .press('End');
   await customSelect.locator('[role="option"]:focus').press('Enter');
-  assert.equal(await customSelect.locator('select').inputValue(), expectedValue);
+  assert.equal(
+    await customSelect.locator('select').inputValue(),
+    expectedValue
+  );
   assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
 }
 

--- a/website/src/components/ImageMarkerPlayground.astro
+++ b/website/src/components/ImageMarkerPlayground.astro
@@ -18,6 +18,17 @@ const strings = isZh
         '选择示例或自己的图片，调整文字和 Logo，然后保存结果。所有处理只在当前浏览器中完成。',
       privacy: '图片不上传',
       steps: ['选择内容', '调整样式', '保存或复制代码'],
+      capabilitiesTitle: '主要功能都可以直接试',
+      capabilities: [
+        '文字水印',
+        'Logo 水印',
+        '文字 + Logo',
+        '单个或平铺',
+        '透明度与描边',
+        '位置与旋转',
+        '批量 Recipe',
+        'PNG、JPEG 与 Web Blob',
+      ],
       webBadge: '实时预览',
       previewTitle: '效果',
       resultLabel: '图片地址',
@@ -38,11 +49,22 @@ const strings = isZh
       textPreset: '只加文字',
       imagePreset: '只加 Logo',
       mixedPreset: '文字 + Logo',
+      examples: '一键示例',
+      examplesHint: '选择后仍可继续调整',
+      examplePresets: [
+        { id: 'mixed', title: '普通文字 + Logo', meta: '两个单点图层', version: '' },
+        { id: 'outline', title: '高对比文字描边', meta: '明暗底图都清楚', version: '' },
+        { id: 'tiled-text', title: '平铺文字', meta: '错行、间距、旋转', version: '' },
+        { id: 'tiled-logo', title: '平铺 Logo', meta: '一次解码，多处绘制', version: '' },
+        { id: 'opacity', title: '半透明文字', meta: '整个文字图层 40%', version: 'v1.8' },
+        { id: 'batch', title: '批量 Recipe', meta: '多图、进度与 Blob', version: 'v1.8' },
+      ],
       textLayer: '文字设置',
       text: '文字内容',
       textPlaceholder: '输入水印文字',
       color: '颜色',
       fontSize: '字号',
+      textOpacity: '文字透明度',
       bold: '粗体',
       stroke: '文字描边',
       strokeColor: '描边颜色',
@@ -62,7 +84,7 @@ const strings = isZh
       defaultLogo: '使用内置 Logo',
       opacity: '透明度',
       scale: '缩放',
-      advanced: '排列、位置与旋转',
+      advanced: '位置、旋转与平铺间距',
       output: '保存设置',
       format: '格式',
       quality: '质量',
@@ -84,6 +106,22 @@ const strings = isZh
       dimensions: '尺寸',
       elapsed: '耗时',
       localNote: '本地图片不会离开你的设备。刷新页面后，选择的文件会被清除。',
+      batchEyebrow: 'v1.8 · 批量 Recipe 与 Web Blob',
+      batchTitle: '一次选择多张图片，统一加水印。',
+      batchDescription:
+        '当前文字、Logo 和导出设置会保存成一个 Recipe。Web 最多同时处理 4 张；结果仍按选择顺序排列。',
+      chooseBatch: '选择多张图片',
+      batchNone: '尚未选择图片',
+      batchSelected: '张图片已加入队列',
+      runBatch: '开始批量处理',
+      cancelBatch: '停止后续任务',
+      batchReady: '选择两张或更多图片开始体验。',
+      batchRunning: '正在处理',
+      batchCancelling: '正在停止；已经开始的图片会处理完成。',
+      batchComplete: '批量处理完成',
+      batchFailed: '批量处理失败',
+      batchResults: '处理结果',
+      downloadResult: '保存',
       differencesTitle: 'Web 与原生输出有什么不同？',
       differences: [
         ['保存结果', 'Web 返回可直接预览和保存的图片地址；iOS 和 Android 返回临时文件路径。'],
@@ -110,6 +148,17 @@ const strings = isZh
         'Use the sample or choose your own image, adjust the text and logo, then save the result. Everything runs in this browser tab.',
       privacy: 'Images are not uploaded',
       steps: ['Choose content', 'Adjust the look', 'Save or copy code'],
+      capabilitiesTitle: 'Try every core workflow',
+      capabilities: [
+        'Text watermark',
+        'Logo watermark',
+        'Text + logo',
+        'Single or tiled',
+        'Opacity and outline',
+        'Position and rotation',
+        'Batch Recipe',
+        'PNG, JPEG, and Web Blob',
+      ],
       webBadge: 'Live preview',
       previewTitle: 'Result',
       resultLabel: 'Image URL',
@@ -130,11 +179,22 @@ const strings = isZh
       textPreset: 'Text only',
       imagePreset: 'Logo only',
       mixedPreset: 'Text + logo',
+      examples: 'One-click examples',
+      examplesHint: 'Keep adjusting after choosing one',
+      examplePresets: [
+        { id: 'mixed', title: 'Text + logo', meta: 'Two single layers', version: '' },
+        { id: 'outline', title: 'High-contrast outline', meta: 'Readable on light or dark', version: '' },
+        { id: 'tiled-text', title: 'Tiled text', meta: 'Stagger, gaps, rotation', version: '' },
+        { id: 'tiled-logo', title: 'Tiled logo', meta: 'Decode once, draw many', version: '' },
+        { id: 'opacity', title: 'Translucent text', meta: 'Whole text layer at 40%', version: 'v1.8' },
+        { id: 'batch', title: 'Batch Recipe', meta: 'Files, progress, and Blob', version: 'v1.8' },
+      ],
       textLayer: 'Text settings',
       text: 'Watermark text',
       textPlaceholder: 'Enter watermark text',
       color: 'Color',
       fontSize: 'Font size',
+      textOpacity: 'Text opacity',
       bold: 'Bold',
       stroke: 'Text outline',
       strokeColor: 'Outline color',
@@ -154,7 +214,7 @@ const strings = isZh
       defaultLogo: 'Use built-in logo',
       opacity: 'Opacity',
       scale: 'Scale',
-      advanced: 'Layout, position, and rotation',
+      advanced: 'Position, rotation, and tile spacing',
       output: 'Save settings',
       format: 'Format',
       quality: 'Quality',
@@ -176,6 +236,22 @@ const strings = isZh
       dimensions: 'Dimensions',
       elapsed: 'Time',
       localNote: 'Local images never leave your device. Selected files are cleared when you refresh.',
+      batchEyebrow: 'v1.8 · Batch Recipe and Web Blob',
+      batchTitle: 'Choose several images. Mark them with one recipe.',
+      batchDescription:
+        'Your current text, logo, and output settings become one reusable Recipe. Web runs up to four jobs at once and keeps results in selection order.',
+      chooseBatch: 'Choose multiple images',
+      batchNone: 'No images selected',
+      batchSelected: 'images queued',
+      runBatch: 'Process batch',
+      cancelBatch: 'Stop new jobs',
+      batchReady: 'Choose two or more images to try batch processing.',
+      batchRunning: 'Processing',
+      batchCancelling: 'Stopping dispatch. Images already running will finish.',
+      batchComplete: 'Batch complete',
+      batchFailed: 'Batch failed',
+      batchResults: 'Batch results',
+      downloadResult: 'Save',
       differencesTitle: 'How does Web output differ from native?',
       differences: [
         ['Saved result', 'Web returns an image URL you can preview or save. iOS and Android return a temporary file path.'],
@@ -224,6 +300,14 @@ const formats = [
   data-copy-failed={strings.copyFailed}
   data-generated-alt={strings.generatedAlt}
   data-filename={strings.filename}
+  data-batch-none={strings.batchNone}
+  data-batch-selected={strings.batchSelected}
+  data-batch-ready={strings.batchReady}
+  data-batch-running={strings.batchRunning}
+  data-batch-cancelling={strings.batchCancelling}
+  data-batch-complete={strings.batchComplete}
+  data-batch-failed={strings.batchFailed}
+  data-batch-download={strings.downloadResult}
 >
   <header class="playground-heading">
     <div>
@@ -319,6 +403,29 @@ const formats = [
         </div>
       </fieldset>
 
+      <fieldset class="control-section example-section">
+        <legend>
+          {strings.examples}
+          <small>{strings.examplesHint}</small>
+        </legend>
+        <div class="example-presets">
+          {strings.examplePresets.map((example, index) => (
+            <button
+              type="button"
+              class:list={{ 'example-button': true, 'is-active': index === 0 }}
+              aria-pressed={index === 0 ? 'true' : 'false'}
+              data-example={example.id}
+            >
+              <span>
+                <strong>{example.title}</strong>
+                {example.version && <em>{example.version}</em>}
+              </span>
+              <small>{example.meta}</small>
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
       <fieldset class="control-section source-section">
         <legend>{strings.background}</legend>
         <div class="file-row">
@@ -344,7 +451,7 @@ const formats = [
           <span>{strings.text}</span>
           <input
             type="text"
-            value="CONFIDENTIAL"
+            value="SHOT ON IMAGE MARKER"
             placeholder={strings.textPlaceholder}
             data-text
           />
@@ -361,6 +468,10 @@ const formats = [
           <label class="field range-field">
             <span>{strings.fontSize} <output data-font-size-output>42 px</output></span>
             <input type="range" min="18" max="120" value="42" step="1" data-font-size />
+          </label>
+          <label class="field range-field">
+            <span>{strings.textOpacity} <output data-text-opacity-output>85%</output></span>
+            <input type="range" min="0" max="1" value="0.85" step="0.05" data-text-opacity />
           </label>
           <label class="check-field">
             <input type="checkbox" checked data-bold />
@@ -386,32 +497,33 @@ const formats = [
           </label>
         </div>
 
+        <div class="layout-choice primary-layout-choice">
+          <span>{strings.layout}</span>
+          <div class="segmented-control layout-control" data-layout-control="text">
+            <button
+              type="button"
+              class="is-active"
+              aria-pressed="true"
+              data-layout-layer="text"
+              data-layout="single"
+            >
+              {strings.singleLayout}
+            </button>
+            <button type="button" data-layout-layer="text" data-layout="tile">
+              {strings.tileLayout}
+            </button>
+          </div>
+        </div>
+
         <details class="advanced-controls">
           <summary>{strings.advanced}</summary>
-          <div class="layout-choice">
-            <span>{strings.layout}</span>
-            <div class="segmented-control layout-control" data-layout-control="text">
-              <button type="button" data-layout-layer="text" data-layout="single">
-                {strings.singleLayout}
-              </button>
-              <button
-                type="button"
-                class="is-active"
-                aria-pressed="true"
-                data-layout-layer="text"
-                data-layout="tile"
-              >
-                {strings.tileLayout}
-              </button>
-            </div>
-          </div>
           <div class="field-grid advanced-grid">
             <label class="field range-field">
-              <span>{strings.rotation} <output data-text-rotation-output>−24°</output></span>
-              <input type="range" min="-45" max="45" value="-24" step="1" data-text-rotation />
+              <span>{strings.rotation} <output data-text-rotation-output>−7°</output></span>
+              <input type="range" min="-45" max="45" value="-7" step="1" data-text-rotation />
             </label>
           </div>
-          <div class="option-grid" data-single-options="text" hidden>
+          <div class="option-grid" data-single-options="text">
             <CustomSelect
               id={`${idPrefix}-text-position`}
               label={strings.position}
@@ -428,7 +540,7 @@ const formats = [
               <input type="number" min="-500" max="500" value="48" step="1" data-text-y />
             </label>
           </div>
-          <div class="option-grid tile-options" data-tile-options="text">
+          <div class="option-grid tile-options" data-tile-options="text" hidden>
             <label class="field compact-field">
               <span>{strings.gapX}</span>
               <input type="text" value="8%" inputmode="decimal" data-text-gap-x />
@@ -472,25 +584,26 @@ const formats = [
           </label>
         </div>
 
+        <div class="layout-choice primary-layout-choice">
+          <span>{strings.layout}</span>
+          <div class="segmented-control layout-control" data-layout-control="image">
+            <button
+              type="button"
+              class="is-active"
+              aria-pressed="true"
+              data-layout-layer="image"
+              data-layout="single"
+            >
+              {strings.singleLayout}
+            </button>
+            <button type="button" data-layout-layer="image" data-layout="tile">
+              {strings.tileLayout}
+            </button>
+          </div>
+        </div>
+
         <details class="advanced-controls">
           <summary>{strings.advanced}</summary>
-          <div class="layout-choice">
-            <span>{strings.layout}</span>
-            <div class="segmented-control layout-control" data-layout-control="image">
-              <button
-                type="button"
-                class="is-active"
-                aria-pressed="true"
-                data-layout-layer="image"
-                data-layout="single"
-              >
-                {strings.singleLayout}
-              </button>
-              <button type="button" data-layout-layer="image" data-layout="tile">
-                {strings.tileLayout}
-              </button>
-            </div>
-          </div>
           <div class="field-grid advanced-grid">
             <label class="field range-field">
               <span>{strings.rotation} <output data-image-rotation-output>0°</output></span>
@@ -558,6 +671,65 @@ const formats = [
       </fieldset>
     </form>
   </div>
+
+  <section class="capability-index" aria-labelledby={`${idPrefix}-capabilities-title`}>
+    <strong id={`${idPrefix}-capabilities-title`}>{strings.capabilitiesTitle}</strong>
+    <ul>
+      {strings.capabilities.map((capability) => <li>{capability}</li>)}
+    </ul>
+  </section>
+
+  <section
+    class="batch-panel"
+    aria-labelledby={`${idPrefix}-batch-title`}
+    data-batch-panel
+    tabindex="-1"
+  >
+    <div class="batch-heading">
+      <div>
+        <p class="panel-kicker">{strings.batchEyebrow}</p>
+        <h3 id={`${idPrefix}-batch-title`}>{strings.batchTitle}</h3>
+        <p>{strings.batchDescription}</p>
+      </div>
+      <div class="batch-picker">
+        <input
+          id={`${idPrefix}-batch-files`}
+          type="file"
+          accept="image/*"
+          multiple
+          data-batch-files
+        />
+        <label class="file-button" for={`${idPrefix}-batch-files`}>{strings.chooseBatch}</label>
+        <span data-batch-selection>{strings.batchNone}</span>
+      </div>
+    </div>
+    <div class="batch-progress-row">
+      <div
+        class="batch-progress"
+        role="progressbar"
+        aria-label={strings.batchRunning}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+      >
+        <span data-batch-progress></span>
+      </div>
+      <span aria-live="polite" data-batch-status>{strings.batchReady}</span>
+      <div class="batch-actions">
+        <button class="primary-button" type="button" data-batch-run disabled>
+          {strings.runBatch}
+        </button>
+        <button class="quiet-button" type="button" data-batch-cancel disabled>
+          {strings.cancelBatch}
+        </button>
+      </div>
+    </div>
+    <div class="batch-results-heading">
+      <h4>{strings.batchResults}</h4>
+      <span data-batch-summary>0 / 0</span>
+    </div>
+    <div class="batch-results" data-batch-results></div>
+  </section>
 
   <section class="code-panel" aria-labelledby={`${idPrefix}-code-title`}>
     <div class="code-heading">
@@ -696,7 +868,7 @@ const formats = [
     const defaultLogo = root.dataset.logoUrl ?? '';
     const state: PlaygroundState = {
       mode: 'mixed',
-      textLayout: 'tile',
+      textLayout: 'single',
       imageLayout: 'single',
       backgroundSrc: defaultBackground,
       logoSrc: defaultLogo,
@@ -722,6 +894,7 @@ const formats = [
     const colorInput = asElement<HTMLInputElement>(root, '[data-color]');
     const colorValue = asElement<HTMLElement>(root, '[data-color-value]');
     const fontSize = asElement<HTMLInputElement>(root, '[data-font-size]');
+    const textOpacity = asElement<HTMLInputElement>(root, '[data-text-opacity]');
     const bold = asElement<HTMLInputElement>(root, '[data-bold]');
     const strokeEnabled = asElement<HTMLInputElement>(root, '[data-stroke-enabled]');
     const strokeColor = asElement<HTMLInputElement>(root, '[data-stroke-color]');
@@ -751,9 +924,19 @@ const formats = [
     const quality = asElement<HTMLInputElement>(root, '[data-quality]');
     const webCode = asElement<HTMLElement>(root, '[data-web-code]');
     const nativeCode = asElement<HTMLElement>(root, '[data-native-code]');
+    const batchFiles = asElement<HTMLInputElement>(root, '[data-batch-files]');
+    const batchSelection = asElement<HTMLElement>(root, '[data-batch-selection]');
+    const batchStatus = asElement<HTMLElement>(root, '[data-batch-status]');
+    const batchSummary = asElement<HTMLElement>(root, '[data-batch-summary]');
+    const batchProgress = asElement<HTMLElement>(root, '[data-batch-progress]');
+    const batchProgressbar = batchProgress.parentElement;
+    const batchRun = asElement<HTMLButtonElement>(root, '[data-batch-run]');
+    const batchCancel = asElement<HTMLButtonElement>(root, '[data-batch-cancel]');
+    const batchResults = asElement<HTMLElement>(root, '[data-batch-results]');
 
     const getTextLayer = (Position: PositionEnum) => ({
       text: textInput.value || 'IMAGE MARKER',
+      alpha: numberValue(textOpacity),
       ...(state.textLayout === 'tile'
         ? {
             layout: {
@@ -851,6 +1034,7 @@ const formats = [
 
     const textLayerCode = () => `{
   text: ${JSON.stringify(textInput.value || 'IMAGE MARKER')},
+  alpha: ${Number(textOpacity.value)},
   ${state.textLayout === 'tile'
     ? `layout: ${tileLayoutCode(textGapX, textGapY, textLayoutX, textLayoutY, textStagger)},`
     : `position: ${positionCode(textPosition.value, textX.value, textY.value)},`}
@@ -923,6 +1107,7 @@ ${layers}
       colorValue.textContent = colorInput.value.toUpperCase();
       strokeColorValue.textContent = strokeColor.value.toUpperCase();
       asElement<HTMLOutputElement>(root, '[data-font-size-output]').value = `${fontSize.value} px`;
+      asElement<HTMLOutputElement>(root, '[data-text-opacity-output]').value = `${Math.round(Number(textOpacity.value) * 100)}%`;
       asElement<HTMLOutputElement>(root, '[data-stroke-width-output]').value = `${strokeWidth.value} px`;
       asElement<HTMLOutputElement>(root, '[data-text-rotation-output]').value = `${Number(textRotation.value) < 0 ? '−' : ''}${Math.abs(Number(textRotation.value))}°`;
       asElement<HTMLOutputElement>(root, '[data-opacity-output]').value = `${Math.round(Number(opacity.value) * 100)}%`;
@@ -982,10 +1167,217 @@ ${layers}
       updateCode();
     };
 
+    const setActiveExample = (example: string | undefined) => {
+      root.querySelectorAll<HTMLButtonElement>('[data-example]').forEach((button) => {
+        const selected = button.dataset.example === example;
+        button.classList.toggle('is-active', selected);
+        button.setAttribute('aria-pressed', String(selected));
+      });
+    };
+
+    const setCustomSelectValue = (select: HTMLSelectElement, value: string) => {
+      select.value = value;
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
+    const applyExample = (example: string) => {
+      setActiveExample(example);
+      if (example === 'batch') {
+        const batchPanel = asElement<HTMLElement>(root, '[data-batch-panel]');
+        batchPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        batchPanel.focus({ preventScroll: true });
+        return;
+      }
+
+      bold.checked = true;
+      colorInput.value = '#ffffff';
+      strokeColor.value = '#101828';
+      textStagger.checked = true;
+
+      if (example === 'mixed') {
+        updateMode('mixed');
+        updateLayout('text', 'single');
+        updateLayout('image', 'single');
+        textInput.value = 'SHOT ON IMAGE MARKER';
+        textOpacity.value = '0.85';
+        fontSize.value = '42';
+        strokeEnabled.checked = true;
+        strokeWidth.value = '2';
+        textRotation.value = '-7';
+        opacity.value = '1';
+        scale.value = '0.72';
+        imageRotation.value = '0';
+        textX.value = '48';
+        textY.value = '48';
+        imageX.value = '42';
+        imageY.value = '42';
+        setCustomSelectValue(textPosition, 'bottomLeft');
+        setCustomSelectValue(imagePosition, 'topRight');
+      } else if (example === 'outline') {
+        updateMode('text');
+        updateLayout('text', 'single');
+        textInput.value = 'IMAGE MARKER';
+        textOpacity.value = '1';
+        fontSize.value = '48';
+        strokeEnabled.checked = true;
+        strokeWidth.value = '4';
+        textRotation.value = '0';
+        textX.value = '36';
+        textY.value = '36';
+        setCustomSelectValue(textPosition, 'topLeft');
+      } else if (example === 'tiled-text') {
+        updateMode('text');
+        updateLayout('text', 'tile');
+        textInput.value = 'CONFIDENTIAL';
+        textOpacity.value = '0.55';
+        fontSize.value = '30';
+        strokeEnabled.checked = true;
+        strokeWidth.value = '2';
+        textRotation.value = '-24';
+      } else if (example === 'tiled-logo') {
+        updateMode('image');
+        updateLayout('image', 'tile');
+        opacity.value = '0.55';
+        scale.value = '0.22';
+        imageRotation.value = '-12';
+        imageStagger.checked = true;
+      } else if (example === 'opacity') {
+        updateMode('text');
+        updateLayout('text', 'single');
+        textInput.value = 'PRIVATE PREVIEW';
+        textOpacity.value = '0.4';
+        fontSize.value = '48';
+        strokeEnabled.checked = true;
+        strokeWidth.value = '2';
+        textRotation.value = '-7';
+        textX.value = '0';
+        textY.value = '0';
+        setCustomSelectValue(textPosition, 'center');
+      }
+
+      updateStrokeOptions();
+      scheduleRender();
+    };
+
     const sourceAlt = preview.alt;
     let renderInFlight = false;
     let queuedSequence = 0;
     let renderTimer = 0;
+    let batchController: AbortController | undefined;
+    let batchObjectUrls: string[] = [];
+
+    const clearBatchResults = () => {
+      batchObjectUrls.forEach((url) => URL.revokeObjectURL(url));
+      batchObjectUrls = [];
+      batchResults.replaceChildren();
+      batchSummary.textContent = '0 / 0';
+      batchProgress.style.width = '0%';
+      batchProgressbar?.setAttribute('aria-valuenow', '0');
+    };
+
+    const setBatchProgress = (settled: number, total: number) => {
+      const percentage = total === 0 ? 0 : Math.round((settled / total) * 100);
+      batchProgress.style.width = `${percentage}%`;
+      batchProgressbar?.setAttribute('aria-valuenow', String(percentage));
+      batchSummary.textContent = `${settled} / ${total}`;
+    };
+
+    const createBatchResultCard = (
+      file: File,
+      result: Awaited<ReturnType<ReturnType<MarkerSdk['default']['createRecipe']>['applyMany']>>[number]
+    ) => {
+      const card = document.createElement('article');
+      card.className = 'batch-result-card';
+      card.dataset.batchResult = result.status;
+
+      if (result.status === 'fulfilled' && result.value instanceof Blob) {
+        const url = URL.createObjectURL(result.value);
+        batchObjectUrls.push(url);
+        const image = document.createElement('img');
+        image.src = url;
+        image.alt = file.name;
+        card.append(image);
+
+        const downloadLink = document.createElement('a');
+        const extension = result.value.type === 'image/jpeg' ? 'jpg' : 'png';
+        downloadLink.href = url;
+        downloadLink.download = `${file.name.replace(/\.[^.]+$/, '')}-marked.${extension}`;
+        downloadLink.textContent = root.dataset.batchDownload ?? 'Save';
+        downloadLink.className = 'batch-result-download';
+        card.append(downloadLink);
+      } else {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'batch-result-placeholder';
+        placeholder.textContent = result.status === 'aborted' ? '×' : '!';
+        card.append(placeholder);
+      }
+
+      const meta = document.createElement('div');
+      const name = document.createElement('strong');
+      name.textContent = file.name;
+      const statusLabel = document.createElement('span');
+      statusLabel.textContent = result.status;
+      meta.append(name, statusLabel);
+      card.append(meta);
+      return card;
+    };
+
+    const runBatch = async () => {
+      const files = [...(batchFiles.files ?? [])];
+      if (files.length < 2 || batchController) return;
+      clearBatchResults();
+      batchController = new AbortController();
+      batchRun.disabled = true;
+      batchCancel.disabled = false;
+      batchFiles.disabled = true;
+      batchStatus.textContent = `${root.dataset.batchRunning ?? ''} 0 / ${files.length}`;
+
+      try {
+        const sdk = await sdkPromise;
+        const textLayer = { type: 'text' as const, ...getTextLayer(sdk.Position) };
+        const imageLayer = { type: 'image' as const, ...getImageLayer(sdk.Position) };
+        const watermarks = state.mode === 'text'
+          ? [textLayer]
+          : state.mode === 'image'
+            ? [imageLayer]
+            : [imageLayer, textLayer];
+        const recipe = sdk.default.createRecipe(
+          {
+            watermarks,
+            saveFormat: format.value === 'jpg' ? sdk.ImageFormat.jpg : sdk.ImageFormat.png,
+            quality: numberValue(quality),
+          },
+          { resultType: 'blob' }
+        );
+        const results = await recipe.applyMany(
+          files.map((file) => ({ backgroundImage: { src: file } })),
+          {
+            concurrency: 4,
+            signal: batchController.signal,
+            onProgress(progress) {
+              setBatchProgress(progress.settled, progress.total);
+              batchStatus.textContent = `${root.dataset.batchRunning ?? ''} ${progress.settled} / ${progress.total}`;
+            },
+          }
+        );
+        batchResults.replaceChildren(
+          ...results.map((result, index) => createBatchResultCard(files[index]!, result))
+        );
+        const succeeded = results.filter((result) => result.status === 'fulfilled').length;
+        const aborted = results.filter((result) => result.status === 'aborted').length;
+        const failed = results.length - succeeded - aborted;
+        batchStatus.textContent = `${root.dataset.batchComplete ?? ''}: ${succeeded} ✓ · ${failed} ! · ${aborted} ×`;
+        setBatchProgress(results.length, results.length);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        batchStatus.textContent = `${root.dataset.batchFailed ?? ''}: ${message}`;
+      } finally {
+        batchController = undefined;
+        batchRun.disabled = files.length < 2;
+        batchCancel.disabled = true;
+        batchFiles.disabled = false;
+      }
+    };
 
     const clearResult = () => {
       state.result = '';
@@ -1099,6 +1491,7 @@ ${layers}
 
     root.querySelectorAll<HTMLButtonElement>('[data-mode]').forEach((button) => {
       button.addEventListener('click', () => {
+        setActiveExample(undefined);
         updateMode((button.dataset.mode ?? 'mixed') as PlaygroundMode);
         scheduleRender();
       });
@@ -1106,6 +1499,7 @@ ${layers}
 
     root.querySelectorAll<HTMLButtonElement>('[data-layout-layer]').forEach((button) => {
       button.addEventListener('click', () => {
+        setActiveExample(undefined);
         updateLayout(
           (button.dataset.layoutLayer ?? 'text') as 'text' | 'image',
           (button.dataset.layout ?? 'single') as LayoutMode
@@ -1114,10 +1508,15 @@ ${layers}
       });
     });
 
+    root.querySelectorAll<HTMLButtonElement>('[data-example]').forEach((button) => {
+      button.addEventListener('click', () => applyExample(button.dataset.example ?? 'mixed'));
+    });
+
     const liveInputs = [
       textInput,
       colorInput,
       fontSize,
+      textOpacity,
       bold,
       strokeEnabled,
       strokeColor,
@@ -1145,7 +1544,10 @@ ${layers}
       format,
       quality,
     ];
-    liveInputs.forEach((input) => input.addEventListener('input', scheduleRender));
+    liveInputs.forEach((input) => input.addEventListener('input', () => {
+      setActiveExample(undefined);
+      scheduleRender();
+    }));
     strokeEnabled.addEventListener('change', updateStrokeOptions);
     format.addEventListener('change', scheduleRender);
     textPosition.addEventListener('change', scheduleRender);
@@ -1201,6 +1603,32 @@ ${layers}
       state.logoSrc = src;
     });
 
+    batchFiles.addEventListener('change', () => {
+      clearBatchResults();
+      const files = [...(batchFiles.files ?? [])];
+      const invalid = files.find(
+        (file) => file.size > MAX_FILE_BYTES || (file.type && !file.type.startsWith('image/'))
+      );
+      if (invalid) {
+        batchStatus.textContent = root.dataset.fileTooLarge ?? root.dataset.sourceFailed ?? '';
+        batchSelection.textContent = root.dataset.batchNone ?? '';
+        batchRun.disabled = true;
+        return;
+      }
+      batchSelection.textContent = files.length === 0
+        ? root.dataset.batchNone ?? ''
+        : `${files.length} ${root.dataset.batchSelected ?? ''}`;
+      batchStatus.textContent = root.dataset.batchReady ?? '';
+      batchRun.disabled = files.length < 2;
+    });
+    batchRun.addEventListener('click', () => void runBatch());
+    batchCancel.addEventListener('click', () => {
+      batchController?.abort();
+      batchCancel.disabled = true;
+      batchStatus.textContent = root.dataset.batchCancelling ?? '';
+    });
+    window.addEventListener('pagehide', clearBatchResults, { once: true });
+
     asElement<HTMLButtonElement>(root, '[data-default-background]').addEventListener('click', () => {
       state.backgroundSrc = defaultBackground;
       backgroundFile.value = '';
@@ -1219,8 +1647,9 @@ ${layers}
       backgroundFile.value = '';
       logoFile.value = '';
       updateMode('mixed');
-      updateLayout('text', 'tile');
+      updateLayout('text', 'single');
       updateLayout('image', 'single');
+      setActiveExample('mixed');
       updateStrokeOptions();
       scheduleRender();
     });
@@ -1286,7 +1715,7 @@ ${layers}
     });
 
     updateMode('mixed');
-    updateLayout('text', 'tile');
+    updateLayout('text', 'single');
     updateLayout('image', 'single');
     updateStrokeOptions();
     updateOutputs();
@@ -1418,6 +1847,44 @@ ${layers}
     font-size: 0.62rem;
   }
 
+  .capability-index {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    align-items: center;
+    gap: 0.8rem;
+    margin: 0 0 0.75rem;
+    padding: 0.58rem 0.72rem;
+    border: 1px solid var(--playground-line);
+    border-radius: 0.85rem;
+    background: color-mix(in srgb, var(--playground-panel) 88%, var(--marker-blue) 4%);
+  }
+
+  .capability-index > strong {
+    color: var(--marker-ink);
+    font-size: 0.68rem;
+    font-weight: 720;
+  }
+
+  .capability-index ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.38rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .capability-index li {
+    padding: 0.2rem 0.46rem;
+    border: 1px solid var(--playground-line);
+    border-radius: 999px;
+    color: var(--marker-muted);
+    background: var(--playground-panel-raised);
+    font-size: 0.62rem;
+    font-weight: 650;
+    line-height: 1.35;
+  }
+
   .playground-shell {
     display: grid;
     grid-template-areas: 'controls preview';
@@ -1429,6 +1896,7 @@ ${layers}
 
   .preview-panel,
   .controls-panel,
+  .batch-panel,
   .code-panel,
   .differences {
     min-width: 0;
@@ -1763,6 +2231,84 @@ ${layers}
     line-height: 1.25;
   }
 
+  .control-section legend > small {
+    float: right;
+    color: var(--marker-muted);
+    font-size: 0.6rem;
+    font-weight: 560;
+    letter-spacing: 0;
+  }
+
+  .example-presets {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem;
+  }
+
+  .example-button {
+    display: flex;
+    min-width: 0;
+    min-height: 3.45rem;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 0.18rem;
+    padding: 0.48rem 0.58rem;
+    border: 1px solid var(--playground-line);
+    border-radius: 0.65rem;
+    color: var(--marker-ink);
+    background: var(--playground-panel-raised);
+    text-align: start;
+  }
+
+  .example-button > span {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.35rem;
+  }
+
+  .example-button strong {
+    min-width: 0;
+    overflow: hidden;
+    font-size: 0.68rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .example-button em {
+    flex: none;
+    padding: 0.08rem 0.28rem;
+    border-radius: 999px;
+    color: var(--marker-coral);
+    background: color-mix(in srgb, var(--marker-coral) 12%, transparent);
+    font-size: 0.52rem;
+    font-style: normal;
+    font-weight: 750;
+  }
+
+  .example-button > small {
+    overflow: hidden;
+    color: var(--marker-muted);
+    font-size: 0.57rem;
+    line-height: 1.3;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .example-button:hover,
+  .example-button.is-active {
+    border-color: color-mix(in srgb, var(--marker-blue) 58%, var(--playground-line));
+    background: color-mix(in srgb, var(--playground-panel-raised) 88%, var(--marker-blue));
+  }
+
+  .example-button.is-active {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--marker-blue) 38%, transparent);
+  }
+
   .segmented-control {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -1855,7 +2401,7 @@ ${layers}
   }
 
   .field-grid-3 .check-field {
-    grid-column: 1 / -1;
+    grid-column: auto;
   }
 
   .stroke-grid {
@@ -1899,6 +2445,13 @@ ${layers}
     color: var(--marker-muted);
     font-size: 0.67rem;
     font-weight: 650;
+  }
+
+  .primary-layout-choice {
+    padding: 0.55rem 0.62rem;
+    border: 1px solid var(--playground-line);
+    border-radius: 0.7rem;
+    background: color-mix(in srgb, var(--playground-panel-raised) 92%, var(--marker-blue) 3%);
   }
 
   .layout-control {
@@ -2031,6 +2584,172 @@ ${layers}
     margin-top: 0;
   }
 
+  .batch-panel {
+    margin-top: 1rem;
+    padding: 1rem;
+  }
+
+  .batch-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .batch-heading h3,
+  .batch-results-heading h4 {
+    margin: 0;
+    color: var(--marker-ink);
+    letter-spacing: -0.025em;
+  }
+
+  .batch-heading h3 {
+    font-size: 1.05rem;
+  }
+
+  .batch-heading p:last-child {
+    max-width: 70ch;
+    margin: 0.35rem 0 0;
+    color: var(--marker-muted);
+    font-size: 0.72rem;
+    line-height: 1.55;
+  }
+
+  .batch-picker {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.55rem;
+  }
+
+  .batch-picker > span,
+  .batch-progress-row > span,
+  .batch-results-heading > span {
+    color: var(--marker-muted);
+    font-family: var(--sl-font-mono);
+    font-size: 0.67rem;
+  }
+
+  .batch-progress-row {
+    display: grid;
+    grid-template-columns: minmax(8rem, 1fr) minmax(10rem, auto) auto;
+    align-items: center;
+    gap: 0.8rem;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--playground-line);
+  }
+
+  .batch-progress {
+    height: 0.5rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--playground-panel-raised);
+  }
+
+  .batch-progress > span {
+    display: block;
+    width: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--marker-blue), var(--marker-coral));
+    transition: width 160ms ease;
+  }
+
+  .batch-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .batch-actions .primary-button,
+  .batch-actions .quiet-button {
+    padding-inline: 0.8rem;
+  }
+
+  .batch-results-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 1rem;
+  }
+
+  .batch-results-heading h4 {
+    font-size: 0.78rem;
+  }
+
+  .batch-results {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.65rem;
+    margin-top: 0.65rem;
+  }
+
+  .batch-results:empty {
+    display: none;
+  }
+
+  .batch-results :global(.batch-result-card) {
+    position: relative;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--playground-line);
+    border-radius: 0.75rem;
+    background: var(--playground-panel-raised);
+  }
+
+  .batch-results :global(.batch-result-card img),
+  .batch-results :global(.batch-result-placeholder) {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    background: #090b11;
+  }
+
+  .batch-results :global(.batch-result-placeholder) {
+    display: grid;
+    place-items: center;
+    color: var(--marker-coral);
+    font-size: 2rem;
+    font-weight: 760;
+  }
+
+  .batch-results :global(.batch-result-card > div:last-child) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.6rem;
+  }
+
+  .batch-results :global(.batch-result-card strong) {
+    overflow: hidden;
+    color: var(--marker-ink);
+    font-size: 0.67rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .batch-results :global(.batch-result-card > div:last-child span) {
+    flex: none;
+    color: var(--marker-muted);
+    font-size: 0.6rem;
+  }
+
+  .batch-results :global(.batch-result-download) {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.3rem 0.5rem;
+    border-radius: 999px;
+    color: #0b1020;
+    background: rgb(255 255 255 / 88%);
+    font-size: 0.62rem;
+    font-weight: 720;
+    text-decoration: none;
+  }
+
   .code-panel {
     margin-top: 1rem;
     overflow: hidden;
@@ -2152,6 +2871,10 @@ ${layers}
       overflow-y: visible;
       scrollbar-gutter: auto;
     }
+
+    .batch-results {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 
   @media (max-width: 44rem) {
@@ -2194,6 +2917,8 @@ ${layers}
     }
 
     .preview-actions,
+    .batch-heading,
+    .batch-progress-row,
     .field-grid,
     .field-grid-3,
     .stroke-grid,
@@ -2202,6 +2927,19 @@ ${layers}
     .output-grid,
     .differences dl {
       grid-template-columns: 1fr;
+    }
+
+    .capability-index {
+      grid-template-columns: 1fr;
+    }
+
+    .batch-picker {
+      justify-content: flex-start;
+    }
+
+    .batch-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
     }
 
     .playground-steps li {

--- a/website/src/content/docs/cookbook.mdx
+++ b/website/src/content/docs/cookbook.mdx
@@ -121,4 +121,46 @@ await Marker.mark({
 });
 ```
 
+### One recipe for a folder of images
+
+`createRecipe` snapshots the ordered layers and output settings. Each input supplies only its own background and optional filename. Batch results remain in input order, even when Web jobs finish in a different order.
+
+```ts
+const recipe = Marker.createRecipe({
+  watermarks: [
+    {
+      type: 'text',
+      text: '© Acme Studio',
+      position: { position: Position.bottomRight, X: 24, Y: 24 },
+      style: { color: '#FFFFFF', fontSize: 28, bold: true },
+    },
+  ],
+  saveFormat: ImageFormat.jpg,
+  quality: 90,
+});
+
+const controller = new AbortController();
+const results = await recipe.applyMany(
+  photos.map((src) => ({ backgroundImage: { src } })),
+  {
+    concurrency: 2,
+    signal: controller.signal,
+    onProgress({ settled, total, failed }) {
+      console.log(`${settled}/${total}; ${failed} failed`);
+    },
+  }
+);
+```
+
+Calling `controller.abort()` stops new items from starting. Items already rendering finish normally. A failed item is reported as `rejected` without stopping the rest of the queue.
+
+For browser file queues, opt into direct byte output:
+
+```ts
+const webRecipe = Marker.createRecipe(recipeOptions, { resultType: 'blob' });
+const blob = await webRecipe.apply({ backgroundImage: { src: file } });
+```
+
+The SDK does not create an object URL. Create and revoke one in your UI only when you need a preview.
+
 To try the Web SDK without installing anything, open the [live playground](/playground/). For native controls and the architecture status panel, run the [React Native example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/example) or [Expo example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/expo-example).

--- a/website/src/content/docs/guides/choose-an-api.mdx
+++ b/website/src/content/docs/guides/choose-an-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: Choose an API
-description: Pick markText, markImage, or mark based on the watermark layers you need.
+description: Pick markText, markImage, mark, or a reusable Recipe based on the work you need to do.
 ---
 
 import { TabItem, Tabs } from '@astrojs/starlight/components';
@@ -12,6 +12,7 @@ The three public methods share the same output options. Choose by layer type:
 | `Marker.markText` | One or many text watermarks | Text array order |
 | `Marker.markImage` | One or many image watermarks | Image array order |
 | `Marker.mark` | Text and image watermarks together | Exact `watermarks` array order |
+| `Marker.createRecipe` | Reuse ordered layers across one or many images | Exact `watermarks` array order |
 
 `markText` and `markImage` remain supported. Use `mark` when a single render needs both text and image layers or when cross-type ordering matters.
 
@@ -87,6 +88,12 @@ The three public methods share the same output options. Choose by layer type:
     ```
   </TabItem>
 </Tabs>
+
+## When to create a Recipe
+
+Use `createRecipe` when the watermark configuration stays the same while the background changes. A Recipe accepts only the modern ordered `watermarks` array; pass `backgroundImage` and `filename` to `apply()` or `applyMany()` for each input.
+
+`applyMany()` reports every item independently and preserves input order. Its default concurrency is 1. Web accepts up to 4 active jobs; iOS and Android stay at 1 to limit native memory pressure. An `AbortSignal` stops new work from being dispatched without claiming to interrupt a render already in progress.
 
 ## Layer order
 

--- a/website/src/content/docs/guides/position-and-style.md
+++ b/website/src/content/docs/guides/position-and-style.md
@@ -84,16 +84,16 @@ Do not set both `fontSize` and `fontSizeRatio` unless you have verified which be
 
 These text options work on iOS, Android, and Web:
 
-| Property | Purpose |
-| --- | --- |
-| `color` | Text color |
-| `fontName` | Platform font family or iOS PostScript name |
-| `fontSize` / `fontSizeRatio` | Fixed or responsive size |
-| `bold`, `italic`, `underline`, `strikeThrough` | Font decorations |
-| `rotate`, `skewX` | Transform the text |
-| `shadowStyle` | Shadow offset, radius, and color |
-| `strokeStyle` | Outline color and width |
-| `textBackgroundStyle` | Padding, color, stretch mode, and corner radius |
+| Property                                       | Purpose                                         |
+| ---------------------------------------------- | ----------------------------------------------- |
+| `color`                                        | Text color                                      |
+| `fontName`                                     | Platform font family or iOS PostScript name     |
+| `fontSize` / `fontSizeRatio`                   | Fixed or responsive size                        |
+| `bold`, `italic`, `underline`, `strikeThrough` | Font decorations                                |
+| `rotate`, `skewX`                              | Transform the text                              |
+| `shadowStyle`                                  | Shadow offset, radius, and color                |
+| `strokeStyle`                                  | Outline color and width                         |
+| `textBackgroundStyle`                          | Padding, color, stretch mode, and corner radius |
 
 Use `TextBackgroundType.none` when the background should fit the text rather than stretch. Its serialized value is `fit`.
 
@@ -113,6 +113,18 @@ style: {
 ```
 
 The outline is included in anchoring and tile spacing. Set `strokeStyle` to `null` or omit it to keep the previous fill-only rendering.
+
+### Text opacity
+
+Set `alpha` on a text layer to fade the complete watermark—including its fill, outline, shadow, and background—without rewriting every color. The value is a number from `0` to `1`; the default is `1`.
+
+```ts
+{
+  text: 'CONFIDENTIAL',
+  alpha: 0.55,
+  style: { color: '#FFFFFF', fontSize: 32 },
+}
+```
 
 ### Custom fonts
 

--- a/website/src/content/docs/zh-cn/cookbook.mdx
+++ b/website/src/content/docs/zh-cn/cookbook.mdx
@@ -121,4 +121,46 @@ await Marker.mark({
 });
 ```
 
+### 一套配方处理整批图片
+
+`createRecipe` 会保存有序图层和导出设置。每次输入只需要提供自己的底图和可选文件名。即使 Web 任务完成顺序不同，批量结果也始终与输入顺序一致。
+
+```ts
+const recipe = Marker.createRecipe({
+  watermarks: [
+    {
+      type: 'text',
+      text: '© Acme Studio',
+      position: { position: Position.bottomRight, X: 24, Y: 24 },
+      style: { color: '#FFFFFF', fontSize: 28, bold: true },
+    },
+  ],
+  saveFormat: ImageFormat.jpg,
+  quality: 90,
+});
+
+const controller = new AbortController();
+const results = await recipe.applyMany(
+  photos.map((src) => ({ backgroundImage: { src } })),
+  {
+    concurrency: 2,
+    signal: controller.signal,
+    onProgress({ settled, total, failed }) {
+      console.log(`${settled}/${total}，${failed} 个失败`);
+    },
+  }
+);
+```
+
+调用 `controller.abort()` 后不会再派发新任务；已经开始渲染的图片仍会正常结束。单张图片失败会记录为 `rejected`，不会中断其他任务。
+
+浏览器批量处理本地文件时，可以显式返回二进制结果：
+
+```ts
+const webRecipe = Marker.createRecipe(recipeOptions, { resultType: 'blob' });
+const blob = await webRecipe.apply({ backgroundImage: { src: file } });
+```
+
+SDK 不会自动创建 Object URL。只有在界面需要预览时，才由调用方创建并及时释放。
+
 如需免安装体验 Web SDK，请打开[在线体验](/zh-cn/playground/)。如需使用原生交互控件和查看架构状态面板，请运行 [React Native 示例](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/example)或 [Expo 示例](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/expo-example)。

--- a/website/src/content/docs/zh-cn/guides/choose-an-api.mdx
+++ b/website/src/content/docs/zh-cn/guides/choose-an-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: 选择 API
-description: 根据所需的水印图层，在 markText、markImage 或 mark 之间进行选择。
+description: 根据图层类型和处理方式，在 markText、markImage、mark 或可复用 Recipe 之间进行选择。
 ---
 
 import { TabItem, Tabs } from '@astrojs/starlight/components';
@@ -12,6 +12,7 @@ import { TabItem, Tabs } from '@astrojs/starlight/components';
 | `Marker.markText` | 一个或多个文本水印 | 文本数组顺序 |
 | `Marker.markImage` | 一个或多个图像水印 | 图像数组顺序 |
 | `Marker.mark` | 同时包含文本和图像水印 | 严格按照 `watermarks` 数组顺序 |
+| `Marker.createRecipe` | 将同一组有序图层用于一张或多张图片 | 严格按照 `watermarks` 数组顺序 |
 
 `markText` 和 `markImage` 仍受支持。当一次渲染需要同时包含文本和图像图层，或不同类型图层之间的顺序很重要时，请使用 `mark`。
 
@@ -87,6 +88,12 @@ import { TabItem, Tabs } from '@astrojs/starlight/components';
     ```
   </TabItem>
 </Tabs>
+
+## 什么时候创建 Recipe
+
+当水印配置保持不变、只有底图发生变化时，适合使用 `createRecipe`。Recipe 只接受现代的有序 `watermarks` 数组；每张图片的 `backgroundImage` 和 `filename` 应传给 `apply()` 或 `applyMany()`。
+
+`applyMany()` 会独立报告每一项，并保持输入顺序。默认并发为 1；Web 最多允许 4 个活动任务，iOS 和 Android 固定为 1，以控制原生内存压力。传入 `AbortSignal` 后会停止派发新任务，但不会宣称能够中断已经开始的渲染。
 
 ## 图层顺序
 

--- a/website/src/content/docs/zh-cn/guides/position-and-style.md
+++ b/website/src/content/docs/zh-cn/guides/position-and-style.md
@@ -84,16 +84,16 @@ style: {
 
 以下文字样式可用于 iOS、Android 和 Web：
 
-| 属性 | 用途 |
-| --- | --- |
-| `color` | 文本颜色 |
-| `fontName` | 平台字体族或 iOS PostScript 名称 |
-| `fontSize` / `fontSizeRatio` | 固定或响应式大小 |
-| `bold`、`italic`、`underline`、`strikeThrough` | 字体装饰 |
-| `rotate`、`skewX` | 文本变换 |
-| `shadowStyle` | 阴影的偏移量、半径和颜色 |
-| `strokeStyle` | 文字描边的颜色和宽度 |
-| `textBackgroundStyle` | 内边距、颜色、拉伸模式和圆角半径 |
+| 属性                                           | 用途                             |
+| ---------------------------------------------- | -------------------------------- |
+| `color`                                        | 文本颜色                         |
+| `fontName`                                     | 平台字体族或 iOS PostScript 名称 |
+| `fontSize` / `fontSizeRatio`                   | 固定或响应式大小                 |
+| `bold`、`italic`、`underline`、`strikeThrough` | 字体装饰                         |
+| `rotate`、`skewX`                              | 文本变换                         |
+| `shadowStyle`                                  | 阴影的偏移量、半径和颜色         |
+| `strokeStyle`                                  | 文字描边的颜色和宽度             |
+| `textBackgroundStyle`                          | 内边距、颜色、拉伸模式和圆角半径 |
 
 当背景应贴合文本而不是拉伸时，请使用 `TextBackgroundType.none`。其序列化值为 `fit`。
 
@@ -113,6 +113,18 @@ style: {
 ```
 
 描边会计入锚点定位和平铺间距。将 `strokeStyle` 设为 `null` 或直接省略，即可保持原来的纯填充文字效果。
+
+### 文字透明度
+
+在文字图层上设置 `alpha`，即可同时调整文字填充、描边、阴影和背景的透明度，无需逐个改写颜色。取值范围为 `0` 到 `1`，默认值为 `1`。
+
+```ts
+{
+  text: 'CONFIDENTIAL',
+  alpha: 0.55,
+  style: { color: '#FFFFFF', fontSize: 32 },
+}
+```
 
 ### 自定义字体
 


### PR DESCRIPTION
## Summary

- add cross-platform text-layer opacity with validation and renderer coverage
- make normal and tiled text/logo layouts explicit in the playground
- add one-click outline, opacity, tiling, mixed-watermark, and v1.8 batch/Blob examples
- update the native example, bilingual docs, README, and playground smoke coverage

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` (7 suites, 74 tests)
- example and Expo example type checks
- website build (96 pages) and playground smoke tests
- Android `:react-native-image-marker:testDebugUnitTest`
- iOS `xcodebuild build-for-testing` for the example and UI test targets
