### PR TITLE
chore: release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.9.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.8.0...v1.9.0) (2026-07-18)
+
+### Features
+
+* add dynamic recipes and blend modes ([#332](https://github.com/JimmyDaddy/react-native-image-marker/pull/332)) ([c71a0e3](https://github.com/JimmyDaddy/react-native-image-marker/commit/c71a0e3ae3f50d259af66b1549517d750dfd5845))
+
 ## [1.8.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.7.0...v1.8.0) (2026-07-18)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "packageManager": "npm@10.9.4",
   "description": "Add text and image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
Prepare the combined v1.9.0 release for dynamic data-driven recipes and cross-platform layer blend modes. Updates the package metadata and changelog only. The feature implementation and full native/Web/browser matrix passed in #332; npm pack dry-run confirms the 1.9.0 artifact.