### PR TITLE
chore: release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.10.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.9.0...v1.10.0) (2026-07-19)
+
+### Features
+
+* **watermark:** add invisible trace watermarking ([#334](https://github.com/JimmyDaddy/react-native-image-marker/pull/334)) ([b0d5f06](https://github.com/JimmyDaddy/react-native-image-marker/commit/b0d5f06710b09a61ee09f31ca3e769b67794b321))
+
 ## [1.9.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.8.0...v1.9.0) (2026-07-18)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "packageManager": "npm@10.9.4",
   "description": "Add visible and invisible image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
## Summary

- bump package version to 1.10.0
- document invisible trace watermarking in the changelog
- prepare the npm release after PR #334

## Verification

- npm run prepack
- npm pack --dry-run --ignore-scripts
- full feature CI passed on PR #334