### PR TITLE
fix: harden v1.10 release quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Verify release notes generation
+        run: npm run check:release-notes
+
       - name: Test
         run: npm test -- --coverage --runInBand
 

--- a/expo-example/scripts/smoke-web.mjs
+++ b/expo-example/scripts/smoke-web.mjs
@@ -246,11 +246,27 @@ async function verifyBrowser(browserName, browserType) {
       adjustedDetected: true,
       wrongKeyDetected: false,
     });
-    assert.deepEqual(harnessResults.invisibleCorpus, {
-      fixtureCount: corpusFixtures.size,
-      detectedCount: corpusFixtures.size,
-      unmarkedFalsePositives: 0,
-    });
+    assert.equal(
+      harnessResults.invisibleCorpus.fixtureCount,
+      corpusFixtures.size
+    );
+    assert.equal(
+      harnessResults.invisibleCorpus.detectedCount,
+      corpusFixtures.size
+    );
+    assert.equal(harnessResults.invisibleCorpus.unmarkedFalsePositives, 0);
+    assert(
+      harnessResults.invisibleCorpus.minimumPsnr >= 40,
+      `Invisible watermark corpus PSNR fell below 40 dB: ${harnessResults.invisibleCorpus.minimumPsnr.toFixed(
+        2
+      )} dB.`
+    );
+    assert(
+      harnessResults.invisibleCorpus.minimumSsim >= 0.99,
+      `Invisible watermark corpus SSIM fell below 0.99: ${harnessResults.invisibleCorpus.minimumSsim.toFixed(
+        5
+      )}.`
+    );
     assert.match(harnessResults.corsMessage, /Access-Control-Allow-Origin/i);
     assert.deepEqual(
       pageErrors,
@@ -259,7 +275,11 @@ async function verifyBrowser(browserName, browserType) {
     );
 
     console.log(
-      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, invisible watermark PNG/JPEG robustness and six-image corpus, Blob/File, Blob recipe output, CORS, rotation crop, alpha, and 4096px max-size rendering.`
+      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, invisible watermark PNG/JPEG robustness and six-image quality corpus (PSNR ${harnessResults.invisibleCorpus.minimumPsnr.toFixed(
+        2
+      )} dB, SSIM ${harnessResults.invisibleCorpus.minimumSsim.toFixed(
+        5
+      )}), Blob/File, Blob recipe output, CORS, rotation crop, alpha, and 4096px max-size rendering.`
     );
   } finally {
     await browser.close();

--- a/expo-example/smoke-harness.web.ts
+++ b/expo-example/smoke-harness.web.ts
@@ -38,6 +38,8 @@ interface WebSmokeHarness {
     fixtureCount: number;
     detectedCount: number;
     unmarkedFalsePositives: number;
+    minimumPsnr: number;
+    minimumSsim: number;
   }>;
   renderCrossOrigin(url: string): Promise<string>;
 }
@@ -93,6 +95,99 @@ async function transformDataUrl(
     context.putImageData(pixels, 0, 0);
   }
   return canvas.toDataURL(type, quality);
+}
+
+async function decodeImage(source: string): Promise<HTMLImageElement> {
+  const image = new Image();
+  image.src = source;
+  await image.decode();
+  return image;
+}
+
+async function compareImageQuality(
+  referenceSource: string,
+  candidateSource: string
+): Promise<{ psnr: number; ssim: number }> {
+  const [reference, candidate] = await Promise.all([
+    decodeImage(referenceSource),
+    decodeImage(candidateSource),
+  ]);
+  const width = candidate.naturalWidth;
+  const height = candidate.naturalHeight;
+  const referenceCanvas = document.createElement('canvas');
+  const candidateCanvas = document.createElement('canvas');
+  referenceCanvas.width = candidateCanvas.width = width;
+  referenceCanvas.height = candidateCanvas.height = height;
+  const referenceContext = referenceCanvas.getContext('2d');
+  const candidateContext = candidateCanvas.getContext('2d');
+  if (!referenceContext || !candidateContext) {
+    throw new Error('Canvas 2D is unavailable.');
+  }
+  referenceContext.drawImage(reference, 0, 0, width, height);
+  candidateContext.drawImage(candidate, 0, 0, width, height);
+  const referencePixels = referenceContext.getImageData(
+    0,
+    0,
+    width,
+    height
+  ).data;
+  const candidatePixels = candidateContext.getImageData(
+    0,
+    0,
+    width,
+    height
+  ).data;
+
+  let squaredError = 0;
+  let referenceLumaSum = 0;
+  let candidateLumaSum = 0;
+  let referenceLumaSquaredSum = 0;
+  let candidateLumaSquaredSum = 0;
+  let lumaProductSum = 0;
+  const pixelCount = width * height;
+  for (let index = 0; index < referencePixels.length; index += 4) {
+    const referenceRed = referencePixels[index]!;
+    const referenceGreen = referencePixels[index + 1]!;
+    const referenceBlue = referencePixels[index + 2]!;
+    const candidateRed = candidatePixels[index]!;
+    const candidateGreen = candidatePixels[index + 1]!;
+    const candidateBlue = candidatePixels[index + 2]!;
+    squaredError +=
+      (referenceRed - candidateRed) ** 2 +
+      (referenceGreen - candidateGreen) ** 2 +
+      (referenceBlue - candidateBlue) ** 2;
+
+    const referenceLuma =
+      referenceRed * 0.2126 + referenceGreen * 0.7152 + referenceBlue * 0.0722;
+    const candidateLuma =
+      candidateRed * 0.2126 + candidateGreen * 0.7152 + candidateBlue * 0.0722;
+    referenceLumaSum += referenceLuma;
+    candidateLumaSum += candidateLuma;
+    referenceLumaSquaredSum += referenceLuma ** 2;
+    candidateLumaSquaredSum += candidateLuma ** 2;
+    lumaProductSum += referenceLuma * candidateLuma;
+  }
+
+  const meanSquaredError = squaredError / (pixelCount * 3);
+  const psnr =
+    meanSquaredError === 0
+      ? Number.POSITIVE_INFINITY
+      : 10 * Math.log10(255 ** 2 / meanSquaredError);
+  const referenceMean = referenceLumaSum / pixelCount;
+  const candidateMean = candidateLumaSum / pixelCount;
+  const referenceVariance =
+    referenceLumaSquaredSum / pixelCount - referenceMean ** 2;
+  const candidateVariance =
+    candidateLumaSquaredSum / pixelCount - candidateMean ** 2;
+  const covariance =
+    lumaProductSum / pixelCount - referenceMean * candidateMean;
+  const c1 = (0.01 * 255) ** 2;
+  const c2 = (0.03 * 255) ** 2;
+  const ssim =
+    ((2 * referenceMean * candidateMean + c1) * (2 * covariance + c2)) /
+    ((referenceMean ** 2 + candidateMean ** 2 + c1) *
+      (referenceVariance + candidateVariance + c2));
+  return { psnr, ssim };
 }
 
 async function createLargeImage(): Promise<File> {
@@ -305,6 +400,8 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
       const key = 'corpus-test-key-2026';
       let detectedCount = 0;
       let unmarkedFalsePositives = 0;
+      let minimumPsnr = Number.POSITIVE_INFINITY;
+      let minimumSsim = Number.POSITIVE_INFINITY;
       for (let index = 0; index < sources.length; index += 1) {
         const source = sources[index]!;
         const unmarked = await Marker.detectInvisible({
@@ -335,11 +432,16 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
         if (detected.detected && detected.payload === payload) {
           detectedCount += 1;
         }
+        const quality = await compareImageQuality(source, marked);
+        minimumPsnr = Math.min(minimumPsnr, quality.psnr);
+        minimumSsim = Math.min(minimumSsim, quality.ssim);
       }
       return {
         fixtureCount: sources.length,
         detectedCount,
         unmarkedFalsePositives,
+        minimumPsnr,
+        minimumSsim,
       };
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react": "~18.2.45",
         "@types/react-native": "0.70.0",
         "commitlint": "^21.2.1",
-        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "del-cli": "^5.0.0",
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^8.5.0",
@@ -2423,6 +2423,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -4837,19 +4850,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@release-it/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
@@ -6712,16 +6712,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-preset-loader": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typecheck:expo-example": "npm --prefix expo-example run typecheck",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepack": "bob build",
+    "check:release-notes": "node scripts/check-release-notes.mjs",
     "release": "release-it",
     "example": "yarn --cwd example",
     "expo-example": "yarn --cwd expo-example",
@@ -85,7 +86,7 @@
     "@types/react": "~18.2.45",
     "@types/react-native": "0.70.0",
     "commitlint": "^21.2.1",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "del-cli": "^5.0.0",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.5.0",
@@ -138,8 +139,7 @@
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",
-      "tagName": "v${version}",
-      "changelog": "grep '^## ' CHANGELOG.md | head -n 1"
+      "tagName": "v${version}"
     },
     "npm": {
       "publish": false

--- a/scripts/check-release-notes.mjs
+++ b/scripts/check-release-notes.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const repositoryRoot = resolve(import.meta.dirname, '..');
+const packageJson = JSON.parse(
+  readFileSync(join(repositoryRoot, 'package.json'), 'utf8')
+);
+assert.equal(
+  packageJson['release-it']?.git?.changelog,
+  undefined,
+  'release-it git.changelog overrides the conventional-changelog plugin.'
+);
+
+const fixtureDirectory = mkdtempSync(
+  join(repositoryRoot, '.release-notes-check-')
+);
+const git = (...args) =>
+  execFileSync('git', args, {
+    cwd: fixtureDirectory,
+    stdio: 'ignore',
+  });
+
+try {
+  writeFileSync(
+    join(fixtureDirectory, 'package.json'),
+    `${JSON.stringify(
+      { name: 'release-notes-check', version: '1.0.0' },
+      null,
+      2
+    )}\n`
+  );
+  writeFileSync(join(fixtureDirectory, 'fixture.txt'), 'initial\n');
+  writeFileSync(
+    join(fixtureDirectory, 'release-it.json'),
+    `${JSON.stringify(
+      {
+        git: {
+          commit: false,
+          tag: false,
+          push: false,
+          requireUpstream: false,
+        },
+        npm: { publish: false },
+        github: { release: false },
+        plugins: {
+          '@release-it/conventional-changelog': {
+            preset: 'conventionalcommits',
+          },
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+  git('init', '--quiet');
+  git('config', 'user.name', 'Release Notes Check');
+  git('config', 'user.email', 'release-notes-check@example.invalid');
+  git('add', '.');
+  git('commit', '--quiet', '-m', 'chore: initial release');
+  git('tag', 'v1.0.0');
+  writeFileSync(join(fixtureDirectory, 'fixture.txt'), 'fixed\n');
+  git('add', 'fixture.txt');
+  git('commit', '--quiet', '-m', 'fix: keep release notes visible');
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      join(repositoryRoot, 'node_modules/release-it/bin/release-it.js'),
+      '--config',
+      'release-it.json',
+      'patch',
+      '--dry-run',
+      '--ci',
+      '--changelog',
+    ],
+    {
+      cwd: fixtureDirectory,
+      encoding: 'utf8',
+    }
+  );
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  assert.equal(result.status, 0, output);
+  assert.match(output, /### Bug Fixes/);
+  assert.match(output, /keep release notes visible/);
+  console.log('Verified conventional release notes generation.');
+} finally {
+  rmSync(fixtureDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- enforce PSNR >= 40 dB and SSIM >= 0.99 across the six-image invisible-watermark corpus in Chromium, Firefox, and WebKit
- restore a compatible conventional-changelog preset and stop the git changelog command from shadowing the release plugin
- add a deterministic release-notes regression check to CI

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` (92 tests)
- `npm run prepack`
- `npm run check:release-notes`
- `npm --prefix expo-example run smoke:web`
- root `release-it patch --dry-run --ci --changelog` generated a non-empty 1.10.1 entry