### PR TITLE
chore: release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.10.1](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.10.0...v1.10.1) (2026-07-19)
+
+### Bug Fixes
+
+* harden v1.10 release quality gates ([95d7d2b](https://github.com/JimmyDaddy/react-native-image-marker/commit/95d7d2b59dc3b2662bebff1b559cef55e1174b0a))
+
 ## [1.10.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.9.0...v1.10.0) (2026-07-19)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "packageManager": "npm@10.9.4",
   "description": "Add visible and invisible image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
## Summary
- bump package version to 1.10.1
- add the generated 1.10.1 changelog entry

## Verification
- `npm run check:release-notes`
- `npm run prepack`