### PR TITLE
feat(watermark): add durable provenance workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       js: ${{ steps.filter.outputs.js }}
       web: ${{ steps.filter.outputs.web }}
       docs: ${{ steps.filter.outputs.docs }}
+      c2pa: ${{ steps.filter.outputs.c2pa }}
       native: ${{ steps.filter.outputs.native }}
       security: ${{ steps.filter.outputs.security }}
     steps:
@@ -161,6 +162,12 @@ jobs:
                   ".github/workflows/docs-site.yml",
               ]
           )
+          c2pa = any_changed(
+              [
+                  "examples/c2pa-service/**",
+                  ".github/workflows/ci.yml",
+              ]
+          )
           security = any_changed(
               [
                   "package.json",
@@ -171,6 +178,8 @@ jobs:
                   "example/package-lock.json",
                   "expo-example/package.json",
                   "expo-example/package-lock.json",
+                  "examples/c2pa-service/package.json",
+                  "examples/c2pa-service/package-lock.json",
                   "react-native-image-marker.podspec",
                   "android/build.gradle",
                   "android/gradle.properties",
@@ -189,6 +198,7 @@ jobs:
               "js": js,
               "web": web,
               "docs": docs,
+              "c2pa": c2pa,
               "native": android or ios,
               "security": security,
           }
@@ -272,6 +282,38 @@ jobs:
 
       - name: Build package
         run: npm run prepack
+
+  c2pa-service:
+    runs-on: ubuntu-latest
+    name: C2PA Service Example
+    needs: changes
+    if: needs.changes.outputs.c2pa == 'true'
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v7
+
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.22.0'
+          cache: npm
+          cache-dependency-path: examples/c2pa-service/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefix examples/c2pa-service
+
+      - name: Typecheck and test
+        run: |
+          npm --prefix examples/c2pa-service run typecheck
+          npm --prefix examples/c2pa-service test
+
+      - name: Audit production dependencies
+        run: npm audit --prefix examples/c2pa-service --omit=dev --audit-level=moderate
+
+      - name: Load official C2PA Node module
+        working-directory: examples/c2pa-service
+        run: |
+          node -e "import('@contentauth/c2pa-node').then(({ Builder, Reader, LocalSigner }) => { if (!Builder || !Reader || !LocalSigner) process.exit(1) })"
 
   docs-site:
     runs-on: ubuntu-latest
@@ -859,6 +901,7 @@ jobs:
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testInvisibleWatermarkFeatureEmbedsAndDetects \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testInvisibleWatermarkMatchesCrossPlatformVectors \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testInvisibleWatermarkEmbedsAndAuthenticatesPixels \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testInvisibleWatermarkRecoversLightImageResizing \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testSharpScaledWatermarkFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testRotationOutputPolicyFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testWatermarkOrientationMatchesUprightPixelReference \
@@ -917,6 +960,7 @@ jobs:
         changes,
         security,
         js-check,
+        c2pa-service,
         docs-site,
         web-example,
         expo-current,

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ yarn-error.log
 package-lock.json
 !/package-lock.json
 !website/package-lock.json
+!examples/c2pa-service/package-lock.json
 yarn.lock
 
 # BUCK

--- a/README.MD
+++ b/README.MD
@@ -195,7 +195,7 @@ Blob mode is Web-only and does not create object URLs. The caller controls `URL.
 
 ### Embed an invisible trace ID
 
-`embedInvisible` writes a short authenticated locator into the final pixels without adding a visible layer. `detectInvisible` recovers it later with the same key. Use random asset or distribution IDs—not names, email addresses, or other personal data.
+`embedInvisible` writes a short authenticated locator into the final pixels without adding a visible layer. `detectInvisible` recovers it later with the same key. The `*Many` methods create and verify recipient-specific copies while preserving input order. Use random asset or distribution IDs—not names, email addresses, or other personal data.
 
 ```ts
 const key = await loadWatermarkKeyFromTrustedStorage();
@@ -211,7 +211,7 @@ const detection = await Marker.detectInvisible({
   image: { src: { uri: marked } },
   key,
   strength: 'robust',
-  search: 'fast',
+  search: 'robust',
 });
 
 if (detection.detected) {
@@ -219,7 +219,11 @@ if (detection.detected) {
 }
 ```
 
-This Beta feature is designed for distribution tracing, not DRM or proof that an image was never edited. JPEG recompression and mild pixel adjustments are covered by the browser test matrix; aggressive crops, resizing, blur, redrawing, and deliberate removal can destroy the mark. Browser code cannot keep a long-lived secret, so production Web workflows should embed on a trusted server or use tightly scoped keys. See the [invisible watermark guide](https://image-marker.corerobin.com/guides/invisible-watermarks/).
+For distribution batches, call `Marker.embedInvisibleMany(inputs, { concurrency, signal, onProgress })` and `Marker.detectInvisibleMany(inputs)`. Robust detection covers limited crops and tested 0.9×–1.1× resize hypotheses; a successful resized detection reports `scale`.
+
+This Beta feature is designed for distribution tracing, not DRM or proof that an image was never edited. JPEG recompression, mild pixel adjustments, and light resizing are covered by the browser test matrix; aggressive crops, resizing outside the tested range, blur, redrawing, and deliberate removal can destroy the mark. Browser code cannot keep a long-lived secret, so production Web workflows should embed on a trusted server or use tightly scoped keys.
+
+For signed provenance, `Marker.embedInvisibleWithCredentials()` composes the locator with an application-supplied Content Credentials adapter. The optional [Node.js C2PA service example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/examples/c2pa-service) keeps the official C2PA runtime and signing material outside the core package. See the [invisible watermark guide](https://image-marker.corerobin.com/guides/invisible-watermarks/) for the security and C2PA boundaries.
 
 ## Live Web SDK
 
@@ -246,6 +250,8 @@ Browser Canvas and native graphics stacks share the API and positioning model bu
 | `Marker.createRecipe`    | Reusable, personalized batch workflows           |
 | `Marker.embedInvisible`  | Write an authenticated short trace ID            |
 | `Marker.detectInvisible` | Recover and verify an invisible trace ID         |
+| `Marker.embedInvisibleMany` / `detectInvisibleMany` | Process ordered trace batches       |
+| `Marker.embedInvisibleWithCredentials` | Add a signed provenance adapter workflow    |
 
 Layers render in array order, so later layers draw over earlier layers. `markText` and `markImage` remain supported; use `mark` when mixed layer order matters.
 
@@ -276,6 +282,7 @@ See the full [compatibility guide](https://image-marker.corerobin.com/compatibil
 
 - [React Native example](example) — full Image Marker Lab and architecture status
 - [Expo example](expo-example) — native development-build workflow plus a dedicated React Native Web entry
+- [C2PA service example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/examples/c2pa-service) — optional Node.js signing and verification adapter
 
 ## Contributing
 

--- a/android/src/main/java/com/jimmydaddy/imagemarker/InvisibleWatermark.kt
+++ b/android/src/main/java/com/jimmydaddy/imagemarker/InvisibleWatermark.kt
@@ -12,19 +12,22 @@ import kotlin.math.cos
 import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
 internal data class InvisibleWatermarkDetection(
   val detected: Boolean,
   val payload: String? = null,
   val confidence: Double,
-  val bitErrorRate: Double? = null
+  val bitErrorRate: Double? = null,
+  val scale: Double? = null
 ) {
   fun toJson(): String = JSONObject().apply {
     put("detected", detected)
     payload?.let { put("payload", it) }
     put("confidence", confidence)
     bitErrorRate?.let { put("bitErrorRate", it) }
+    scale?.let { put("scale", it) }
     put("algorithm", InvisibleWatermark.ALGORITHM)
   }.toString()
 }
@@ -68,6 +71,15 @@ internal object InvisibleWatermark {
     val confidence: Double,
     val bitErrorRate: Double
   )
+
+  internal data class PixelBuffer(
+    val pixels: IntArray,
+    val width: Int,
+    val height: Int
+  )
+
+  private val resizeScales = doubleArrayOf(0.95, 1.05, 0.9, 1.1)
+  private val channelShifts = intArrayOf(24, 16, 8, 0)
 
   fun embed(
     bitmap: Bitmap,
@@ -147,9 +159,66 @@ internal object InvisibleWatermark {
     require(search == "fast" || search == "robust") { "Unsupported invisible watermark search mode: $search." }
     val permutation = permutation(key)
     val seed = seedForKey(keyBytes)
-    val offsets = if (search == "robust") BLOCK_SIZE else 1
-    val phaseXs = if (search == "robust") TILE_WIDTH else 1
-    val phaseYs = if (search == "robust") TILE_HEIGHT else 1
+    val scales = if (search == "robust") doubleArrayOf(1.0, *resizeScales) else doubleArrayOf(1.0)
+
+    for (scale in scales) {
+      val candidateBuffer = if (scale == 1.0) {
+        PixelBuffer(pixels, width, height)
+      } else {
+        val targetWidth = (width / scale).roundToInt()
+        val targetHeight = (height / scale).roundToInt()
+        if (targetWidth < MIN_WIDTH || targetHeight < MIN_HEIGHT) continue
+        if (scale < 1) {
+          resizePixelsNearest(pixels, width, height, targetWidth, targetHeight)
+        } else {
+          resizePixelsBilinear(pixels, width, height, targetWidth, targetHeight)
+        }
+      }
+      val deltaFactors = if (scale == 1.0) doubleArrayOf(1.0) else doubleArrayOf(1.0, 0.9)
+      for (factor in deltaFactors) {
+        val candidate = detectAtScale(
+          candidateBuffer.pixels,
+          candidateBuffer.width,
+          candidateBuffer.height,
+          keyBytes,
+          permutation,
+          seed,
+          delta * factor,
+          robust = false
+        )
+        if (candidate != null) return candidate.toDetection(scale)
+      }
+    }
+
+    if (search == "robust") {
+      val candidate = detectAtScale(
+        pixels,
+        width,
+        height,
+        keyBytes,
+        permutation,
+        seed,
+        delta,
+        robust = true
+      )
+      if (candidate != null) return candidate.toDetection()
+    }
+    return InvisibleWatermarkDetection(false, confidence = 0.0)
+  }
+
+  private fun detectAtScale(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    keyBytes: ByteArray,
+    permutation: IntArray,
+    seed: Int,
+    delta: Double,
+    robust: Boolean
+  ): Candidate? {
+    val offsets = if (robust) BLOCK_SIZE else 1
+    val phaseXs = if (robust) TILE_WIDTH else 1
+    val phaseYs = if (robust) TILE_HEIGHT else 1
     var best: Candidate? = null
 
     for (offsetY in 0 until offsets) {
@@ -166,29 +235,100 @@ internal object InvisibleWatermark {
               phaseX,
               phaseY
             ) ?: continue
-            if (best == null || candidate.confidence > best!!.confidence) {
+            if (candidate.confidence > (best?.confidence ?: -1.0)) {
               best = candidate
-              if (search == "fast" || candidate.confidence >= 0.98) {
-                return candidate.toDetection()
+              if (!robust || candidate.confidence >= 0.98) {
+                return candidate
               }
             }
           }
         }
       }
     }
-    return best?.toDetection() ?: InvisibleWatermarkDetection(false, confidence = 0.0)
+    return best
   }
 
   internal fun frameForTesting(payload: String, key: String): ByteArray = buildFrame(payload, key)
 
   internal fun permutationForTesting(key: String): IntArray = permutation(key)
 
-  private fun Candidate.toDetection() = InvisibleWatermarkDetection(
+  internal fun resizePixelsForTesting(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    scale: Double
+  ): PixelBuffer = resizePixelsBilinear(
+    pixels,
+    width,
+    height,
+    (width * scale).roundToInt(),
+    (height * scale).roundToInt()
+  )
+
+  private fun Candidate.toDetection(scale: Double = 1.0) = InvisibleWatermarkDetection(
     detected = true,
     payload = payload,
     confidence = confidence,
-    bitErrorRate = bitErrorRate
+    bitErrorRate = bitErrorRate,
+    scale = scale.takeUnless { it == 1.0 }
   )
+
+  private fun resizePixelsNearest(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    targetWidth: Int,
+    targetHeight: Int
+  ): PixelBuffer {
+    val output = IntArray(targetWidth * targetHeight)
+    for (targetY in 0 until targetHeight) {
+      val sourceY = min(height - 1, floor((targetY + 0.5) * height / targetHeight).toInt())
+      for (targetX in 0 until targetWidth) {
+        val sourceX = min(width - 1, floor((targetX + 0.5) * width / targetWidth).toInt())
+        output[targetY * targetWidth + targetX] = pixels[sourceY * width + sourceX]
+      }
+    }
+    return PixelBuffer(output, targetWidth, targetHeight)
+  }
+
+  private fun resizePixelsBilinear(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    targetWidth: Int,
+    targetHeight: Int
+  ): PixelBuffer {
+    require(targetWidth > 0 && targetHeight > 0) { "Resize dimensions must be positive." }
+    val output = IntArray(targetWidth * targetHeight)
+    val scaleX = width.toDouble() / targetWidth
+    val scaleY = height.toDouble() / targetHeight
+    for (targetY in 0 until targetHeight) {
+      val sourceY = (targetY + 0.5) * scaleY - 0.5
+      val top = max(0, min(height - 1, floor(sourceY).toInt()))
+      val bottom = min(height - 1, top + 1)
+      val weightY = max(0.0, min(1.0, sourceY - top))
+      for (targetX in 0 until targetWidth) {
+        val sourceX = (targetX + 0.5) * scaleX - 0.5
+        val left = max(0, min(width - 1, floor(sourceX).toInt()))
+        val right = min(width - 1, left + 1)
+        val weightX = max(0.0, min(1.0, sourceX - left))
+        val topLeft = pixels[top * width + left]
+        val topRight = pixels[top * width + right]
+        val bottomLeft = pixels[bottom * width + left]
+        val bottomRight = pixels[bottom * width + right]
+        var pixel = 0
+        for (shift in channelShifts) {
+          val topValue = channel(topLeft, shift) * (1 - weightX) + channel(topRight, shift) * weightX
+          val bottomValue = channel(bottomLeft, shift) * (1 - weightX) + channel(bottomRight, shift) * weightX
+          pixel = pixel or ((topValue * (1 - weightY) + bottomValue * weightY).roundToInt().coerceIn(0, 255) shl shift)
+        }
+        output[targetY * targetWidth + targetX] = pixel
+      }
+    }
+    return PixelBuffer(output, targetWidth, targetHeight)
+  }
+
+  private fun channel(pixel: Int, shift: Int): Int = (pixel ushr shift) and 0xff
 
   private fun validatePixels(pixels: IntArray, width: Int, height: Int) {
     require(width >= MIN_WIDTH && height >= MIN_HEIGHT) {

--- a/android/src/test/java/com/jimmydaddy/imagemarker/InvisibleWatermarkTest.kt
+++ b/android/src/test/java/com/jimmydaddy/imagemarker/InvisibleWatermarkTest.kt
@@ -49,6 +49,30 @@ class InvisibleWatermarkTest {
     )
   }
 
+  @Test
+  fun recoversLightImageResizingInRobustMode() {
+    val width = 256
+    val height = 176
+    val pixels = fixture(width, height)
+    InvisibleWatermark.embedPixels(pixels, width, height, "asset-42", key, "robust")
+
+    for (scale in listOf(0.9, 0.95, 1.05, 1.1)) {
+      val resized = InvisibleWatermark.resizePixelsForTesting(pixels, width, height, scale)
+      val result = InvisibleWatermark.detectPixels(
+        resized.pixels,
+        resized.width,
+        resized.height,
+        key,
+        strength = "robust",
+        search = "robust"
+      )
+
+      assertTrue("Expected scale $scale to be recovered", result.detected)
+      assertEquals("asset-42", result.payload)
+      assertEquals(scale, result.scale!!, 0.0001)
+    }
+  }
+
   private fun fixture(width: Int, height: Int): IntArray =
     IntArray(width * height) { index ->
       val red = 80 + (index % 96)

--- a/docs/rfcs/0004-v1.11-durable-provenance-workflows.md
+++ b/docs/rfcs/0004-v1.11-durable-provenance-workflows.md
@@ -1,0 +1,233 @@
+# RFC 0004：v1.11 可扩展追踪与内容凭证工作流
+
+- 状态：Accepted
+- 目标版本：v1.11
+- 适用平台：iOS、Android、Web；可选 Node.js 服务端示例
+
+## 背景
+
+v1.10 已提供跨 iOS、Android 和 Web 的短 locator 隐形水印，但生产工作流仍有三个缺口：批量分发需要调用者自行编排；`robust` 检测只恢复有限裁剪，不能恢复轻度缩放；Web 的高成本检测会长时间占用主线程。另一方面，隐形水印只能恢复一个经过认证的 locator，不能替代带数字签名的来源声明。
+
+原计划把批量追踪与检测可靠性放在 v1.11，把 C2PA Content Credentials 集成放在 v1.12。本 RFC 将两者合并到 v1.11，但维持清晰边界：基础 SDK 继续零 C2PA 运行时依赖；签名密钥只存在于调用者提供的适配器或服务端；当前 `dct-qim-v1` 未列入 C2PA Soft Binding Algorithm List，因此不把它宣传或序列化为标准 C2PA soft binding。
+
+## 目标
+
+1. 为隐形水印提供保持输入顺序、逐项报告、可取消派发的批量嵌入与检测 API。
+2. `robust` 检测在原有裁剪恢复之外，尝试恢复 0.9× 到 1.1× 的轻度缩放。
+3. Web 高成本检测以协作式异步任务运行，定期归还主线程并支持批量取消派发。
+4. 提供不绑定具体 C2PA SDK 的 Content Credentials 适配器协议和组合 API。
+5. 提供基于官方 `@contentauth/c2pa-node` 的独立 Node.js 服务端示例，展示签名、读取与验证；证书和私钥只能从运行环境注入。
+6. 不改变 `dct-qim-v1` 帧格式，不破坏 v1.10 已生成图片的检测能力。
+
+## 非目标
+
+- 不承诺抵抗任意比例缩放、旋转、透视、截图、打印后拍照或生成式去水印。
+- 不在浏览器或移动端 SDK 中保存 C2PA 私钥、证书私钥或长期水印主密钥。
+- 不把 `dct-qim-v1` 声明成 C2PA 已登记的 soft binding 算法。
+- 不实现 C2PA Manifest Repository、标准 Soft Binding Resolution API 或公共信任列表服务。
+- 不把 48 MB 级的 C2PA Node 原生二进制加入基础 npm 包或 React Native bundle。
+- 不在 v1.11 引入 Web Worker 构建产物。协作式异步检测先解决长任务阻塞和 bundler 兼容问题；独立 Worker 可在后续版本评估。
+
+## 公共 API
+
+### 批量隐形水印
+
+复用 v1.8 的 `WatermarkBatchOptions` 与 `WatermarkBatchResult`：
+
+```ts
+Marker.embedInvisibleMany(
+  inputs: readonly EmbedInvisibleWatermarkOptions[],
+  options?: WatermarkBatchOptions<string>
+): Promise<Array<WatermarkBatchResult<string>>>;
+
+Marker.detectInvisibleMany(
+  inputs: readonly DetectInvisibleWatermarkOptions[],
+  options?: WatermarkBatchOptions<InvisibleWatermarkDetectionResult>
+): Promise<Array<WatermarkBatchResult<InvisibleWatermarkDetectionResult>>>;
+```
+
+每个输入拥有独立的 `image`、`payload`、`key`、强度和输出选项，因此可以为同一素材的不同收件人写入不同 locator。结果始终与输入同序；单项失败不拒绝整个批次。默认并发为 1，Web 上限为 4，iOS 和 Android 上限为 1。`AbortSignal` 只阻止尚未开始的项目，不声称中断已经进入 Canvas 或原生解码的任务。
+
+批量执行器从 recipe 中抽成共享的内部实现，使 `applyMany()` 与新 API 使用同一套参数校验、进度计数、异常隔离和取消语义。
+
+### 缩放恢复
+
+`DetectInvisibleWatermarkOptions.search` 保持 `'fast' | 'robust'`，不增加第二个容易冲突的开关：
+
+- `fast`：行为与 v1.10 相同，只检查原始比例、零网格偏移和零 tile 相位。
+- `robust`：先按 v1.10 路径检查原始比例与裁剪相位；失败后依次检查 0.95、1.05、0.9、1.1 的比例假设。
+
+检测器把输入按比例假设的倒数恢复到候选像素网格，再执行既有 8×8 DCT-QIM 检测。较接近 1 的候选优先，检测到高置信度有效帧后立即停止。帧格式、密钥派生、CRC 和 auth tag 都不改变。
+
+```ts
+interface InvisibleWatermarkDetectionResult {
+  // v1.10 fields...
+  /** Estimated scale of the inspected image relative to the embedded pixels. */
+  scale?: number;
+}
+```
+
+原始比例检测成功时省略 `scale`；通过缩放候选恢复时返回对应的 0.9、0.95、1.05 或 1.1。该值是检测器假设，不是精密图像测量。
+
+### Web 非阻塞检测
+
+Web 的 `detectInvisible()` 继续返回同一个 Promise，但内部使用异步检测器：
+
+1. 按 block row 分段采集 DCT observation。
+2. robust 相位搜索按固定数量候选分段。
+3. 每个时间片达到预算后，通过 `scheduler.yield()`（可用时）或 `setTimeout(0)` 归还事件循环。
+4. fast 模式也使用异步入口，但不会增加额外比例或相位搜索。
+
+目标不是让总 CPU 时间消失，而是避免在 2048 px 图片的 robust 检测中出现持续数百毫秒、不可交互的单个长任务。同步像素参考函数继续保留给单测、黄金向量和 native 对照实现。
+
+### Content Credentials 适配器
+
+基础 SDK 只定义最小协议：
+
+```ts
+interface ContentCredentialsClaim {
+  title: string;
+  format?: 'image/jpeg' | 'image/png';
+  generator?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+interface ContentCredentialsSignRequest {
+  image: string;
+  locator: string;
+  algorithm: 'dct-qim-v1';
+  claim: ContentCredentialsClaim;
+}
+
+interface ContentCredentialsSignResult {
+  image: string;
+  manifestId?: string;
+}
+
+interface ContentCredentialsVerificationResult {
+  valid: boolean;
+  manifestId?: string;
+  validationStatus?: readonly string[];
+  manifest?: unknown;
+}
+
+interface ContentCredentialsAdapter {
+  sign(
+    request: ContentCredentialsSignRequest
+  ): Promise<ContentCredentialsSignResult>;
+  verify(image: string): Promise<ContentCredentialsVerificationResult>;
+}
+
+Marker.embedInvisibleWithCredentials({
+  watermark: EmbedInvisibleWatermarkOptions,
+  adapter: ContentCredentialsAdapter,
+  claim: ContentCredentialsClaim
+}): Promise<{
+  watermarkedImage: string;
+  signedImage: string;
+  manifestId?: string;
+}>;
+
+Marker.verifyContentCredentials({
+  image: string,
+  adapter: ContentCredentialsAdapter
+}): Promise<ContentCredentialsVerificationResult>;
+```
+
+组合顺序固定为“先写入隐形 locator，再对最终像素签名”。适配器抛错时保留原始异常，不把“水印已生成但签名失败”伪装成完整成功。调用者如果需要保留中间结果，应先单独调用 `embedInvisible()`。
+
+## C2PA 合规边界
+
+C2PA 2.4 区分 hard binding 与 soft binding；soft binding 可由指纹或隐形水印提供，但写入 C2PA Manifest 的算法必须存在于维护中的 Soft Binding Algorithm List。当前登记列表包含 Digimarc、Adobe TrustMark、ISCC 等算法，没有 `dct-qim-v1`。因此 v1.11 示例遵循以下规则：
+
+1. 使用 C2PA hard binding 对已完成隐形水印处理的 JPEG/PNG 签名。
+2. 使用私有标签 `org.corerobin.image-marker.trace.v1` 写入算法名和 `SHA-256(locator)`，不写入 locator 明文。
+3. 不生成 `c2pa.watermarked` action，也不生成标准 soft binding assertion，避免产生不符合规范的 Content Credential。
+4. 文档明确说明：隐形 locator 可以供调用者自己的数据库恢复记录，但在算法完成登记前，它不是标准 C2PA Soft Binding Resolution API 的输入。
+
+规范依据：
+
+- [C2PA Content Credentials 2.4：Binding to Content](https://spec.c2pa.org/specifications/specifications/2.4/specs/ContentCredentials.html)
+- [C2PA Soft Binding Algorithm List](https://github.com/c2pa-org/softbinding-algorithm-list)
+- [官方 c2pa-js monorepo 与 `@contentauth/c2pa-node`](https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node)
+
+## Node.js 服务端示例
+
+`examples/c2pa-service` 是独立 package，不进入根包依赖树。它使用 Node.js 22、官方 `@contentauth/c2pa-node` 和内置 HTTP API，提供：
+
+- `POST /sign`：接收 base64 JPEG/PNG、locator 与 claim，返回带 Content Credential 的图片。
+- `POST /verify`：读取并验证嵌入的 Manifest，返回 manifest ID、验证状态和精简后的 manifest。
+- 请求体大小、媒体类型和 base64 格式校验。
+- 从 `C2PA_CERT_PATH`、`C2PA_PRIVATE_KEY_PATH` 和可选 `C2PA_TSA_URL` 读取签名材料。
+- 不附带示例私钥，不打印 locator、证书私钥或原始图片内容。
+
+服务实现把 C2PA SDK 封装在可注入 engine 后面；单测使用 fake engine，不需要真实签名密钥。CI 安装该独立 package、执行类型检查和单测，并确认官方 Node 模块可以加载。
+
+## 平台实现
+
+### TypeScript / Web
+
+- 共享批量执行器位于纯 TypeScript 模块。
+- 双线性 RGBA 缩放参考实现保持 alpha，并对候选尺寸重新执行最小尺寸校验。
+- 异步 detector 与同步 detector 共享 observation、frame 校验和置信度计算，禁止复制第二套帧逻辑。
+- Canvas 读取仍遵守 CORS 规则；缩放候选不会绕过 tainted canvas 限制。
+
+### Android
+
+- 原比例 robust 检测失败后，使用确定性的双线性像素缩放生成候选。
+- 候选逐一释放，不同时保留多个大 Bitmap/IntArray。
+- 维持原生任务并发上限 1。
+
+### iOS
+
+- 原比例 robust 检测失败后，在 RGBA buffer 上生成单个双线性候选并检测。
+- 使用 `autoreleasepool`/局部 buffer 生命周期控制峰值内存。
+- 维持原生任务并发上限 1。
+
+## 校验与错误
+
+- 批量输入必须是数组；并发必须是正有限整数。
+- Content Credentials adapter 必须同时提供 `sign` 与 `verify` 函数。
+- claim title 不得为空；format 只接受 JPEG/PNG。
+- adapter 返回值必须包含非空图片字符串；verification 的 `valid` 必须是布尔值。
+- 缩放候选无法检测不是异常，最终返回 `detected: false`。
+- adapter 网络、签名或验证失败属于异常，保留 adapter 的错误信息。
+
+## 测试与验收
+
+### 批量 API
+
+- Web 并发上限 4、native 上限 1、结果同序、单项失败隔离。
+- abort 前、执行中和全部完成后的行为。
+- progress observer 抛错不影响批次。
+- 每项不同 payload/key，错误 key 不串项。
+
+### 缩放与检测
+
+- TypeScript、Kotlin、Swift 覆盖 0.9、0.95、1.0、1.05、1.1 候选。
+- 六张真实图片的 0.9× 与 1.1× Web 端恢复率必须为 100%；0.95× 与 1.05× 同样纳入门禁。
+- PNG 与 JPEG 75 在轻度缩放后必须恢复；错误 key 和原图保持零误报。
+- v1.10 黄金向量和未缩放检测结果不变。
+- robust 总耗时记录到 CI 输出；不设置依赖 runner 绝对性能的脆弱秒数阈值。
+
+### Web 响应性
+
+- 浏览器 smoke 在 robust 检测运行时安排计时器心跳，至少观察到一次事件循环让出。
+- Chromium、Firefox、WebKit 都执行缩放恢复和心跳断言。
+
+### Content Credentials
+
+- core adapter 组合顺序、请求字段、返回值校验和错误透传单测。
+- 服务端 fake engine 覆盖签名、验证、超限请求、不支持媒体类型和无效 base64。
+- CI 使用 Node 22 安装并加载 `@contentauth/c2pa-node`；真实证书签名作为 maintainer 手动发布检查，不把私钥放入公共 CI。
+
+## 文档与示例
+
+- 中英文隐形水印指南增加批量分发、轻度缩放范围和性能说明。
+- Playground 增加批量 API 代码示例与 0.9×/1.1× 检测演示；C2PA 只展示工作流和服务端配置，不上传用户图片到项目维护者控制的服务。
+- React Native 与 Expo 示例展示 `embedInvisibleMany()` / `detectInvisibleMany()`。
+- README 只增加简洁能力入口，安全边界和部署细节留在指南与服务端示例。
+
+## 发布策略
+
+上述能力统一在 v1.11.0 发布。批量方法和 adapter 协议作为稳定 API；缩放恢复仍属于 `robust` 检测能力，不改变 `dct-qim-v1` 算法标识。若未来 `dct-qim-v1` 或替代算法进入 C2PA Soft Binding Algorithm List，再通过新的 RFC 增加标准 soft binding assertion 与 resolution API，不在本版本提前占用规范语义。

--- a/docs/rfcs/0004-v1.11-durable-provenance-workflows.md
+++ b/docs/rfcs/0004-v1.11-durable-provenance-workflows.md
@@ -55,9 +55,9 @@ Marker.detectInvisibleMany(
 `DetectInvisibleWatermarkOptions.search` 保持 `'fast' | 'robust'`，不增加第二个容易冲突的开关：
 
 - `fast`：行为与 v1.10 相同，只检查原始比例、零网格偏移和零 tile 相位。
-- `robust`：先按 v1.10 路径检查原始比例与裁剪相位；失败后依次检查 0.95、1.05、0.9、1.1 的比例假设。
+- `robust`：先快速检查原始比例，再依次快速检查 0.95、1.05、0.9、1.1 的比例假设；都失败后才执行原始比例的完整裁剪相位搜索。这样既保留 v1.10 的裁剪恢复，又避免每个缩放候选与完整相位搜索相乘。
 
-检测器把输入按比例假设的倒数恢复到候选像素网格，再执行既有 8×8 DCT-QIM 检测。较接近 1 的候选优先，检测到高置信度有效帧后立即停止。帧格式、密钥派生、CRC 和 auth tag 都不改变。
+检测器把输入按比例假设的倒数恢复到候选像素网格，再执行既有 8×8 DCT-QIM 检测。缩放候选会额外尝试 0.9 的量化步长衰减，用于补偿 JPEG 重编码对恢复后 DCT 幅度的削弱；不会降低 CRC 或 auth tag 校验。较接近 1 的候选优先，检测到有效帧后立即停止。帧格式、密钥派生、CRC 和 auth tag 都不改变。
 
 ```ts
 interface InvisibleWatermarkDetectionResult {
@@ -168,19 +168,19 @@ C2PA 2.4 区分 hard binding 与 soft binding；soft binding 可由指纹或隐�
 ### TypeScript / Web
 
 - 共享批量执行器位于纯 TypeScript 模块。
-- 双线性 RGBA 缩放参考实现保持 alpha，并对候选尺寸重新执行最小尺寸校验。
+- RGBA 缩放参考实现保持 alpha，并对候选尺寸重新执行最小尺寸校验。恢复放大过的输入时使用双线性缩小；恢复已缩小的输入时使用确定性最近邻放大，避免二次插值继续削弱 DCT 信号。
 - 异步 detector 与同步 detector 共享 observation、frame 校验和置信度计算，禁止复制第二套帧逻辑。
 - Canvas 读取仍遵守 CORS 规则；缩放候选不会绕过 tainted canvas 限制。
 
 ### Android
 
-- 原比例 robust 检测失败后，使用确定性的双线性像素缩放生成候选。
+- 原比例快速检测失败后，使用确定性的双线性缩小或最近邻放大生成候选；候选失败后再执行原比例完整 robust 搜索。
 - 候选逐一释放，不同时保留多个大 Bitmap/IntArray。
 - 维持原生任务并发上限 1。
 
 ### iOS
 
-- 原比例 robust 检测失败后，在 RGBA buffer 上生成单个双线性候选并检测。
+- 原比例快速检测失败后，在 RGBA buffer 上生成单个双线性缩小或最近邻放大候选并检测；候选失败后再执行原比例完整 robust 搜索。
 - 使用 `autoreleasepool`/局部 buffer 生命周期控制峰值内存。
 - 维持原生任务并发上限 1。
 
@@ -206,7 +206,7 @@ C2PA 2.4 区分 hard binding 与 soft binding；soft binding 可由指纹或隐�
 
 - TypeScript、Kotlin、Swift 覆盖 0.9、0.95、1.0、1.05、1.1 候选。
 - 六张真实图片的 0.9× 与 1.1× Web 端恢复率必须为 100%；0.95× 与 1.05× 同样纳入门禁。
-- PNG 与 JPEG 75 在轻度缩放后必须恢复；错误 key 和原图保持零误报。
+- PNG 轻度缩放，以及 JPEG 75 重编码后再轻度缩放都必须恢复；错误 key 和原图保持零误报。
 - v1.10 黄金向量和未缩放检测结果不变。
 - robust 总耗时记录到 CI 输出；不设置依赖 runner 绝对性能的脆弱秒数阈值。
 

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -256,7 +256,7 @@ final class ImageMarkerExampleUITests: XCTestCase {
 
     XCTAssertTrue(app.otherElements["result-preview-ready"].waitForExistence(timeout: 30))
     let verified = app.staticTexts.matching(
-      NSPredicate(format: "label BEGINSWITH %@", "Invisible trace verified: asset-42")
+      NSPredicate(format: "label BEGINSWITH %@", "Invisible batch verified · 2 outputs")
     ).firstMatch
     XCTAssertTrue(verified.waitForExistence(timeout: 10))
   }

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -157,6 +157,34 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertGreaterThan(result.confidence, 0.8)
   }
 
+  func testInvisibleWatermarkRecoversLightImageResizing() throws {
+    let image = makeSolidImage(
+      size: CGSize(width: 256, height: 176),
+      color: UIColor(red: 0.35, green: 0.48, blue: 0.62, alpha: 1)
+    )
+    let key = "0123456789abcdef"
+    let marked = try InvisibleWatermark.embed(
+      image: image,
+      payload: "asset-42",
+      key: key,
+      strength: "robust"
+    )
+
+    for scale in [0.9, 0.95, 1.05, 1.1] {
+      let resized = try InvisibleWatermark.resizeForTesting(image: marked, scale: scale)
+      let result = try InvisibleWatermark.detect(
+        image: resized,
+        key: key,
+        strength: "robust",
+        search: "robust"
+      )
+
+      XCTAssertTrue(result.detected, "Expected scale \(scale) to be recovered")
+      XCTAssertEqual(result.payload, "asset-42")
+      XCTAssertEqual(result.scale ?? 0, scale, accuracy: 0.0001)
+    }
+  }
+
   func testApp() throws {
     let app = XCUIApplication()
     app.launch()

--- a/example/src/ImageMarkerLab.tsx
+++ b/example/src/ImageMarkerLab.tsx
@@ -1093,12 +1093,12 @@ function useViewModel(props: ImageMarkerLabProps) {
 
   async function runInvisibleWatermarkFeature() {
     const key = 'example-only-key-2026';
-    const payload = 'asset-42';
+    const payloads = ['asset-41', 'asset-42'];
     setBackgroundFormat('normal image');
     applyConfig({
       image: assets.bg,
       waterMarkType: 'text',
-      text: payload,
+      text: payloads[0],
       saveFormat: ImageFormat.png,
       backgroundScale: 1,
       backgroundRotate: 0,
@@ -1109,31 +1109,59 @@ function useViewModel(props: ImageMarkerLabProps) {
     setLoading(true);
 
     try {
-      const path = await Marker.embedInvisible({
-        image: { src: assets.bg },
-        payload,
-        key,
-        strength: 'robust',
-        saveFormat: ImageFormat.png,
-        filename: 'invisible-watermark-demo',
+      const embedded = await Marker.embedInvisibleMany(
+        payloads.map((payload) => ({
+          image: { src: assets.bg },
+          payload,
+          key,
+          strength: 'robust',
+          saveFormat: ImageFormat.png,
+          filename: `invisible-watermark-${payload}`,
+        })),
+        { concurrency: 2 }
+      );
+      const paths = embedded.map((result) => {
+        if (result.status !== 'fulfilled') {
+          throw result.status === 'rejected'
+            ? result.reason
+            : new Error('Invisible batch was aborted.');
+        }
+        return result.value;
       });
-      const detection = await Marker.detectInvisible({
-        image: { src: { uri: path } },
-        key,
-        strength: 'robust',
-        search: 'fast',
+      const detected = await Marker.detectInvisibleMany(
+        paths.map((path) => ({
+          image: { src: { uri: path } },
+          key,
+          strength: 'robust',
+          search: 'fast',
+        })),
+        { concurrency: 2 }
+      );
+      const detections = detected.map((result) => {
+        if (result.status !== 'fulfilled') {
+          throw result.status === 'rejected'
+            ? result.reason
+            : new Error('Detection batch was aborted.');
+        }
+        return result.value;
       });
-      if (!detection.detected || detection.payload !== payload) {
-        throw new Error('The embedded payload could not be authenticated.');
+      if (
+        detections.some(
+          (detection, index) =>
+            !detection.detected || detection.payload !== payloads[index]
+        )
+      ) {
+        throw new Error('A batched payload could not be authenticated.');
       }
 
+      const path = paths[0]!;
       setUri(formatResultUri(path, ImageFormat.png));
       setShow(true);
-      setLastRun(`Invisible trace verified · ${payload}`);
+      setLastRun(`Invisible batch verified · ${payloads.length} outputs`);
       setResultContract(
-        `Invisible trace verified: ${detection.payload} · ${Math.round(
-          detection.confidence * 100
-        )}% confidence`
+        `Recipient-specific traces verified in input order: ${detections
+          .map((detection) => detection.payload)
+          .join(', ')}`
       );
       await updateFileSize(path, ImageFormat.png);
     } catch (error) {

--- a/examples/c2pa-service/README.md
+++ b/examples/c2pa-service/README.md
@@ -1,0 +1,41 @@
+# C2PA service example
+
+This independent Node.js 22 example adds a signed C2PA Content Credential **after** `react-native-image-marker` has embedded its invisible locator. It is not installed with the main package.
+
+The service deliberately uses a C2PA hard binding. `dct-qim-v1` is not registered in the C2PA Soft Binding Algorithm List, so the example does not emit `c2pa.watermarked` or a standard soft-binding assertion. Instead, the private `org.corerobin.image-marker.trace.v1` assertion stores the algorithm name and `SHA-256(locator)`, never the locator itself.
+
+## Run
+
+```sh
+npm install
+export C2PA_CERT_PATH=/secure/path/certificate.pem
+export C2PA_PRIVATE_KEY_PATH=/secure/path/private-key.pem
+export C2PA_TSA_URL=https://timestamp.example.com # optional
+npm start
+```
+
+The signing certificate must be suitable for C2PA. `C2PA_SIGNING_ALGORITHM` defaults to `es256`. Never commit private signing material or expose this example without your own authentication, rate limiting, TLS, audit logging, and origin policy.
+
+The service exposes `POST /sign` and `POST /verify` with JSON/base64 JPEG or PNG bodies. `src/client-adapter.mjs` provides a data-URL adapter for `Marker.embedInvisibleWithCredentials()` and `Marker.verifyContentCredentials()`.
+
+```js
+import Marker from 'react-native-image-marker';
+import { createHttpContentCredentialsAdapter } from './src/client-adapter.mjs';
+
+const adapter = createHttpContentCredentialsAdapter({
+  baseUrl: 'https://credentials.example.com',
+});
+
+const result = await Marker.embedInvisibleWithCredentials({
+  watermark: {
+    image: { src: inputDataUrl },
+    payload: 'asset-42',
+    key: process.env.WATERMARK_KEY,
+    saveFormat: 'png',
+  },
+  claim: { title: 'asset-42.png', format: 'image/png' },
+  adapter,
+});
+```
+
+The sample adapter accepts data URLs only. Native file upload, authentication, retry policy, and locator-to-record storage belong in the application.

--- a/examples/c2pa-service/package-lock.json
+++ b/examples/c2pa-service/package-lock.json
@@ -1,0 +1,671 @@
+{
+  "name": "react-native-image-marker-c2pa-service-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "react-native-image-marker-c2pa-service-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@contentauth/c2pa-node": "0.6.3",
+        "@contentauth/c2pa-types": "0.7.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@contentauth/c2pa-node": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@contentauth/c2pa-node/-/c2pa-node-0.6.3.tgz",
+      "integrity": "sha512-ZywfFUW4Z3okcQfTzaT8il6crwGXFYNYB6TztYJi7NXz5cVgUSjjkqxUUm8+DFwflQZ62Gu6Ac59GA6HG4z8Cg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "cargo-cp-artifact": "^0.1.9",
+        "cli-progress": "^3.12.0",
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.4",
+        "mkdirp": "^3.0.1",
+        "node-fetch": "^3.3.2",
+        "pkg-dir": "^8.0.0",
+        "pretty-bytes": "^6.1.1",
+        "unzipper": "^0.10.14"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@contentauth/c2pa-types": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@contentauth/c2pa-types/-/c2pa-types-0.7.2.tgz",
+      "integrity": "sha512-SH+q4a6ZS2z2YhlqfTB2GzN1S4M9koLhJETGPxL5J4JVhJEFSyEQK52PnwOhee+ObiZdDZK18NI+s+1IrUSdTQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/cargo-cp-artifact": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.9.tgz",
+      "integrity": "sha512-6F+UYzTaGB+awsTXg0uSJA1/b/B3DDJzpKVRu0UmyI7DmNeaAl2RFHuTGIN6fEgpadRxoXGb7gbC1xo4C3IdyA==",
+      "license": "MIT",
+      "bin": {
+        "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
+      "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/examples/c2pa-service/package.json
+++ b/examples/c2pa-service/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-native-image-marker-c2pa-service-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "exports": {
+    "./client-adapter": "./src/client-adapter.mjs"
+  },
+  "scripts": {
+    "start": "node src/server.mjs",
+    "test": "node --test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@contentauth/c2pa-node": "0.6.3",
+    "@contentauth/c2pa-types": "0.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/c2pa-service/src/c2pa-engine.mjs
+++ b/examples/c2pa-service/src/c2pa-engine.mjs
@@ -1,0 +1,163 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { Builder, LocalSigner, Reader } from '@contentauth/c2pa-node';
+
+const TRACE_ASSERTION_LABEL = 'org.corerobin.image-marker.trace.v1';
+const SIGNING_ALGORITHMS = new Set([
+  'es256',
+  'es384',
+  'es512',
+  'ps256',
+  'ps384',
+  'ps512',
+  'ed25519',
+]);
+
+/** @param {string} locator @param {unknown} metadata */
+export function createTraceAssertion(locator, metadata) {
+  return {
+    algorithm: 'dct-qim-v1',
+    locator_sha256: createHash('sha256')
+      .update(locator, 'utf8')
+      .digest('hex'),
+    ...(metadata === undefined ? {} : { metadata }),
+  };
+}
+
+/** @param {unknown} value */
+function validationCodes(value) {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    entry && typeof entry === 'object' && typeof entry.code === 'string'
+      ? [entry.code]
+      : []
+  );
+}
+
+/** @param {unknown} value */
+function failureCodes(value) {
+  if (!value || typeof value !== 'object') return [];
+  const activeManifest = /** @type {Record<string, unknown>} */ (value)
+    .activeManifest;
+  return activeManifest && typeof activeManifest === 'object'
+    ? validationCodes(
+        /** @type {Record<string, unknown>} */ (activeManifest).failure
+      )
+    : [];
+}
+
+/**
+ * @param {{certificate: Buffer, privateKey: Buffer, algorithm?: string, tsaUrl?: string}} options
+ */
+export function createC2paEngine({
+  certificate,
+  privateKey,
+  algorithm = 'es256',
+  tsaUrl,
+}) {
+  if (!SIGNING_ALGORITHMS.has(algorithm)) {
+    throw new Error(`Unsupported C2PA signing algorithm: ${algorithm}.`);
+  }
+  const signer = LocalSigner.newSigner(
+    certificate,
+    privateKey,
+    /** @type {import('@contentauth/c2pa-node').SigningAlg} */ (algorithm),
+    tsaUrl
+  );
+
+  return {
+    /**
+     * @param {{image: Buffer, mimeType: string, locator: string, claim: Record<string, unknown>}} input
+     */
+    async sign(input) {
+      const generator =
+        typeof input.claim.generator === 'string'
+          ? input.claim.generator
+          : 'react-native-image-marker/1.11';
+      const builder = Builder.withJson({
+        claim_generator_info: [{ name: generator, version: '1.11.0' }],
+        title: String(input.claim.title),
+        format: input.mimeType,
+      });
+      builder.addAssertion(
+        TRACE_ASSERTION_LABEL,
+        JSON.stringify(
+          createTraceAssertion(input.locator, input.claim.metadata)
+        ),
+        'Json'
+      );
+      const destination = /** @type {import('@contentauth/c2pa-node').DestinationBufferAsset} */ ({
+        buffer: null,
+      });
+      builder.sign(
+        signer,
+        { buffer: input.image, mimeType: input.mimeType },
+        destination
+      );
+      if (!destination.buffer) {
+        throw new Error('C2PA SDK did not return a signed image.');
+      }
+      const reader = await Reader.fromAsset({
+        buffer: destination.buffer,
+        mimeType: input.mimeType,
+      });
+      return {
+        image: destination.buffer,
+        mimeType: input.mimeType,
+        manifestId: reader?.activeLabel(),
+      };
+    },
+
+    /** @param {{image: Buffer, mimeType: string}} input */
+    async verify(input) {
+      const reader = await Reader.fromAsset({
+        buffer: input.image,
+        mimeType: input.mimeType,
+      });
+      if (!reader) {
+        return {
+          valid: false,
+          validationStatus: ['manifest.missing'],
+        };
+      }
+      const store = reader.json();
+      const failures = failureCodes(store.validation_results);
+      const statuses = [
+        ...validationCodes(store.validation_status),
+        ...failures,
+      ];
+      return {
+        valid:
+          Boolean(reader.activeLabel()) &&
+          store.validation_state !== 'Invalid' &&
+          failures.length === 0,
+        manifestId: reader.activeLabel(),
+        validationStatus: [...new Set(statuses)],
+        manifest: reader.getActive(),
+      };
+    },
+  };
+}
+
+/** @param {NodeJS.ProcessEnv} [environment] */
+export async function createC2paEngineFromEnvironment(
+  environment = process.env
+) {
+  const certificatePath = environment.C2PA_CERT_PATH;
+  const privateKeyPath = environment.C2PA_PRIVATE_KEY_PATH;
+  if (!certificatePath || !privateKeyPath) {
+    throw new Error(
+      'C2PA_CERT_PATH and C2PA_PRIVATE_KEY_PATH must point to signing material.'
+    );
+  }
+  const [certificate, privateKey] = await Promise.all([
+    readFile(certificatePath),
+    readFile(privateKeyPath),
+  ]);
+  return createC2paEngine({
+    certificate,
+    privateKey,
+    algorithm: environment.C2PA_SIGNING_ALGORITHM ?? 'es256',
+    tsaUrl: environment.C2PA_TSA_URL,
+  });
+}

--- a/examples/c2pa-service/src/client-adapter.mjs
+++ b/examples/c2pa-service/src/client-adapter.mjs
@@ -1,0 +1,75 @@
+/** @param {string} image */
+function parseDataUrl(image) {
+  const match = /^data:(image\/(?:jpeg|png));base64,([A-Za-z0-9+/]+={0,2})$/u.exec(
+    image
+  );
+  if (!match) {
+    throw new Error('The example adapter requires a JPEG or PNG data URL.');
+  }
+  return { mimeType: match[1], base64: match[2] };
+}
+
+/** @param {Response} response */
+async function readResponse(response) {
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      body && typeof body.error === 'string'
+        ? body.error
+        : `C2PA service returned HTTP ${response.status}.`
+    );
+  }
+  return body;
+}
+
+/**
+ * Creates an adapter compatible with Marker.embedInvisibleWithCredentials().
+ * This example intentionally accepts data URLs only; native file URI upload
+ * policy belongs in the application.
+ *
+ * @param {{baseUrl: string, fetch?: typeof globalThis.fetch}} options
+ */
+export function createHttpContentCredentialsAdapter({
+  baseUrl,
+  fetch: request = globalThis.fetch,
+}) {
+  if (typeof request !== 'function') {
+    throw new Error('A fetch implementation is required.');
+  }
+  const endpoint = baseUrl.replace(/\/$/u, '');
+  return {
+    /**
+     * @param {{image: string, locator: string, algorithm: string, claim: Record<string, unknown>}} input
+     */
+    async sign(input) {
+      const image = parseDataUrl(input.image);
+      const body = await readResponse(
+        await request(`${endpoint}/sign`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            image,
+            locator: input.locator,
+            algorithm: input.algorithm,
+            claim: input.claim,
+          }),
+        })
+      );
+      return {
+        image: `data:${body.image.mimeType};base64,${body.image.base64}`,
+        manifestId: body.manifestId,
+      };
+    },
+    /** @param {string} imageUrl */
+    async verify(imageUrl) {
+      const image = parseDataUrl(imageUrl);
+      return readResponse(
+        await request(`${endpoint}/verify`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ image }),
+        })
+      );
+    },
+  };
+}

--- a/examples/c2pa-service/src/server.mjs
+++ b/examples/c2pa-service/src/server.mjs
@@ -1,0 +1,21 @@
+import { createServer } from 'node:http';
+import { createC2paEngineFromEnvironment } from './c2pa-engine.mjs';
+import { createRequestHandler } from './service.mjs';
+
+const host = process.env.HOST ?? '127.0.0.1';
+const port = Number(process.env.PORT ?? 8787);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error('PORT must be an integer between 1 and 65535.');
+}
+
+const engine = await createC2paEngineFromEnvironment();
+const server = createServer(createRequestHandler({ engine }));
+server.listen(port, host, () => {
+  console.log(`C2PA example service listening on http://${host}:${port}`);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}

--- a/examples/c2pa-service/src/service.mjs
+++ b/examples/c2pa-service/src/service.mjs
@@ -1,0 +1,209 @@
+import { Buffer } from 'node:buffer';
+
+export const DEFAULT_MAX_BODY_BYTES = 12 * 1024 * 1024;
+const SUPPORTED_MEDIA_TYPES = new Set(['image/jpeg', 'image/png']);
+
+export class HttpError extends Error {
+  /** @param {number} status @param {string} message */
+  constructor(status, message) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+  }
+}
+
+/** @param {unknown} value @param {string} label */
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new HttpError(400, `${label} must be an object.`);
+  }
+  return /** @type {Record<string, unknown>} */ (value);
+}
+
+/** @param {unknown} value */
+function decodeBase64(value) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(value)
+  ) {
+    throw new HttpError(400, 'image.base64 must be valid padded base64.');
+  }
+  const output = Buffer.from(value, 'base64');
+  if (
+    output.length === 0 ||
+    output.toString('base64').replace(/=+$/u, '') !==
+      value.replace(/=+$/u, '')
+  ) {
+    throw new HttpError(400, 'image.base64 must be valid padded base64.');
+  }
+  return output;
+}
+
+/** @param {unknown} value */
+function parseImage(value) {
+  const image = requireObject(value, 'image');
+  if (
+    typeof image.mimeType !== 'string' ||
+    !SUPPORTED_MEDIA_TYPES.has(image.mimeType)
+  ) {
+    throw new HttpError(415, 'image.mimeType must be image/jpeg or image/png.');
+  }
+  return {
+    buffer: decodeBase64(image.base64),
+    mimeType: image.mimeType,
+  };
+}
+
+/** @param {unknown} value @param {string} mimeType */
+function parseClaim(value, mimeType) {
+  const claim = requireObject(value, 'claim');
+  if (typeof claim.title !== 'string' || !claim.title.trim()) {
+    throw new HttpError(400, 'claim.title must not be empty.');
+  }
+  if (claim.format !== undefined && claim.format !== mimeType) {
+    throw new HttpError(400, 'claim.format must match image.mimeType.');
+  }
+  if (
+    claim.generator !== undefined &&
+    (typeof claim.generator !== 'string' || !claim.generator.trim())
+  ) {
+    throw new HttpError(400, 'claim.generator must be a non-empty string.');
+  }
+  if (
+    claim.metadata !== undefined &&
+    (!claim.metadata ||
+      typeof claim.metadata !== 'object' ||
+      Array.isArray(claim.metadata))
+  ) {
+    throw new HttpError(400, 'claim.metadata must be an object.');
+  }
+  return {
+    title: claim.title.trim(),
+    format: mimeType,
+    generator:
+      typeof claim.generator === 'string' ? claim.generator.trim() : undefined,
+    metadata:
+      claim.metadata === undefined
+        ? undefined
+        : { .../** @type {Record<string, unknown>} */ (claim.metadata) },
+  };
+}
+
+/** @param {import('node:http').IncomingMessage} request @param {number} limit */
+async function readJsonBody(request, limit) {
+  const contentType = request.headers['content-type']?.split(';', 1)[0];
+  if (contentType !== 'application/json') {
+    throw new HttpError(415, 'Content-Type must be application/json.');
+  }
+  /** @type {Buffer[]} */
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > limit) {
+      throw new HttpError(413, `Request body exceeds ${limit} bytes.`);
+    }
+    chunks.push(buffer);
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch {
+    throw new HttpError(400, 'Request body must contain valid JSON.');
+  }
+}
+
+/**
+ * @typedef {{
+ *   sign(input: {image: Buffer, mimeType: string, locator: string, claim: Record<string, unknown>}): Promise<{image: Buffer, mimeType: string, manifestId?: string}>,
+ *   verify(input: {image: Buffer, mimeType: string}): Promise<{valid: boolean, manifestId?: string, validationStatus?: string[], manifest?: unknown}>
+ * }} C2paEngine
+ */
+
+/**
+ * @param {{engine: C2paEngine, maxBodyBytes?: number}} options
+ */
+export function createRequestHandler({
+  engine,
+  maxBodyBytes = DEFAULT_MAX_BODY_BYTES,
+}) {
+  if (!engine || typeof engine.sign !== 'function' || typeof engine.verify !== 'function') {
+    throw new Error('A C2PA engine with sign() and verify() is required.');
+  }
+  if (!Number.isInteger(maxBodyBytes) || maxBodyBytes <= 0) {
+    throw new Error('maxBodyBytes must be a positive integer.');
+  }
+
+  /**
+   * @param {import('node:http').IncomingMessage} request
+   * @param {import('node:http').ServerResponse} response
+   */
+  return async function handle(request, response) {
+    response.setHeader('content-type', 'application/json; charset=utf-8');
+    response.setHeader('cache-control', 'no-store');
+    response.setHeader('x-content-type-options', 'nosniff');
+    try {
+      if (request.method !== 'POST') {
+        throw new HttpError(405, 'Only POST is supported.');
+      }
+      const body = requireObject(
+        await readJsonBody(request, maxBodyBytes),
+        'request body'
+      );
+      if (request.url === '/sign') {
+        const image = parseImage(body.image);
+        if (
+          typeof body.locator !== 'string' ||
+          Buffer.byteLength(body.locator, 'utf8') < 1 ||
+          Buffer.byteLength(body.locator, 'utf8') > 12
+        ) {
+          throw new HttpError(400, 'locator must contain 1 to 12 UTF-8 bytes.');
+        }
+        if (body.algorithm !== 'dct-qim-v1') {
+          throw new HttpError(400, 'algorithm must be dct-qim-v1.');
+        }
+        const result = await engine.sign({
+          image: image.buffer,
+          mimeType: image.mimeType,
+          locator: body.locator,
+          claim: parseClaim(body.claim, image.mimeType),
+        });
+        response.statusCode = 200;
+        response.end(
+          JSON.stringify({
+            image: {
+              base64: result.image.toString('base64'),
+              mimeType: result.mimeType,
+            },
+            manifestId: result.manifestId,
+          })
+        );
+        return;
+      }
+      if (request.url === '/verify') {
+        const image = parseImage(body.image);
+        const result = await engine.verify({
+          image: image.buffer,
+          mimeType: image.mimeType,
+        });
+        response.statusCode = 200;
+        response.end(JSON.stringify(result));
+        return;
+      }
+      throw new HttpError(404, 'Route not found.');
+    } catch (error) {
+      const status = error instanceof HttpError ? error.status : 500;
+      response.statusCode = status;
+      response.end(
+        JSON.stringify({
+          error:
+            error instanceof HttpError
+              ? error.message
+              : 'C2PA operation failed.',
+        })
+      );
+    }
+  };
+}

--- a/examples/c2pa-service/test/c2pa-engine.test.mjs
+++ b/examples/c2pa-service/test/c2pa-engine.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createTraceAssertion } from '../src/c2pa-engine.mjs';
+
+test('hashes the locator before creating the private assertion', () => {
+  const assertion = createTraceAssertion('asset-42', { collection: 'demo' });
+
+  assert.deepEqual(assertion, {
+    algorithm: 'dct-qim-v1',
+    locator_sha256:
+      '83dbdd21217e280cf7ef11027ec96e1f43aab7e6d2fcf61a25b57aa0857c5e36',
+    metadata: { collection: 'demo' },
+  });
+  assert.equal(JSON.stringify(assertion).includes('asset-42'), false);
+});

--- a/examples/c2pa-service/test/client-adapter.test.mjs
+++ b/examples/c2pa-service/test/client-adapter.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHttpContentCredentialsAdapter } from '../src/client-adapter.mjs';
+
+test('maps data URLs to the sign and verify service contract', async () => {
+  const requests = [];
+  const adapter = createHttpContentCredentialsAdapter({
+    baseUrl: 'https://credentials.example.com/',
+    fetch: async (url, init) => {
+      requests.push({ url, body: JSON.parse(String(init.body)) });
+      if (String(url).endsWith('/sign')) {
+        return Response.json({
+          image: { mimeType: 'image/png', base64: 'c2lnbmVk' },
+          manifestId: 'urn:c2pa:test',
+        });
+      }
+      return Response.json({ valid: true, manifestId: 'urn:c2pa:test' });
+    },
+  });
+
+  const signed = await adapter.sign({
+    image: 'data:image/png;base64,iVBORw==',
+    locator: 'asset-42',
+    algorithm: 'dct-qim-v1',
+    claim: { title: 'Example' },
+  });
+  assert.deepEqual(signed, {
+    image: 'data:image/png;base64,c2lnbmVk',
+    manifestId: 'urn:c2pa:test',
+  });
+  assert.deepEqual(await adapter.verify(signed.image), {
+    valid: true,
+    manifestId: 'urn:c2pa:test',
+  });
+  assert.deepEqual(requests, [
+    {
+      url: 'https://credentials.example.com/sign',
+      body: {
+        image: { mimeType: 'image/png', base64: 'iVBORw==' },
+        locator: 'asset-42',
+        algorithm: 'dct-qim-v1',
+        claim: { title: 'Example' },
+      },
+    },
+    {
+      url: 'https://credentials.example.com/verify',
+      body: {
+        image: { mimeType: 'image/png', base64: 'c2lnbmVk' },
+      },
+    },
+  ]);
+});
+
+test('preserves service errors and rejects unsupported image URLs', async () => {
+  const adapter = createHttpContentCredentialsAdapter({
+    baseUrl: 'https://credentials.example.com',
+    fetch: async () =>
+      Response.json({ error: 'Signing unavailable.' }, { status: 503 }),
+  });
+
+  await assert.rejects(
+    adapter.verify('https://example.com/image.png'),
+    /requires a JPEG or PNG data URL/
+  );
+  await assert.rejects(
+    adapter.verify('data:image/png;base64,iVBORw=='),
+    /Signing unavailable/
+  );
+});

--- a/examples/c2pa-service/test/service.test.mjs
+++ b/examples/c2pa-service/test/service.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { createRequestHandler } from '../src/service.mjs';
+
+const png = Buffer.from('89504e470d0a1a0a', 'hex');
+
+async function withServer(options, callback) {
+  const server = createServer(createRequestHandler(options));
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('No address');
+  try {
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+}
+
+function fakeEngine() {
+  return {
+    sign: async (input) => ({
+      image: Buffer.concat([input.image, Buffer.from('signed')]),
+      mimeType: input.mimeType,
+      manifestId: 'example:manifest',
+    }),
+    verify: async () => ({
+      valid: true,
+      manifestId: 'example:manifest',
+      validationStatus: [],
+    }),
+  };
+}
+
+test('signs and verifies through an injected engine', async () => {
+  await withServer({ engine: fakeEngine() }, async (baseUrl) => {
+    const signResponse = await fetch(`${baseUrl}/sign`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        image: { base64: png.toString('base64'), mimeType: 'image/png' },
+        locator: 'asset-42',
+        algorithm: 'dct-qim-v1',
+        claim: { title: 'Example', format: 'image/png' },
+      }),
+    });
+    assert.equal(signResponse.status, 200);
+    const signed = await signResponse.json();
+    assert.equal(signed.manifestId, 'example:manifest');
+    assert.equal(
+      Buffer.from(signed.image.base64, 'base64').subarray(-6).toString(),
+      'signed'
+    );
+
+    const verifyResponse = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        image: { base64: signed.image.base64, mimeType: 'image/png' },
+      }),
+    });
+    assert.equal(verifyResponse.status, 200);
+    assert.deepEqual(await verifyResponse.json(), {
+      valid: true,
+      manifestId: 'example:manifest',
+      validationStatus: [],
+    });
+  });
+});
+
+test('rejects unsupported media types and invalid base64', async () => {
+  await withServer({ engine: fakeEngine() }, async (baseUrl) => {
+    const unsupported = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        image: { base64: png.toString('base64'), mimeType: 'image/gif' },
+      }),
+    });
+    assert.equal(unsupported.status, 415);
+
+    const invalid = await fetch(`${baseUrl}/verify`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        image: { base64: 'not base64', mimeType: 'image/png' },
+      }),
+    });
+    assert.equal(invalid.status, 400);
+  });
+});
+
+test('rejects request bodies over the configured limit', async () => {
+  await withServer(
+    { engine: fakeEngine(), maxBodyBytes: 64 },
+    async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/verify`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ image: { base64: 'A'.repeat(256) } }),
+      });
+      assert.equal(response.status, 413);
+    }
+  );
+});

--- a/examples/c2pa-service/tsconfig.json
+++ b/examples/c2pa-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.mjs"]
+}

--- a/expo-example/App.tsx
+++ b/expo-example/App.tsx
@@ -147,32 +147,57 @@ function App() {
 
   const runInvisibleTrace = useCallback(async () => {
     const key = 'example-only-key-2026';
-    const payload = 'asset-42';
+    const payloads = ['asset-41', 'asset-42'];
     setIsRendering(true);
     setMessage('Embedding and authenticating an invisible trace…');
     try {
-      const output = await Marker.embedInvisible({
-        image: { src: background },
-        payload,
-        key,
-        strength: 'robust',
-        saveFormat: ImageFormat.png,
-        filename: `image-marker-trace-${Date.now()}`,
+      const embedded = await Marker.embedInvisibleMany(
+        payloads.map((payload) => ({
+          image: { src: background },
+          payload,
+          key,
+          strength: 'robust',
+          saveFormat: ImageFormat.png,
+          filename: `image-marker-trace-${payload}-${Date.now()}`,
+        })),
+        { concurrency: 2 }
+      );
+      const outputs = embedded.map((batchResult) => {
+        if (batchResult.status !== 'fulfilled') {
+          throw batchResult.status === 'rejected'
+            ? batchResult.reason
+            : new Error('Trace batch was aborted.');
+        }
+        return batchResult.value;
       });
-      const detection = await Marker.detectInvisible({
-        image: { src: { uri: output } },
-        key,
-        strength: 'robust',
-        search: 'fast',
+      const detected = await Marker.detectInvisibleMany(
+        outputs.map((output) => ({
+          image: { src: { uri: output } },
+          key,
+          strength: 'robust',
+          search: 'fast',
+        })),
+        { concurrency: 2 }
+      );
+      const detections = detected.map((batchResult) => {
+        if (batchResult.status !== 'fulfilled') {
+          throw batchResult.status === 'rejected'
+            ? batchResult.reason
+            : new Error('Detection batch was aborted.');
+        }
+        return batchResult.value;
       });
-      if (!detection.detected || detection.payload !== payload) {
-        throw new Error('The embedded trace could not be authenticated.');
+      if (
+        detections.some(
+          (detection, index) =>
+            !detection.detected || detection.payload !== payloads[index]
+        )
+      ) {
+        throw new Error('A batched trace could not be authenticated.');
       }
-      setResult(output);
+      setResult(outputs[0]);
       setMessage(
-        `Invisible trace verified: ${detection.payload} · ${Math.round(
-          detection.confidence * 100
-        )}% confidence.`
+        `Verified ${detections.length} recipient-specific invisible traces in input order.`
       );
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'Trace failed.');
@@ -261,12 +286,11 @@ function App() {
         </View>
 
         <View style={styles.note}>
-          <Text style={styles.noteTitle}>
-            Invisible trace watermark · v1.10
-          </Text>
+          <Text style={styles.noteTitle}>Invisible trace batch · v1.11</Text>
           <Text style={styles.noteText}>
-            Embed a short locator in the pixels, then authenticate it with the
-            same key. The demo key is public and must not be used in production.
+            Create recipient-specific locators in one ordered batch, then
+            authenticate every result. The public demo key is not for
+            production.
           </Text>
           <Pressable
             disabled={isRendering}

--- a/expo-example/scripts/smoke-web.mjs
+++ b/expo-example/scripts/smoke-web.mjs
@@ -23,7 +23,7 @@ const corpusFixtures = new Map(
     'watermark-coast.jpg',
     'watermark-after-dark.jpg',
     'watermark-waypoint.jpg',
-    'example-lab-compose.jpg',
+    'watermark-image-layer.jpg',
     'sample1.png',
   ].map((name) => [`corpus/${name}`, name])
 );
@@ -255,6 +255,32 @@ async function verifyBrowser(browserName, browserType) {
       corpusFixtures.size
     );
     assert.equal(harnessResults.invisibleCorpus.unmarkedFalsePositives, 0);
+    assert.equal(
+      harnessResults.invisibleCorpus.resizeDetectedCount,
+      corpusFixtures.size * 4,
+      JSON.stringify({
+        byScale: harnessResults.invisibleCorpus.resizeDetectedByScale,
+        failedSources:
+          harnessResults.invisibleCorpus.resizeFailedSourceIndexes,
+      })
+    );
+    assert.equal(
+      harnessResults.invisibleCorpus.resizeScaleMatchCount,
+      corpusFixtures.size * 4,
+      JSON.stringify(harnessResults.invisibleCorpus.resizeScaleMatchesByScale)
+    );
+    assert.equal(
+      harnessResults.invisibleCorpus.jpeg75ResizeDetectedCount,
+      corpusFixtures.size
+    );
+    assert.equal(
+      harnessResults.invisibleCorpus.batchProgressCount,
+      corpusFixtures.size * 5
+    );
+    assert(
+      harnessResults.invisibleCorpus.heartbeatCount > 0,
+      'Robust detection never yielded to the browser event loop.'
+    );
     assert(
       harnessResults.invisibleCorpus.minimumPsnr >= 40,
       `Invisible watermark corpus PSNR fell below 40 dB: ${harnessResults.invisibleCorpus.minimumPsnr.toFixed(
@@ -275,7 +301,9 @@ async function verifyBrowser(browserName, browserType) {
     );
 
     console.log(
-      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, invisible watermark PNG/JPEG robustness and six-image quality corpus (PSNR ${harnessResults.invisibleCorpus.minimumPsnr.toFixed(
+      `Verified ${browserName}: Canvas pixels, tiled text/logo layers, invisible watermark PNG/JPEG and 0.9x-1.1x resize recovery across six images in ${harnessResults.invisibleCorpus.resizeDurationMs.toFixed(
+        0
+      )} ms, responsive batch detection, and quality corpus (PSNR ${harnessResults.invisibleCorpus.minimumPsnr.toFixed(
         2
       )} dB, SSIM ${harnessResults.invisibleCorpus.minimumSsim.toFixed(
         5

--- a/expo-example/smoke-harness.web.ts
+++ b/expo-example/smoke-harness.web.ts
@@ -40,6 +40,15 @@ interface WebSmokeHarness {
     unmarkedFalsePositives: number;
     minimumPsnr: number;
     minimumSsim: number;
+    resizeDetectedCount: number;
+    resizeScaleMatchCount: number;
+    resizeDetectedByScale: Record<string, number>;
+    resizeScaleMatchesByScale: Record<string, number>;
+    resizeFailedSourceIndexes: number[];
+    jpeg75ResizeDetectedCount: number;
+    batchProgressCount: number;
+    heartbeatCount: number;
+    resizeDurationMs: number;
   }>;
   renderCrossOrigin(url: string): Promise<string>;
 }
@@ -94,6 +103,22 @@ async function transformDataUrl(
     }
     context.putImageData(pixels, 0, 0);
   }
+  return canvas.toDataURL(type, quality);
+}
+
+async function resizeDataUrl(
+  dataUrl: string,
+  scale: number,
+  type: 'image/jpeg' | 'image/png' = 'image/png',
+  quality?: number
+): Promise<string> {
+  const image = await decodeImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(image.naturalWidth * scale);
+  canvas.height = Math.round(image.naturalHeight * scale);
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('Canvas 2D is unavailable.');
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
   return canvas.toDataURL(type, quality);
 }
 
@@ -402,6 +427,16 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
       let unmarkedFalsePositives = 0;
       let minimumPsnr = Number.POSITIVE_INFINITY;
       let minimumSsim = Number.POSITIVE_INFINITY;
+      let resizeDetectedCount = 0;
+      let resizeScaleMatchCount = 0;
+      const resizeDetectedByScale: Record<string, number> = {};
+      const resizeScaleMatchesByScale: Record<string, number> = {};
+      const resizeFailedSourceIndexes: number[] = [];
+      let jpeg75ResizeDetectedCount = 0;
+      let batchProgressCount = 0;
+      let heartbeatCount = 0;
+      let resizeDurationMs = 0;
+      const resizeScales = [0.9, 0.95, 1.05, 1.1] as const;
       for (let index = 0; index < sources.length; index += 1) {
         const source = sources[index]!;
         const unmarked = await Marker.detectInvisible({
@@ -435,6 +470,82 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
         const quality = await compareImageQuality(source, marked);
         minimumPsnr = Math.min(minimumPsnr, quality.psnr);
         minimumSsim = Math.min(minimumSsim, quality.ssim);
+
+        const resizePayload = `resize-${index}`;
+        const resizeMarked = await Marker.embedInvisible({
+          image: { src: source },
+          payload: resizePayload,
+          key,
+          strength: 'robust',
+          saveFormat: ImageFormat.png,
+          maxSize: 512,
+        });
+        const jpeg75 = await transformDataUrl(resizeMarked, 'image/jpeg', 0.75);
+        const resized = await Promise.all([
+          ...resizeScales.map((scale) => resizeDataUrl(resizeMarked, scale)),
+          resizeDataUrl(jpeg75, 1.05),
+        ]);
+        let heartbeat = 0;
+        const heartbeatTimer = window.setInterval(() => {
+          heartbeat += 1;
+        }, 0);
+        const startedAt = performance.now();
+        let resizeResults;
+        try {
+          resizeResults = await Marker.detectInvisibleMany(
+            resized.map((image) => ({
+              image: { src: image },
+              key,
+              strength: 'robust' as const,
+              search: 'robust' as const,
+            })),
+            {
+              concurrency: 4,
+              onProgress() {
+                batchProgressCount += 1;
+              },
+            }
+          );
+        } finally {
+          window.clearInterval(heartbeatTimer);
+          resizeDurationMs += performance.now() - startedAt;
+          heartbeatCount += heartbeat;
+        }
+        resizeScales.forEach((scale, scaleIndex) => {
+          const result = resizeResults[scaleIndex];
+          if (
+            result?.status === 'fulfilled' &&
+            result.value.detected &&
+            result.value.payload === resizePayload
+          ) {
+            resizeDetectedCount += 1;
+            resizeDetectedByScale[String(scale)] =
+              (resizeDetectedByScale[String(scale)] ?? 0) + 1;
+            if (result.value.scale === scale) {
+              resizeScaleMatchCount += 1;
+              resizeScaleMatchesByScale[String(scale)] =
+                (resizeScaleMatchesByScale[String(scale)] ?? 0) + 1;
+            }
+          }
+        });
+        if (
+          resizeResults
+            .slice(0, resizeScales.length)
+            .some(
+              (result) =>
+                result.status !== 'fulfilled' || !result.value.detected
+            )
+        ) {
+          resizeFailedSourceIndexes.push(index);
+        }
+        const jpegResult = resizeResults[resizeScales.length];
+        if (
+          jpegResult?.status === 'fulfilled' &&
+          jpegResult.value.detected &&
+          jpegResult.value.payload === resizePayload
+        ) {
+          jpeg75ResizeDetectedCount += 1;
+        }
       }
       return {
         fixtureCount: sources.length,
@@ -442,6 +553,15 @@ function createHarness(assets: SmokeHarnessAssets): WebSmokeHarness {
         unmarkedFalsePositives,
         minimumPsnr,
         minimumSsim,
+        resizeDetectedCount,
+        resizeScaleMatchCount,
+        resizeDetectedByScale,
+        resizeScaleMatchesByScale,
+        resizeFailedSourceIndexes,
+        jpeg75ResizeDetectedCount,
+        batchProgressCount,
+        heartbeatCount,
+        resizeDurationMs,
       };
     },
 

--- a/ios/RCTImageMarker/InvisibleWatermark.swift
+++ b/ios/RCTImageMarker/InvisibleWatermark.swift
@@ -9,6 +9,7 @@ struct InvisibleWatermarkDetection {
     let payload: String?
     let confidence: Double
     let bitErrorRate: Double?
+    let scale: Double?
 
     func json() throws -> String {
         var value: [String: Any] = [
@@ -18,6 +19,7 @@ struct InvisibleWatermarkDetection {
         ]
         if let payload { value["payload"] = payload }
         if let bitErrorRate { value["bitErrorRate"] = bitErrorRate }
+        if let scale { value["scale"] = scale }
         let data = try JSONSerialization.data(withJSONObject: value)
         guard let output = String(data: data, encoding: .utf8) else {
             throw NSError(domain: ErrorDomainEnum.BASE.rawValue, code: 1)
@@ -49,6 +51,7 @@ enum InvisibleWatermark {
         [1, 3, 3, 1],
         [2, 4, 4, 2],
     ]
+    private static let resizeScales = [0.95, 1.05, 0.9, 1.1]
     private static let basisCache: [[[Double]]] = (0...4).map { u in
         (0...4).map { v in createBasis(u: u, v: v) }
     }
@@ -107,6 +110,13 @@ enum InvisibleWatermark {
                     userInfo: [NSLocalizedDescriptionKey: "Failed to create image pixel context"]
                 )
             }
+        }
+
+        init(bytes: [UInt8], width: Int, height: Int, scale: CGFloat) {
+            self.bytes = bytes
+            self.width = width
+            self.height = height
+            self.scale = scale
         }
 
         func image() throws -> UIImage {
@@ -184,6 +194,23 @@ enum InvisibleWatermark {
         try permutation(key: key)
     }
 
+    static func resizeForTesting(image: UIImage, scale: Double) throws -> UIImage {
+        let source = try PixelImage(image: image)
+        let resized = resizePixelsBilinear(
+            source.bytes,
+            width: source.width,
+            height: source.height,
+            targetWidth: Int((Double(source.width) * scale).rounded()),
+            targetHeight: Int((Double(source.height) * scale).rounded())
+        )
+        return try PixelImage(
+            bytes: resized.bytes,
+            width: resized.width,
+            height: resized.height,
+            scale: source.scale
+        ).image()
+    }
+
     private static func validatePixels(_ bytes: [UInt8], width: Int, height: Int) throws {
         guard width >= minimumWidth, height >= minimumHeight else {
             throw NSError(
@@ -251,9 +278,83 @@ enum InvisibleWatermark {
         }
         let order = try permutation(key: key)
         let seed = hmacSeed(keyBytes)
-        let offsets = search == "robust" ? blockSize : 1
-        let phaseXs = search == "robust" ? tileWidth : 1
-        let phaseYs = search == "robust" ? tileHeight : 1
+        let scales = search == "robust" ? [1.0] + resizeScales : [1.0]
+
+        for scale in scales {
+            let candidateImage: PixelImage
+            if scale == 1 {
+                candidateImage = PixelImage(bytes: bytes, width: width, height: height, scale: 1)
+            } else {
+                let targetWidth = Int((Double(width) / scale).rounded())
+                let targetHeight = Int((Double(height) / scale).rounded())
+                if targetWidth < minimumWidth || targetHeight < minimumHeight { continue }
+                candidateImage = scale < 1
+                    ? resizePixelsNearest(
+                        bytes,
+                        width: width,
+                        height: height,
+                        targetWidth: targetWidth,
+                        targetHeight: targetHeight
+                    )
+                    : resizePixelsBilinear(
+                        bytes,
+                        width: width,
+                        height: height,
+                        targetWidth: targetWidth,
+                        targetHeight: targetHeight
+                    )
+            }
+            let deltaFactors = scale == 1 ? [1.0] : [1.0, 0.9]
+            for factor in deltaFactors {
+                if let candidate = detectAtScale(
+                    candidateImage.bytes,
+                    width: candidateImage.width,
+                    height: candidateImage.height,
+                    keyBytes: keyBytes,
+                    permutation: order,
+                    seed: seed,
+                    delta: delta * factor,
+                    robust: false
+                ) {
+                    return detection(candidate, scale: scale)
+                }
+            }
+        }
+
+        if search == "robust", let candidate = detectAtScale(
+            bytes,
+            width: width,
+            height: height,
+            keyBytes: keyBytes,
+            permutation: order,
+            seed: seed,
+            delta: delta,
+            robust: true
+        ) {
+            return detection(candidate)
+        }
+        return InvisibleWatermarkDetection(
+            detected: false,
+            payload: nil,
+            confidence: 0,
+            bitErrorRate: nil,
+            scale: nil
+        )
+    }
+
+    private static func detectAtScale(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int,
+        keyBytes: [UInt8],
+        permutation: [Int],
+        seed: UInt32,
+        delta: Double,
+        robust: Bool
+    ) -> Candidate? {
+        let offsets = robust ? blockSize : 1
+        let phaseXs = robust ? tileWidth : 1
+        let phaseYs = robust ? tileHeight : 1
         var best: Candidate?
 
         for offsetY in 0..<offsets {
@@ -270,7 +371,7 @@ enum InvisibleWatermark {
                         guard let candidate = decodeCandidate(
                             observations,
                             keyBytes: keyBytes,
-                            permutation: order,
+                            permutation: permutation,
                             seed: seed,
                             delta: delta,
                             phaseX: phaseX,
@@ -278,29 +379,88 @@ enum InvisibleWatermark {
                         ) else { continue }
                         if best == nil || candidate.confidence > best!.confidence {
                             best = candidate
-                            if search == "fast" || candidate.confidence >= 0.98 {
-                                return detection(candidate)
+                            if !robust || candidate.confidence >= 0.98 {
+                                return candidate
                             }
                         }
                     }
                 }
             }
         }
-        return best.map(detection) ?? InvisibleWatermarkDetection(
-            detected: false,
-            payload: nil,
-            confidence: 0,
-            bitErrorRate: nil
-        )
+        return best
     }
 
-    private static func detection(_ candidate: Candidate) -> InvisibleWatermarkDetection {
+    private static func detection(
+        _ candidate: Candidate,
+        scale: Double = 1
+    ) -> InvisibleWatermarkDetection {
         InvisibleWatermarkDetection(
             detected: true,
             payload: candidate.payload,
             confidence: candidate.confidence,
-            bitErrorRate: candidate.bitErrorRate
+            bitErrorRate: candidate.bitErrorRate,
+            scale: scale == 1 ? nil : scale
         )
+    }
+
+    private static func resizePixelsNearest(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int,
+        targetWidth: Int,
+        targetHeight: Int
+    ) -> PixelImage {
+        var output = [UInt8](repeating: 0, count: targetWidth * targetHeight * 4)
+        for targetY in 0..<targetHeight {
+            let sourceY = min(height - 1, Int(floor((Double(targetY) + 0.5) * Double(height) / Double(targetHeight))))
+            for targetX in 0..<targetWidth {
+                let sourceX = min(width - 1, Int(floor((Double(targetX) + 0.5) * Double(width) / Double(targetWidth))))
+                let source = (sourceY * width + sourceX) * 4
+                let target = (targetY * targetWidth + targetX) * 4
+                output[target..<(target + 4)] = bytes[source..<(source + 4)]
+            }
+        }
+        return PixelImage(bytes: output, width: targetWidth, height: targetHeight, scale: 1)
+    }
+
+    private static func resizePixelsBilinear(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int,
+        targetWidth: Int,
+        targetHeight: Int
+    ) -> PixelImage {
+        precondition(targetWidth > 0 && targetHeight > 0)
+        var output = [UInt8](repeating: 0, count: targetWidth * targetHeight * 4)
+        let scaleX = Double(width) / Double(targetWidth)
+        let scaleY = Double(height) / Double(targetHeight)
+        for targetY in 0..<targetHeight {
+            let sourceY = (Double(targetY) + 0.5) * scaleY - 0.5
+            let top = max(0, min(height - 1, Int(floor(sourceY))))
+            let bottom = min(height - 1, top + 1)
+            let weightY = max(0, min(1, sourceY - Double(top)))
+            for targetX in 0..<targetWidth {
+                let sourceX = (Double(targetX) + 0.5) * scaleX - 0.5
+                let left = max(0, min(width - 1, Int(floor(sourceX))))
+                let right = min(width - 1, left + 1)
+                let weightX = max(0, min(1, sourceX - Double(left)))
+                let topLeft = (top * width + left) * 4
+                let topRight = (top * width + right) * 4
+                let bottomLeft = (bottom * width + left) * 4
+                let bottomRight = (bottom * width + right) * 4
+                let target = (targetY * targetWidth + targetX) * 4
+                for channel in 0..<4 {
+                    let topValue = Double(bytes[topLeft + channel]) * (1 - weightX)
+                        + Double(bytes[topRight + channel]) * weightX
+                    let bottomValue = Double(bytes[bottomLeft + channel]) * (1 - weightX)
+                        + Double(bytes[bottomRight + channel]) * weightX
+                    output[target + channel] = UInt8(
+                        max(0, min(255, (topValue * (1 - weightY) + bottomValue * weightY).rounded()))
+                    )
+                }
+            }
+        }
+        return PixelImage(bytes: output, width: targetWidth, height: targetHeight, scale: 1)
     }
 
     private static func buildFrame(payload: String, key: String) throws -> [UInt8] {

--- a/src/__tests__/content-credentials.test.ts
+++ b/src/__tests__/content-credentials.test.ts
@@ -1,0 +1,165 @@
+import {
+  embedInvisibleWithCredentials,
+  verifyContentCredentials,
+  type ContentCredentialsAdapter,
+} from '../content-credentials';
+
+const watermark = {
+  image: { src: 'source.jpg' },
+  payload: 'asset-42',
+  key: '0123456789abcdef',
+} as const;
+
+describe('Content Credentials adapter workflow', () => {
+  it('embeds before signing and returns both stages', async () => {
+    const calls: string[] = [];
+    const adapter: ContentCredentialsAdapter = {
+      async sign(request) {
+        calls.push(`sign:${request.image}`);
+        expect(request).toEqual({
+          image: 'watermarked.png',
+          locator: 'asset-42',
+          algorithm: 'dct-qim-v1',
+          claim: {
+            title: 'Distribution copy',
+            format: 'image/png',
+            generator: undefined,
+            metadata: { recipient: 'internal' },
+          },
+        });
+        return { image: 'signed.png', manifestId: 'urn:c2pa:test' };
+      },
+      async verify() {
+        return { valid: true };
+      },
+    };
+
+    await expect(
+      embedInvisibleWithCredentials(
+        async () => {
+          calls.push('embed');
+          return 'watermarked.png';
+        },
+        {
+          watermark,
+          adapter,
+          claim: {
+            title: ' Distribution copy ',
+            format: 'image/png',
+            metadata: { recipient: 'internal' },
+          },
+        }
+      )
+    ).resolves.toEqual({
+      watermarkedImage: 'watermarked.png',
+      signedImage: 'signed.png',
+      manifestId: 'urn:c2pa:test',
+    });
+    expect(calls).toEqual(['embed', 'sign:watermarked.png']);
+  });
+
+  it('validates adapters, claims, sign results, and verification results', async () => {
+    const validAdapter: ContentCredentialsAdapter = {
+      async sign() {
+        return { image: '' };
+      },
+      async verify() {
+        return { valid: true };
+      },
+    };
+    await expect(
+      embedInvisibleWithCredentials(async () => 'watermarked.png', {
+        watermark,
+        adapter: validAdapter,
+        claim: { title: 'Copy' },
+      })
+    ).rejects.toThrow('invalid signed image');
+    await expect(
+      embedInvisibleWithCredentials(async () => 'watermarked.png', {
+        watermark,
+        adapter: validAdapter,
+        claim: { title: ' ' },
+      })
+    ).rejects.toThrow('title must not be empty');
+    await expect(
+      verifyContentCredentials({
+        image: 'signed.png',
+        adapter: {
+          async sign() {
+            return { image: 'signed.png' };
+          },
+          async verify() {
+            return {} as never;
+          },
+        },
+      })
+    ).rejects.toThrow('invalid verification result');
+    await expect(
+      verifyContentCredentials({
+        image: 'signed.png',
+        adapter: {
+          async sign() {
+            return { image: 'signed.png' };
+          },
+          async verify() {
+            return { valid: true, manifestId: 42 } as never;
+          },
+        },
+      })
+    ).rejects.toThrow('invalid manifest ID');
+  });
+
+  it('preserves adapter errors', async () => {
+    const expected = new Error('signing service unavailable');
+    await expect(
+      embedInvisibleWithCredentials(async () => 'watermarked.png', {
+        watermark,
+        claim: { title: 'Copy' },
+        adapter: {
+          async sign() {
+            throw expected;
+          },
+          async verify() {
+            return { valid: false };
+          },
+        },
+      })
+    ).rejects.toBe(expected);
+  });
+
+  it('signs the locator snapshot that was passed to embedding', async () => {
+    const mutable = {
+      image: { src: 'before.jpg' },
+      payload: 'asset-42',
+      key: '0123456789abcdef',
+    };
+    let embeddedPayload = '';
+    const signedLocators: string[] = [];
+    const operation = embedInvisibleWithCredentials(
+      async (options) => {
+        embeddedPayload = options.payload;
+        await Promise.resolve();
+        return 'watermarked.png';
+      },
+      {
+        watermark: mutable,
+        claim: { title: 'Copy' },
+        adapter: {
+          async sign(request) {
+            signedLocators.push(request.locator);
+            return { image: 'signed.png' };
+          },
+          async verify() {
+            return { valid: true };
+          },
+        },
+      }
+    );
+    mutable.payload = 'changed';
+    mutable.image.src = 'after.jpg';
+
+    await operation;
+    expect(embeddedPayload).toBe('asset-42');
+    expect(signedLocators).toEqual(['asset-42']);
+  });
+});

--- a/src/__tests__/image-mark-options.typecheck.ts
+++ b/src/__tests__/image-mark-options.typecheck.ts
@@ -1,5 +1,6 @@
 import Marker, {
   type BlendMode,
+  type ContentCredentialsAdapter,
   ImageFormat,
   type ImageMarkOptions,
   type TextMarkOptions,
@@ -22,6 +23,47 @@ export const invisibleDetection = Marker.detectInvisible({
   image: { src: 'file:///tmp/marked.png' },
   key: '0123456789abcdef',
   search: 'robust',
+});
+
+export const invisibleBatch = Marker.embedInvisibleMany(
+  [
+    {
+      image: { src: 'file:///tmp/background.png' },
+      payload: 'asset-42',
+      key: '0123456789abcdef',
+    },
+  ],
+  {
+    concurrency: 2,
+    onProgress(progress) {
+      const completed: number = progress.settled;
+      completed.toFixed(0);
+    },
+  }
+);
+
+const contentCredentialsAdapter: ContentCredentialsAdapter = {
+  async sign(request) {
+    return { image: request.image, manifestId: request.locator };
+  },
+  async verify() {
+    return { valid: true };
+  },
+};
+
+export const signedInvisibleOutput = Marker.embedInvisibleWithCredentials({
+  watermark: {
+    image: { src: 'file:///tmp/background.png' },
+    payload: 'asset-42',
+    key: '0123456789abcdef',
+  },
+  claim: { title: 'Example', format: 'image/png' },
+  adapter: contentCredentialsAdapter,
+});
+
+export const credentialsVerification = Marker.verifyContentCredentials({
+  image: 'file:///tmp/signed.png',
+  adapter: contentCredentialsAdapter,
 });
 
 // The deprecated single-watermark shape remains source-compatible for users

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -70,6 +70,7 @@ describe('Marker JS wrapper', () => {
         payload: 'asset-42',
         confidence: 0.94,
         bitErrorRate: 0.03,
+        scale: 0.95,
         algorithm: 'dct-qim-v1',
       })
     );
@@ -101,7 +102,11 @@ describe('Marker JS wrapper', () => {
         search: 'robust',
       })
     ).resolves.toEqual(
-      expect.objectContaining({ detected: true, payload: 'asset-42' })
+      expect.objectContaining({
+        detected: true,
+        payload: 'asset-42',
+        scale: 0.95,
+      })
     );
     expect(nativeModule.detectInvisible).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -124,6 +129,22 @@ describe('Marker JS wrapper', () => {
         key: '0123456789abcdef',
       })
     ).rejects.toThrow('invalid JSON');
+
+    nativeModule.detectInvisible.mockResolvedValue(
+      JSON.stringify({
+        detected: true,
+        payload: 'asset-42',
+        confidence: 0.9,
+        algorithm: 'dct-qim-v1',
+        scale: 2,
+      })
+    );
+    await expect(
+      Marker.detectInvisible({
+        image: { src: 'file:///tmp/invisible.png' },
+        key: '0123456789abcdef',
+      })
+    ).rejects.toThrow('invalid data');
   });
 
   it('creates reusable native recipes through the public Marker API', async () => {
@@ -185,6 +206,41 @@ describe('Marker JS wrapper', () => {
         (result: { status: string }) => result.status === 'fulfilled'
       )
     ).toBe(true);
+  });
+
+  it('keeps native invisible batches serial and isolates item failures', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    nativeModule.embedInvisible.mockImplementation(async (options) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      if (options.payload === 'recipient-2') throw new Error('write failed');
+      return `/tmp/${options.payload}.png`;
+    });
+
+    const results = await Marker.embedInvisibleMany(
+      [1, 2, 3].map((src, index) => ({
+        image: { src },
+        payload: `recipient-${index + 1}`,
+        key: `0123456789abcde${index}`,
+      })),
+      { concurrency: 3 }
+    );
+
+    expect(maximumActive).toBe(1);
+    expect(results).toEqual([
+      { status: 'fulfilled', value: '/tmp/recipient-1.png' },
+      {
+        status: 'rejected',
+        reason: expect.objectContaining({ message: 'write failed' }),
+      },
+      { status: 'fulfilled', value: '/tmp/recipient-3.png' },
+    ]);
+    expect(
+      nativeModule.embedInvisible.mock.calls.map(([value]) => value.payload)
+    ).toEqual(['recipient-1', 'recipient-2', 'recipient-3']);
   });
 
   it('normalizes markText options before calling the native module', async () => {

--- a/src/__tests__/invisible-watermark.test.ts
+++ b/src/__tests__/invisible-watermark.test.ts
@@ -1,10 +1,12 @@
 import {
   buildInvisibleWatermarkFrame,
   createInvisibleWatermarkPermutation,
+  detectInvisibleWatermarkPixelsAsync,
   detectInvisibleWatermarkPixels,
   embedInvisibleWatermarkPixels,
   encodeUtf8,
   hmacSha256,
+  resizeInvisibleWatermarkPixels,
   sha256,
 } from '../invisible-watermark';
 
@@ -161,6 +163,62 @@ describe('invisible watermark core', () => {
       })
     ).toEqual(expect.objectContaining({ detected: true, payload: 'crop-7' }));
   }, 20_000);
+
+  it.each([0.9, 0.95, 1.05, 1.1])(
+    'recovers a locator after %sx resizing',
+    (scale) => {
+      const width = 256;
+      const height = 176;
+      const data = createPixels(width, height);
+      embedInvisibleWatermarkPixels(
+        { data, width, height },
+        { payload: 'scale-7', key: KEY, strength: 'robust' }
+      );
+      const resized = resizeInvisibleWatermarkPixels(
+        { data, width, height },
+        Math.round(width * scale),
+        Math.round(height * scale)
+      );
+
+      expect(
+        detectInvisibleWatermarkPixels(resized, {
+          key: KEY,
+          strength: 'robust',
+          search: 'robust',
+        })
+      ).toEqual(
+        expect.objectContaining({
+          detected: true,
+          payload: 'scale-7',
+          scale,
+        })
+      );
+    },
+    20_000
+  );
+
+  it('yields the event loop during asynchronous Web detection', async () => {
+    const width = 256;
+    const height = 176;
+    const data = createPixels(width, height);
+    embedInvisibleWatermarkPixels(
+      { data, width, height },
+      { payload: 'async-7', key: KEY }
+    );
+    let heartbeat = false;
+    const detection = detectInvisibleWatermarkPixelsAsync(
+      { data, width, height },
+      { key: KEY, search: 'fast' }
+    );
+    setTimeout(() => {
+      heartbeat = true;
+    }, 0);
+
+    await expect(detection).resolves.toEqual(
+      expect.objectContaining({ detected: true, payload: 'async-7' })
+    );
+    expect(heartbeat).toBe(true);
+  });
 
   it('does not authenticate an unmarked image or the wrong key', () => {
     const width = 256;

--- a/src/__tests__/web-marker-api.test.ts
+++ b/src/__tests__/web-marker-api.test.ts
@@ -196,6 +196,45 @@ describe('WebMarker public API', () => {
     expect(maximumActive).toBe(4);
   });
 
+  it('caps public Web invisible batches at four active renders', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    mockRenderWebCompositionToCanvas.mockImplementation(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      const itemPixels = pixels.slice();
+      const context = {
+        getImageData: jest.fn(() => ({
+          data: itemPixels,
+          width: 256,
+          height: 176,
+        })),
+        putImageData: jest.fn(),
+      };
+      return {
+        width: 256,
+        height: 176,
+        getContext: jest.fn(() => context),
+        toDataURL: jest.fn(() => 'data:image/png;base64,invisible'),
+        toBlob: jest.fn(),
+      };
+    });
+
+    const results = await WebMarker.embedInvisibleMany(
+      Array.from({ length: 8 }, (_, index) => ({
+        image: { src: `/background-${index}.jpg` },
+        payload: `asset-${index}`,
+        key: `0123456789abcde${index}`,
+      })),
+      { concurrency: 8 }
+    );
+
+    expect(maximumActive).toBe(4);
+    expect(results.every((result) => result.status === 'fulfilled')).toBe(true);
+  });
+
   it('keeps image arrays before the legacy image compatibility layer', async () => {
     const options: ImageMarkOptions = {
       backgroundImage: { src: '/background.jpg' },

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,143 @@
+export interface WatermarkBatchFulfilledResult<Result> {
+  status: 'fulfilled';
+  value: Result;
+}
+
+export interface WatermarkBatchRejectedResult {
+  status: 'rejected';
+  reason: unknown;
+}
+
+export interface WatermarkBatchAbortedResult {
+  status: 'aborted';
+  reason: Error;
+}
+
+export type WatermarkBatchResult<Result> =
+  | WatermarkBatchFulfilledResult<Result>
+  | WatermarkBatchRejectedResult
+  | WatermarkBatchAbortedResult;
+
+export interface WatermarkBatchProgress<Result> {
+  total: number;
+  settled: number;
+  succeeded: number;
+  failed: number;
+  aborted: number;
+  /** Index of the item that produced this progress update. */
+  index: number;
+  result: WatermarkBatchResult<Result>;
+}
+
+export interface WatermarkBatchOptions<Result> {
+  /** Requested worker count. Web is capped at 4 and native targets at 1. */
+  concurrency?: number;
+  /** Stops new items from starting. Already-running items are allowed to finish. */
+  signal?: AbortSignal;
+  /** Called once when each item is fulfilled, rejected, or skipped after abort. */
+  onProgress?: (progress: WatermarkBatchProgress<Result>) => void;
+}
+
+function abortResult<Result>(): WatermarkBatchResult<Result> {
+  const reason = new Error(
+    'Batch item was not started because the operation was aborted.'
+  );
+  reason.name = 'AbortError';
+  return { status: 'aborted', reason };
+}
+
+export async function runWatermarkBatch<Input, Result>(
+  inputs: readonly Input[],
+  task: (input: Input, index: number) => Promise<Result>,
+  batchOptions: WatermarkBatchOptions<Result> = {},
+  maximumConcurrency = 1,
+  inputLabel = 'batch'
+): Promise<Array<WatermarkBatchResult<Result>>> {
+  if (!Array.isArray(inputs)) {
+    throw new Error(`${inputLabel} inputs must be an array.`);
+  }
+  const requestedConcurrency = batchOptions.concurrency ?? 1;
+  if (
+    !Number.isFinite(requestedConcurrency) ||
+    !Number.isInteger(requestedConcurrency) ||
+    requestedConcurrency <= 0
+  ) {
+    throw new Error('concurrency must be a positive finite integer.');
+  }
+  if (inputs.length === 0) {
+    return [];
+  }
+
+  const concurrency = Math.min(
+    requestedConcurrency,
+    maximumConcurrency,
+    inputs.length
+  );
+  const results: Array<WatermarkBatchResult<Result> | undefined> = new Array(
+    inputs.length
+  );
+  let cursor = 0;
+  let settled = 0;
+  let succeeded = 0;
+  let failed = 0;
+  let aborted = 0;
+
+  const report = (
+    index: number,
+    result: WatermarkBatchResult<Result>
+  ): void => {
+    settled += 1;
+    if (result.status === 'fulfilled') succeeded += 1;
+    else if (result.status === 'rejected') failed += 1;
+    else aborted += 1;
+    try {
+      batchOptions.onProgress?.({
+        total: inputs.length,
+        settled,
+        succeeded,
+        failed,
+        aborted,
+        index,
+        result,
+      });
+    } catch {
+      // Progress observers must not interrupt the batch or change results.
+    }
+  };
+
+  const worker = async (): Promise<void> => {
+    while (!batchOptions.signal?.aborted) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= inputs.length) {
+        return;
+      }
+      if (batchOptions.signal?.aborted) {
+        return;
+      }
+      let result: WatermarkBatchResult<Result>;
+      try {
+        result = {
+          status: 'fulfilled',
+          value: await task(inputs[index] as Input, index),
+        };
+      } catch (reason) {
+        result = { status: 'rejected', reason };
+      }
+      results[index] = result;
+      report(index, result);
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+
+  for (let index = 0; index < inputs.length; index += 1) {
+    if (!results[index]) {
+      const result = abortResult<Result>();
+      results[index] = result;
+      report(index, result);
+    }
+  }
+
+  return results as Array<WatermarkBatchResult<Result>>;
+}

--- a/src/content-credentials.ts
+++ b/src/content-credentials.ts
@@ -1,0 +1,201 @@
+import type { EmbedInvisibleWatermarkOptions } from './invisible-watermark';
+import { INVISIBLE_WATERMARK_ALGORITHM } from './invisible-watermark';
+
+export interface ContentCredentialsClaim {
+  /** Human-readable asset title included in the signed manifest. */
+  title: string;
+  /** Encoded image type. The v1.11 workflow supports JPEG and PNG. */
+  format?: 'image/jpeg' | 'image/png';
+  /** Claim generator name shown by Content Credentials readers. */
+  generator?: string;
+  /** Adapter-specific public metadata. Never include signing secrets. */
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface ContentCredentialsSignRequest {
+  /** Image already containing the invisible locator. */
+  image: string;
+  /** Locator used to correlate the signed record. */
+  locator: string;
+  /** Pixel algorithm that wrote the locator. */
+  algorithm: typeof INVISIBLE_WATERMARK_ALGORITHM;
+  claim: ContentCredentialsClaim;
+}
+
+export interface ContentCredentialsSignResult {
+  /** Image containing the signed Content Credential. */
+  image: string;
+  manifestId?: string;
+}
+
+export interface ContentCredentialsVerificationResult {
+  valid: boolean;
+  manifestId?: string;
+  validationStatus?: readonly string[];
+  manifest?: unknown;
+}
+
+export interface ContentCredentialsAdapter {
+  sign(
+    request: ContentCredentialsSignRequest
+  ): Promise<ContentCredentialsSignResult>;
+  verify(image: string): Promise<ContentCredentialsVerificationResult>;
+}
+
+export interface EmbedInvisibleWithCredentialsOptions {
+  watermark: EmbedInvisibleWatermarkOptions;
+  adapter: ContentCredentialsAdapter;
+  claim: ContentCredentialsClaim;
+}
+
+export interface EmbedInvisibleWithCredentialsResult {
+  watermarkedImage: string;
+  signedImage: string;
+  manifestId?: string;
+}
+
+export interface VerifyContentCredentialsOptions {
+  image: string;
+  adapter: ContentCredentialsAdapter;
+}
+
+function validateAdapter(
+  adapter: ContentCredentialsAdapter
+): ContentCredentialsAdapter {
+  if (
+    !adapter ||
+    typeof adapter.sign !== 'function' ||
+    typeof adapter.verify !== 'function'
+  ) {
+    throw new Error(
+      'Content Credentials adapter must provide sign() and verify() functions.'
+    );
+  }
+  return adapter;
+}
+
+function snapshotClaim(
+  claim: ContentCredentialsClaim
+): ContentCredentialsClaim {
+  if (!claim || typeof claim.title !== 'string' || !claim.title.trim()) {
+    throw new Error('Content Credentials claim title must not be empty.');
+  }
+  if (
+    claim.format !== undefined &&
+    claim.format !== 'image/jpeg' &&
+    claim.format !== 'image/png'
+  ) {
+    throw new Error(
+      'Content Credentials claim format must be image/jpeg or image/png.'
+    );
+  }
+  if (
+    claim.generator !== undefined &&
+    (typeof claim.generator !== 'string' || !claim.generator.trim())
+  ) {
+    throw new Error(
+      'Content Credentials claim generator must be a non-empty string.'
+    );
+  }
+  if (
+    claim.metadata !== undefined &&
+    (!claim.metadata ||
+      typeof claim.metadata !== 'object' ||
+      Array.isArray(claim.metadata))
+  ) {
+    throw new Error('Content Credentials claim metadata must be an object.');
+  }
+  return {
+    title: claim.title.trim(),
+    format: claim.format,
+    generator: claim.generator?.trim(),
+    metadata: claim.metadata ? { ...claim.metadata } : undefined,
+  };
+}
+
+function validateSignResult(
+  result: ContentCredentialsSignResult
+): ContentCredentialsSignResult {
+  if (!result || typeof result.image !== 'string' || !result.image) {
+    throw new Error(
+      'Content Credentials adapter returned an invalid signed image.'
+    );
+  }
+  if (
+    result.manifestId !== undefined &&
+    typeof result.manifestId !== 'string'
+  ) {
+    throw new Error(
+      'Content Credentials adapter returned an invalid manifest ID.'
+    );
+  }
+  return result;
+}
+
+function validateVerificationResult(
+  result: ContentCredentialsVerificationResult
+): ContentCredentialsVerificationResult {
+  if (!result || typeof result.valid !== 'boolean') {
+    throw new Error(
+      'Content Credentials adapter returned an invalid verification result.'
+    );
+  }
+  if (
+    result.manifestId !== undefined &&
+    typeof result.manifestId !== 'string'
+  ) {
+    throw new Error(
+      'Content Credentials adapter returned an invalid manifest ID.'
+    );
+  }
+  if (
+    result.validationStatus !== undefined &&
+    (!Array.isArray(result.validationStatus) ||
+      result.validationStatus.some((status) => typeof status !== 'string'))
+  ) {
+    throw new Error(
+      'Content Credentials adapter returned invalid validation status data.'
+    );
+  }
+  return result;
+}
+
+export async function embedInvisibleWithCredentials(
+  embed: (options: EmbedInvisibleWatermarkOptions) => Promise<string>,
+  options: EmbedInvisibleWithCredentialsOptions
+): Promise<EmbedInvisibleWithCredentialsResult> {
+  const adapter = validateAdapter(options?.adapter);
+  const claim = snapshotClaim(options?.claim);
+  const watermark = {
+    ...options.watermark,
+    image: { ...options.watermark?.image },
+  };
+  const locator = watermark.payload;
+  const watermarkedImage = await embed(watermark);
+  const signed = validateSignResult(
+    await adapter.sign({
+      image: watermarkedImage,
+      locator,
+      algorithm: INVISIBLE_WATERMARK_ALGORITHM,
+      claim,
+    })
+  );
+  const result: EmbedInvisibleWithCredentialsResult = {
+    watermarkedImage,
+    signedImage: signed.image,
+  };
+  if (signed.manifestId !== undefined) {
+    result.manifestId = signed.manifestId;
+  }
+  return result;
+}
+
+export async function verifyContentCredentials(
+  options: VerifyContentCredentialsOptions
+): Promise<ContentCredentialsVerificationResult> {
+  const adapter = validateAdapter(options?.adapter);
+  if (typeof options?.image !== 'string' || !options.image) {
+    throw new Error('Content Credentials image must not be empty.');
+  }
+  return validateVerificationResult(await adapter.verify(options.image));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,19 @@ export {
   INVISIBLE_WATERMARK_MIN_HEIGHT,
   INVISIBLE_WATERMARK_MIN_KEY_BYTES,
   INVISIBLE_WATERMARK_MIN_WIDTH,
+  INVISIBLE_WATERMARK_RESIZE_SCALES,
 } from './invisible-watermark';
+
+export type {
+  ContentCredentialsAdapter,
+  ContentCredentialsClaim,
+  ContentCredentialsSignRequest,
+  ContentCredentialsSignResult,
+  ContentCredentialsVerificationResult,
+  EmbedInvisibleWithCredentialsOptions,
+  EmbedInvisibleWithCredentialsResult,
+  VerifyContentCredentialsOptions,
+} from './content-credentials';
 
 /**
  * Position enum for text watermark and image watermark

--- a/src/invisible-watermark.ts
+++ b/src/invisible-watermark.ts
@@ -7,6 +7,10 @@ export const INVISIBLE_WATERMARK_MAX_PAYLOAD_BYTES = 12;
 export const INVISIBLE_WATERMARK_MIN_KEY_BYTES = 16;
 export const INVISIBLE_WATERMARK_MIN_WIDTH = 128;
 export const INVISIBLE_WATERMARK_MIN_HEIGHT = 88;
+export const INVISIBLE_WATERMARK_RESIZE_SCALES = [
+  0.95, 1.05, 0.9, 1.1,
+] as const;
+const INVISIBLE_WATERMARK_RESIZE_DELTA_FACTORS = [1, 0.9];
 
 const BLOCK_SIZE = 8;
 const TILE_WIDTH = 16;
@@ -57,7 +61,7 @@ const STRENGTH_DELTAS: Record<InvisibleWatermarkStrength, number> = {
 /** Pixel-change strength used by the DCT-QIM invisible watermark. */
 export type InvisibleWatermarkStrength = 'subtle' | 'balanced' | 'robust';
 
-/** Detection search cost. Robust search also checks shifted block grids and tile phases. */
+/** Detection search cost. Robust search also checks light resizing, shifted block grids, and tile phases. */
 export type InvisibleWatermarkSearch = 'fast' | 'robust';
 
 /** Source image accepted by the invisible watermark APIs. */
@@ -94,7 +98,7 @@ export interface DetectInvisibleWatermarkOptions {
   key: string;
   /** The same pixel-change strength used during embedding. @defaultValue `balanced` */
   strength?: InvisibleWatermarkStrength;
-  /** Use `robust` for limited crop recovery at a substantially higher CPU cost. @defaultValue `fast` */
+  /** Use `robust` for 0.9×–1.1× resize and limited crop recovery at a higher CPU cost. @defaultValue `fast` */
   search?: InvisibleWatermarkSearch;
   /** Maximum decoded width or height. Keep this consistent with embedding. @defaultValue 2048 */
   maxSize?: number;
@@ -112,6 +116,8 @@ export interface InvisibleWatermarkDetectionResult {
   bitErrorRate?: number;
   /** Versioned pixel algorithm identifier. */
   algorithm: typeof INVISIBLE_WATERMARK_ALGORITHM;
+  /** Estimated input scale when robust resize recovery was required. */
+  scale?: number;
 }
 
 export interface InvisibleWatermarkPixelBuffer {
@@ -135,6 +141,9 @@ function toPublicDetectionResult(
   if (candidate.payload !== undefined) result.payload = candidate.payload;
   if (candidate.bitErrorRate !== undefined) {
     result.bitErrorRate = candidate.bitErrorRate;
+  }
+  if (candidate.scale !== undefined && candidate.scale !== 1) {
+    result.scale = candidate.scale;
   }
   return result;
 }
@@ -729,6 +738,48 @@ function observeGrid(
   return observations;
 }
 
+async function yieldToEventLoop(): Promise<void> {
+  const scheduler = (
+    globalThis as typeof globalThis & {
+      scheduler?: { yield?: () => Promise<void> };
+    }
+  ).scheduler;
+  if (typeof scheduler?.yield === 'function') {
+    await scheduler.yield();
+    return;
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+async function observeGridAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  offsetX: number,
+  offsetY: number
+): Promise<BlockObservation[]> {
+  const blocksX = Math.floor((buffer.width - offsetX) / BLOCK_SIZE);
+  const blocksY = Math.floor((buffer.height - offsetY) / BLOCK_SIZE);
+  const observations: BlockObservation[] = [];
+  for (let blockY = 0; blockY < blocksY; blockY += 1) {
+    for (let blockX = 0; blockX < blocksX; blockX += 1) {
+      const block = readLuminanceBlock(
+        buffer,
+        offsetX + blockX * BLOCK_SIZE,
+        offsetY + blockY * BLOCK_SIZE
+      );
+      if (!block.usable) continue;
+      const differences = new Float64Array(COEFFICIENT_PAIRS.length);
+      COEFFICIENT_PAIRS.forEach((pair, index) => {
+        differences[index] = coefficientDifference(block.luminance, pair);
+      });
+      observations.push({ differences, blockX, blockY });
+    }
+    if ((blockY + 1) % 8 === 0) {
+      await yieldToEventLoop();
+    }
+  }
+  return observations;
+}
+
 function decodeCandidate(
   observations: BlockObservation[],
   keyBytes: Uint8Array,
@@ -796,26 +847,45 @@ function decodeCandidate(
   };
 }
 
-export function detectInvisibleWatermarkPixels(
-  buffer: InvisibleWatermarkPixelBuffer,
-  options: Pick<DetectInvisibleWatermarkOptions, 'key' | 'strength' | 'search'>
-): InvisibleWatermarkDetectionResult {
-  validateImageDimensions(buffer.width, buffer.height);
-  if (buffer.data.length < buffer.width * buffer.height * 4) {
-    throw new Error(
-      'RGBA pixel buffer is smaller than its declared dimensions.'
-    );
-  }
+interface DetectionContext {
+  keyBytes: Uint8Array;
+  permutation: Uint16Array;
+  seed: number;
+  delta: number;
+}
+
+function createDetectionContext(
+  options: Pick<DetectInvisibleWatermarkOptions, 'key' | 'strength'>
+): DetectionContext {
   const keyBytes = encodeUtf8(options.key ?? '');
   if (keyBytes.length < INVISIBLE_WATERMARK_MIN_KEY_BYTES) {
     throw new Error(
       `key must contain at least ${INVISIBLE_WATERMARK_MIN_KEY_BYTES} UTF-8 bytes.`
     );
   }
-  const delta = STRENGTH_DELTAS[validateStrength(options.strength)];
-  const search = validateSearch(options.search);
-  const permutation = createInvisibleWatermarkPermutation(options.key);
-  const seed = seedForKey(keyBytes);
+  return {
+    keyBytes,
+    delta: STRENGTH_DELTAS[validateStrength(options.strength)],
+    permutation: createInvisibleWatermarkPermutation(options.key),
+    seed: seedForKey(keyBytes),
+  };
+}
+
+function validatePixelBuffer(buffer: InvisibleWatermarkPixelBuffer): void {
+  validateImageDimensions(buffer.width, buffer.height);
+  if (buffer.data.length < buffer.width * buffer.height * 4) {
+    throw new Error(
+      'RGBA pixel buffer is smaller than its declared dimensions.'
+    );
+  }
+}
+
+function detectAtScale(
+  buffer: InvisibleWatermarkPixelBuffer,
+  context: DetectionContext,
+  search: InvisibleWatermarkSearch,
+  scale = 1
+): DetectionCandidate | null {
   const offsets = search === 'robust' ? BLOCK_SIZE : 1;
   const phaseXs = search === 'robust' ? TILE_WIDTH : 1;
   const phaseYs = search === 'robust' ? TILE_HEIGHT : 1;
@@ -828,29 +898,355 @@ export function detectInvisibleWatermarkPixels(
         for (let phaseX = 0; phaseX < phaseXs; phaseX += 1) {
           const candidate = decodeCandidate(
             observations,
-            keyBytes,
-            permutation,
-            seed,
-            delta,
+            context.keyBytes,
+            context.permutation,
+            context.seed,
+            context.delta,
             phaseX,
             phaseY
           );
           if (candidate && (!best || candidate.confidence > best.confidence)) {
+            candidate.scale = scale;
             best = candidate;
             if (search === 'fast' || candidate.confidence >= 0.98) {
-              return toPublicDetectionResult(candidate);
+              return candidate;
             }
           }
         }
       }
     }
   }
-  if (best) {
-    return toPublicDetectionResult(best);
+  return best;
+}
+
+async function detectAtScaleAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  context: DetectionContext,
+  search: InvisibleWatermarkSearch,
+  scale = 1
+): Promise<DetectionCandidate | null> {
+  const offsets = search === 'robust' ? BLOCK_SIZE : 1;
+  const phaseXs = search === 'robust' ? TILE_WIDTH : 1;
+  const phaseYs = search === 'robust' ? TILE_HEIGHT : 1;
+  let best: DetectionCandidate | null = null;
+  let candidatesSinceYield = 0;
+  for (let offsetY = 0; offsetY < offsets; offsetY += 1) {
+    for (let offsetX = 0; offsetX < offsets; offsetX += 1) {
+      const observations = await observeGridAsync(buffer, offsetX, offsetY);
+      for (let phaseY = 0; phaseY < phaseYs; phaseY += 1) {
+        for (let phaseX = 0; phaseX < phaseXs; phaseX += 1) {
+          const candidate = decodeCandidate(
+            observations,
+            context.keyBytes,
+            context.permutation,
+            context.seed,
+            context.delta,
+            phaseX,
+            phaseY
+          );
+          if (candidate && (!best || candidate.confidence > best.confidence)) {
+            candidate.scale = scale;
+            best = candidate;
+            if (search === 'fast' || candidate.confidence >= 0.98) {
+              return candidate;
+            }
+          }
+          candidatesSinceYield += 1;
+          if (candidatesSinceYield >= 16) {
+            candidatesSinceYield = 0;
+            await yieldToEventLoop();
+          }
+        }
+      }
+    }
   }
+  return best;
+}
+
+function detectResizedCandidate(
+  buffer: InvisibleWatermarkPixelBuffer,
+  context: DetectionContext,
+  scale: number
+): DetectionCandidate | null {
+  const observations = observeGrid(buffer, 0, 0);
+  for (const factor of INVISIBLE_WATERMARK_RESIZE_DELTA_FACTORS) {
+    const candidate = decodeCandidate(
+      observations,
+      context.keyBytes,
+      context.permutation,
+      context.seed,
+      context.delta * factor,
+      0,
+      0
+    );
+    if (candidate) {
+      candidate.scale = scale;
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function detectResizedCandidateAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  context: DetectionContext,
+  scale: number
+): Promise<DetectionCandidate | null> {
+  const observations = await observeGridAsync(buffer, 0, 0);
+  for (const factor of INVISIBLE_WATERMARK_RESIZE_DELTA_FACTORS) {
+    const candidate = decodeCandidate(
+      observations,
+      context.keyBytes,
+      context.permutation,
+      context.seed,
+      context.delta * factor,
+      0,
+      0
+    );
+    if (candidate) {
+      candidate.scale = scale;
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function resizeTarget(
+  buffer: InvisibleWatermarkPixelBuffer,
+  scale: number
+): { width: number; height: number } | null {
+  const width = Math.max(1, Math.round(buffer.width / scale));
+  const height = Math.max(1, Math.round(buffer.height / scale));
+  return width >= INVISIBLE_WATERMARK_MIN_WIDTH &&
+    height >= INVISIBLE_WATERMARK_MIN_HEIGHT
+    ? { width, height }
+    : null;
+}
+
+export function resizeInvisibleWatermarkPixels(
+  buffer: InvisibleWatermarkPixelBuffer,
+  width: number,
+  height: number
+): InvisibleWatermarkPixelBuffer {
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(
+      'Invisible watermark resize dimensions must be positive integers.'
+    );
+  }
+  const output = new Uint8ClampedArray(width * height * 4);
+  const scaleX = buffer.width / width;
+  const scaleY = buffer.height / height;
+  for (let targetY = 0; targetY < height; targetY += 1) {
+    const sourceY = (targetY + 0.5) * scaleY - 0.5;
+    const top = Math.max(0, Math.min(buffer.height - 1, Math.floor(sourceY)));
+    const bottom = Math.min(buffer.height - 1, top + 1);
+    const weightY = Math.max(0, Math.min(1, sourceY - top));
+    for (let targetX = 0; targetX < width; targetX += 1) {
+      const sourceX = (targetX + 0.5) * scaleX - 0.5;
+      const left = Math.max(0, Math.min(buffer.width - 1, Math.floor(sourceX)));
+      const right = Math.min(buffer.width - 1, left + 1);
+      const weightX = Math.max(0, Math.min(1, sourceX - left));
+      const topLeft = (top * buffer.width + left) * 4;
+      const topRight = (top * buffer.width + right) * 4;
+      const bottomLeft = (bottom * buffer.width + left) * 4;
+      const bottomRight = (bottom * buffer.width + right) * 4;
+      const target = (targetY * width + targetX) * 4;
+      for (let channel = 0; channel < 4; channel += 1) {
+        const topValue =
+          buffer.data[topLeft + channel]! * (1 - weightX) +
+          buffer.data[topRight + channel]! * weightX;
+        const bottomValue =
+          buffer.data[bottomLeft + channel]! * (1 - weightX) +
+          buffer.data[bottomRight + channel]! * weightX;
+        output[target + channel] =
+          topValue * (1 - weightY) + bottomValue * weightY;
+      }
+    }
+  }
+  return { data: output, width, height };
+}
+
+function resizeInvisibleWatermarkPixelsNearest(
+  buffer: InvisibleWatermarkPixelBuffer,
+  width: number,
+  height: number
+): InvisibleWatermarkPixelBuffer {
+  const output = new Uint8ClampedArray(width * height * 4);
+  for (let targetY = 0; targetY < height; targetY += 1) {
+    const sourceY = Math.min(
+      buffer.height - 1,
+      Math.floor(((targetY + 0.5) * buffer.height) / height)
+    );
+    for (let targetX = 0; targetX < width; targetX += 1) {
+      const sourceX = Math.min(
+        buffer.width - 1,
+        Math.floor(((targetX + 0.5) * buffer.width) / width)
+      );
+      const source = (sourceY * buffer.width + sourceX) * 4;
+      const target = (targetY * width + targetX) * 4;
+      output[target] = buffer.data[source]!;
+      output[target + 1] = buffer.data[source + 1]!;
+      output[target + 2] = buffer.data[source + 2]!;
+      output[target + 3] = buffer.data[source + 3]!;
+    }
+  }
+  return { data: output, width, height };
+}
+
+async function resizeInvisibleWatermarkPixelsAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  width: number,
+  height: number
+): Promise<InvisibleWatermarkPixelBuffer> {
+  const output = new Uint8ClampedArray(width * height * 4);
+  const scaleX = buffer.width / width;
+  const scaleY = buffer.height / height;
+  for (let targetY = 0; targetY < height; targetY += 1) {
+    const sourceY = (targetY + 0.5) * scaleY - 0.5;
+    const top = Math.max(0, Math.min(buffer.height - 1, Math.floor(sourceY)));
+    const bottom = Math.min(buffer.height - 1, top + 1);
+    const weightY = Math.max(0, Math.min(1, sourceY - top));
+    for (let targetX = 0; targetX < width; targetX += 1) {
+      const sourceX = (targetX + 0.5) * scaleX - 0.5;
+      const left = Math.max(0, Math.min(buffer.width - 1, Math.floor(sourceX)));
+      const right = Math.min(buffer.width - 1, left + 1);
+      const weightX = Math.max(0, Math.min(1, sourceX - left));
+      const topLeft = (top * buffer.width + left) * 4;
+      const topRight = (top * buffer.width + right) * 4;
+      const bottomLeft = (bottom * buffer.width + left) * 4;
+      const bottomRight = (bottom * buffer.width + right) * 4;
+      const target = (targetY * width + targetX) * 4;
+      for (let channel = 0; channel < 4; channel += 1) {
+        const topValue =
+          buffer.data[topLeft + channel]! * (1 - weightX) +
+          buffer.data[topRight + channel]! * weightX;
+        const bottomValue =
+          buffer.data[bottomLeft + channel]! * (1 - weightX) +
+          buffer.data[bottomRight + channel]! * weightX;
+        output[target + channel] =
+          topValue * (1 - weightY) + bottomValue * weightY;
+      }
+    }
+    if ((targetY + 1) % 16 === 0) {
+      await yieldToEventLoop();
+    }
+  }
+  return { data: output, width, height };
+}
+
+async function resizeInvisibleWatermarkPixelsNearestAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  width: number,
+  height: number
+): Promise<InvisibleWatermarkPixelBuffer> {
+  const output = new Uint8ClampedArray(width * height * 4);
+  for (let targetY = 0; targetY < height; targetY += 1) {
+    const sourceY = Math.min(
+      buffer.height - 1,
+      Math.floor(((targetY + 0.5) * buffer.height) / height)
+    );
+    for (let targetX = 0; targetX < width; targetX += 1) {
+      const sourceX = Math.min(
+        buffer.width - 1,
+        Math.floor(((targetX + 0.5) * buffer.width) / width)
+      );
+      const source = (sourceY * buffer.width + sourceX) * 4;
+      const target = (targetY * width + targetX) * 4;
+      output[target] = buffer.data[source]!;
+      output[target + 1] = buffer.data[source + 1]!;
+      output[target + 2] = buffer.data[source + 2]!;
+      output[target + 3] = buffer.data[source + 3]!;
+    }
+    if ((targetY + 1) % 32 === 0) {
+      await yieldToEventLoop();
+    }
+  }
+  return { data: output, width, height };
+}
+
+function emptyDetectionResult(): InvisibleWatermarkDetectionResult {
   return {
     detected: false,
     confidence: 0,
     algorithm: INVISIBLE_WATERMARK_ALGORITHM,
   };
+}
+
+export function detectInvisibleWatermarkPixels(
+  buffer: InvisibleWatermarkPixelBuffer,
+  options: Pick<DetectInvisibleWatermarkOptions, 'key' | 'strength' | 'search'>
+): InvisibleWatermarkDetectionResult {
+  validatePixelBuffer(buffer);
+  const context = createDetectionContext(options);
+  const search = validateSearch(options.search);
+  const scales =
+    search === 'robust'
+      ? ([1, ...INVISIBLE_WATERMARK_RESIZE_SCALES] as const)
+      : ([1] as const);
+  for (const scale of scales) {
+    const target = scale === 1 ? null : resizeTarget(buffer, scale);
+    if (scale !== 1 && !target) continue;
+    const candidateBuffer = target
+      ? scale < 1
+        ? resizeInvisibleWatermarkPixelsNearest(
+            buffer,
+            target.width,
+            target.height
+          )
+        : resizeInvisibleWatermarkPixels(buffer, target.width, target.height)
+      : buffer;
+    const candidate = target
+      ? detectResizedCandidate(candidateBuffer, context, scale)
+      : detectAtScale(candidateBuffer, context, 'fast', scale);
+    if (candidate) return toPublicDetectionResult(candidate);
+  }
+  if (search === 'robust') {
+    const candidate = detectAtScale(buffer, context, 'robust');
+    if (candidate) return toPublicDetectionResult(candidate);
+  }
+  return emptyDetectionResult();
+}
+
+export async function detectInvisibleWatermarkPixelsAsync(
+  buffer: InvisibleWatermarkPixelBuffer,
+  options: Pick<DetectInvisibleWatermarkOptions, 'key' | 'strength' | 'search'>
+): Promise<InvisibleWatermarkDetectionResult> {
+  validatePixelBuffer(buffer);
+  const context = createDetectionContext(options);
+  const search = validateSearch(options.search);
+  const scales =
+    search === 'robust'
+      ? ([1, ...INVISIBLE_WATERMARK_RESIZE_SCALES] as const)
+      : ([1] as const);
+  for (const scale of scales) {
+    const target = scale === 1 ? null : resizeTarget(buffer, scale);
+    if (scale !== 1 && !target) continue;
+    const candidateBuffer = target
+      ? scale < 1
+        ? await resizeInvisibleWatermarkPixelsNearestAsync(
+            buffer,
+            target.width,
+            target.height
+          )
+        : await resizeInvisibleWatermarkPixelsAsync(
+            buffer,
+            target.width,
+            target.height
+          )
+      : buffer;
+    const candidate = target
+      ? await detectResizedCandidateAsync(candidateBuffer, context, scale)
+      : await detectAtScaleAsync(candidateBuffer, context, 'fast', scale);
+    if (candidate) return toPublicDetectionResult(candidate);
+  }
+  if (search === 'robust') {
+    const candidate = await detectAtScaleAsync(buffer, context, 'robust');
+    if (candidate) return toPublicDetectionResult(candidate);
+  }
+  return emptyDetectionResult();
 }

--- a/src/marker.native.ts
+++ b/src/marker.native.ts
@@ -26,8 +26,21 @@ import type {
   EmbedInvisibleWatermarkOptions,
   InvisibleWatermarkDetectionResult,
 } from './invisible-watermark';
+import { runWatermarkBatch } from './batch';
+import type { WatermarkBatchOptions, WatermarkBatchResult } from './batch';
+import {
+  embedInvisibleWithCredentials,
+  verifyContentCredentials,
+} from './content-credentials';
+import type {
+  ContentCredentialsVerificationResult,
+  EmbedInvisibleWithCredentialsOptions,
+  EmbedInvisibleWithCredentialsResult,
+  VerifyContentCredentialsOptions,
+} from './content-credentials';
 import {
   INVISIBLE_WATERMARK_ALGORITHM,
+  INVISIBLE_WATERMARK_RESIZE_SCALES,
   validateDetectInvisibleOptions,
   validateEmbedInvisibleOptions,
 } from './invisible-watermark';
@@ -53,6 +66,57 @@ function getImageMarker(): Spec {
 
 /** Native iOS and Android implementation of the public Marker API. */
 class Marker {
+  /** Embed a locator first, then ask the supplied adapter to sign the result. */
+  static embedInvisibleWithCredentials(
+    options: EmbedInvisibleWithCredentialsOptions
+  ): Promise<EmbedInvisibleWithCredentialsResult> {
+    return embedInvisibleWithCredentials(
+      (watermark) => Marker.embedInvisible(watermark),
+      options
+    );
+  }
+
+  /** Verify Content Credentials through an application-supplied adapter. */
+  static verifyContentCredentials(
+    options: VerifyContentCredentialsOptions
+  ): Promise<ContentCredentialsVerificationResult> {
+    return verifyContentCredentials(options);
+  }
+
+  /** Embed authenticated locators into many images while preserving input order. */
+  static embedInvisibleMany(
+    inputs: readonly EmbedInvisibleWatermarkOptions[],
+    options?: WatermarkBatchOptions<string>
+  ): Promise<Array<WatermarkBatchResult<string>>> {
+    const snapshots = Array.isArray(inputs)
+      ? inputs.map((input) => ({ ...input, image: { ...input?.image } }))
+      : inputs;
+    return runWatermarkBatch(
+      snapshots,
+      (input) => Marker.embedInvisible(input),
+      options,
+      1,
+      'embedInvisibleMany'
+    );
+  }
+
+  /** Detect authenticated locators in many images while preserving input order. */
+  static detectInvisibleMany(
+    inputs: readonly DetectInvisibleWatermarkOptions[],
+    options?: WatermarkBatchOptions<InvisibleWatermarkDetectionResult>
+  ): Promise<Array<WatermarkBatchResult<InvisibleWatermarkDetectionResult>>> {
+    const snapshots = Array.isArray(inputs)
+      ? inputs.map((input) => ({ ...input, image: { ...input?.image } }))
+      : inputs;
+    return runWatermarkBatch(
+      snapshots,
+      (input) => Marker.detectInvisible(input),
+      options,
+      1,
+      'detectInvisibleMany'
+    );
+  }
+
   /**
    * Embed a short, authenticated locator into the final image pixels.
    *
@@ -84,19 +148,40 @@ class Marker {
         'Native invisible watermark detector returned invalid JSON.'
       );
     }
+    const detection = result as {
+      detected?: unknown;
+      payload?: unknown;
+      confidence?: unknown;
+      bitErrorRate?: unknown;
+      algorithm?: unknown;
+      scale?: unknown;
+    };
     if (
       !result ||
       typeof result !== 'object' ||
-      typeof (result as { detected?: unknown }).detected !== 'boolean' ||
-      typeof (result as { confidence?: unknown }).confidence !== 'number' ||
-      (result as { algorithm?: unknown }).algorithm !==
-        INVISIBLE_WATERMARK_ALGORITHM
+      typeof detection.detected !== 'boolean' ||
+      typeof detection.confidence !== 'number' ||
+      !Number.isFinite(detection.confidence) ||
+      detection.confidence < 0 ||
+      detection.confidence > 1 ||
+      detection.algorithm !== INVISIBLE_WATERMARK_ALGORITHM ||
+      (detection.detected && typeof detection.payload !== 'string') ||
+      (detection.bitErrorRate !== undefined &&
+        (typeof detection.bitErrorRate !== 'number' ||
+          !Number.isFinite(detection.bitErrorRate) ||
+          detection.bitErrorRate < 0 ||
+          detection.bitErrorRate > 1)) ||
+      (detection.scale !== undefined &&
+        (typeof detection.scale !== 'number' ||
+          !INVISIBLE_WATERMARK_RESIZE_SCALES.includes(
+            detection.scale as (typeof INVISIBLE_WATERMARK_RESIZE_SCALES)[number]
+          )))
     ) {
       throw new Error(
         'Native invisible watermark detector returned invalid data.'
       );
     }
-    return result as InvisibleWatermarkDetectionResult;
+    return detection as InvisibleWatermarkDetectionResult;
   }
 
   /** Save ordered layers and output settings for reuse across one or many images. */

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -10,6 +10,17 @@ import type {
   WatermarkLayout,
 } from './index';
 import { validateMarkOptions } from './validate';
+import { runWatermarkBatch } from './batch';
+import type { WatermarkBatchOptions, WatermarkBatchResult } from './batch';
+
+export type {
+  WatermarkBatchAbortedResult,
+  WatermarkBatchFulfilledResult,
+  WatermarkBatchOptions,
+  WatermarkBatchProgress,
+  WatermarkBatchRejectedResult,
+  WatermarkBatchResult,
+} from './batch';
 
 export const WATERMARK_RECIPE_SCHEMA_VERSION = 1 as const;
 
@@ -77,46 +88,6 @@ export interface WatermarkRecipeInput {
   filename?: string;
   /** Values substituted into text templates and used by layer conditions. */
   variables?: Readonly<Record<string, WatermarkRecipeVariable>>;
-}
-
-export interface WatermarkBatchFulfilledResult<Result> {
-  status: 'fulfilled';
-  value: Result;
-}
-
-export interface WatermarkBatchRejectedResult {
-  status: 'rejected';
-  reason: unknown;
-}
-
-export interface WatermarkBatchAbortedResult {
-  status: 'aborted';
-  reason: Error;
-}
-
-export type WatermarkBatchResult<Result> =
-  | WatermarkBatchFulfilledResult<Result>
-  | WatermarkBatchRejectedResult
-  | WatermarkBatchAbortedResult;
-
-export interface WatermarkBatchProgress<Result> {
-  total: number;
-  settled: number;
-  succeeded: number;
-  failed: number;
-  aborted: number;
-  /** Index of the item that produced this progress update. */
-  index: number;
-  result: WatermarkBatchResult<Result>;
-}
-
-export interface WatermarkBatchOptions<Result> {
-  /** Requested worker count. Web is capped at 4 and native targets at 1. */
-  concurrency?: number;
-  /** Stops new items from starting. Already-running items are allowed to finish. */
-  signal?: AbortSignal;
-  /** Called once when each item is fulfilled, rejected, or skipped after abort. */
-  onProgress?: (progress: WatermarkBatchProgress<Result>) => void;
 }
 
 export interface WatermarkRecipe<Result = string> {
@@ -514,14 +485,6 @@ function validateUniqueFilenames(
   });
 }
 
-function abortResult<Result>(): WatermarkBatchResult<Result> {
-  const reason = new Error(
-    'Batch item was not started because the operation was aborted.'
-  );
-  reason.name = 'AbortError';
-  return { status: 'aborted', reason };
-}
-
 export function createWatermarkRecipe<Result>(
   options: WatermarkRecipeOptions,
   renderer: RecipeRenderer<Result>,
@@ -561,93 +524,15 @@ export function createWatermarkRecipe<Result>(
       if (!Array.isArray(inputs)) {
         throw new Error('applyMany inputs must be an array.');
       }
-      const requestedConcurrency = batchOptions.concurrency ?? 1;
-      if (
-        !Number.isFinite(requestedConcurrency) ||
-        !Number.isInteger(requestedConcurrency) ||
-        requestedConcurrency <= 0
-      ) {
-        throw new Error('concurrency must be a positive finite integer.');
-      }
-
       const queuedInputs = inputs.map(snapshotInput);
       validateUniqueFilenames(queuedInputs, recipe.saveFormat);
-      if (queuedInputs.length === 0) {
-        return [];
-      }
-
-      const concurrency = Math.min(
-        requestedConcurrency,
+      return runWatermarkBatch(
+        queuedInputs,
+        applySnapshot,
+        batchOptions,
         maximumConcurrency,
-        queuedInputs.length
+        'applyMany'
       );
-      const results: Array<WatermarkBatchResult<Result> | undefined> =
-        new Array(queuedInputs.length);
-      let cursor = 0;
-      let settled = 0;
-      let succeeded = 0;
-      let failed = 0;
-      let aborted = 0;
-
-      const report = (
-        index: number,
-        result: WatermarkBatchResult<Result>
-      ): void => {
-        settled += 1;
-        if (result.status === 'fulfilled') succeeded += 1;
-        else if (result.status === 'rejected') failed += 1;
-        else aborted += 1;
-        try {
-          batchOptions.onProgress?.({
-            total: queuedInputs.length,
-            settled,
-            succeeded,
-            failed,
-            aborted,
-            index,
-            result,
-          });
-        } catch {
-          // Progress observers must not interrupt the batch or change results.
-        }
-      };
-
-      const worker = async (): Promise<void> => {
-        while (!batchOptions.signal?.aborted) {
-          const index = cursor;
-          cursor += 1;
-          if (index >= queuedInputs.length) {
-            return;
-          }
-          const input = queuedInputs[index];
-          if (!input) {
-            return;
-          }
-          let result: WatermarkBatchResult<Result>;
-          try {
-            result = {
-              status: 'fulfilled',
-              value: await applySnapshot(input, index),
-            };
-          } catch (reason) {
-            result = { status: 'rejected', reason };
-          }
-          results[index] = result;
-          report(index, result);
-        }
-      };
-
-      await Promise.all(Array.from({ length: concurrency }, worker));
-
-      for (let index = 0; index < queuedInputs.length; index += 1) {
-        if (!results[index]) {
-          const result = abortResult<Result>();
-          results[index] = result;
-          report(index, result);
-        }
-      }
-
-      return results as Array<WatermarkBatchResult<Result>>;
     },
   };
 }

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -27,8 +27,20 @@ import type {
   EmbedInvisibleWatermarkOptions,
   InvisibleWatermarkDetectionResult,
 } from '../invisible-watermark';
+import { runWatermarkBatch } from '../batch';
+import type { WatermarkBatchOptions, WatermarkBatchResult } from '../batch';
 import {
-  detectInvisibleWatermarkPixels,
+  embedInvisibleWithCredentials,
+  verifyContentCredentials,
+} from '../content-credentials';
+import type {
+  ContentCredentialsVerificationResult,
+  EmbedInvisibleWithCredentialsOptions,
+  EmbedInvisibleWithCredentialsResult,
+  VerifyContentCredentialsOptions,
+} from '../content-credentials';
+import {
+  detectInvisibleWatermarkPixelsAsync,
   embedInvisibleWatermarkPixels,
   validateDetectInvisibleOptions,
   validateEmbedInvisibleOptions,
@@ -138,6 +150,57 @@ function createMarkLayers(options: MarkOptions): WebRenderLayer[] {
  * 2D implementation, which only touches DOM globals when a method is called.
  */
 class Marker {
+  /** Embed a locator first, then ask the supplied adapter to sign the result. */
+  static embedInvisibleWithCredentials(
+    options: EmbedInvisibleWithCredentialsOptions
+  ): Promise<EmbedInvisibleWithCredentialsResult> {
+    return embedInvisibleWithCredentials(
+      (watermark) => Marker.embedInvisible(watermark),
+      options
+    );
+  }
+
+  /** Verify Content Credentials through an application-supplied adapter. */
+  static verifyContentCredentials(
+    options: VerifyContentCredentialsOptions
+  ): Promise<ContentCredentialsVerificationResult> {
+    return verifyContentCredentials(options);
+  }
+
+  /** Embed authenticated locators into many images while preserving input order. */
+  static embedInvisibleMany(
+    inputs: readonly EmbedInvisibleWatermarkOptions[],
+    options?: WatermarkBatchOptions<string>
+  ): Promise<Array<WatermarkBatchResult<string>>> {
+    const snapshots = Array.isArray(inputs)
+      ? inputs.map((input) => ({ ...input, image: { ...input?.image } }))
+      : inputs;
+    return runWatermarkBatch(
+      snapshots,
+      (input) => Marker.embedInvisible(input),
+      options,
+      4,
+      'embedInvisibleMany'
+    );
+  }
+
+  /** Detect authenticated locators in many images while preserving input order. */
+  static detectInvisibleMany(
+    inputs: readonly DetectInvisibleWatermarkOptions[],
+    options?: WatermarkBatchOptions<InvisibleWatermarkDetectionResult>
+  ): Promise<Array<WatermarkBatchResult<InvisibleWatermarkDetectionResult>>> {
+    const snapshots = Array.isArray(inputs)
+      ? inputs.map((input) => ({ ...input, image: { ...input?.image } }))
+      : inputs;
+    return runWatermarkBatch(
+      snapshots,
+      (input) => Marker.detectInvisible(input),
+      options,
+      4,
+      'detectInvisibleMany'
+    );
+  }
+
   /**
    * Embed a short, authenticated locator into the final image pixels.
    *
@@ -173,7 +236,7 @@ class Marker {
       maxSize: options.maxSize,
     });
     const imageData = readImageData(canvas);
-    return detectInvisibleWatermarkPixels(
+    return detectInvisibleWatermarkPixelsAsync(
       { data: imageData.data, width: canvas.width, height: canvas.height },
       options
     );

--- a/website/scripts/smoke-playground.mjs
+++ b/website/scripts/smoke-playground.mjs
@@ -227,6 +227,13 @@ async function assertInvisibleTrace(page, playground) {
       .querySelector('[data-invisible-status]')
       ?.textContent?.includes('Verified: asset-42')
   );
+  await playground
+    .getByText('Compose signed Content Credentials', { exact: true })
+    .click();
+  assert.match(
+    (await playground.locator('.invisible-code').last().textContent()) ?? '',
+    /embedInvisibleWithCredentials/
+  );
 }
 
 async function assertBatchRecipe(page, playground) {
@@ -299,7 +306,7 @@ async function assertLayoutControlsAndCode(page, playground) {
   const preview = playground.locator('[data-preview]');
 
   assert.equal(await playground.locator('[data-example]').count(), 8);
-  assert.equal(await playground.locator('.capability-index li').count(), 10);
+  assert.equal(await playground.locator('.capability-index li').count(), 11);
   assert(
     await textSingle.isVisible(),
     'Text layout switch should be visible without opening advanced controls.'
@@ -629,8 +636,8 @@ async function assertCustomSelects(playground) {
   const customSelects = playground.locator('[data-custom-select]');
   assert.equal(
     await customSelects.count(),
-    6,
-    'Playground should render six custom selectors.'
+    7,
+    'Playground should render seven custom selectors.'
   );
   for (const select of await playground.locator('select').all()) {
     assert.equal(

--- a/website/src/components/CustomSelect.astro
+++ b/website/src/components/CustomSelect.astro
@@ -13,7 +13,8 @@ interface Props {
     | 'text-blend'
     | 'image-blend'
     | 'format'
-    | 'invisible-strength';
+    | 'invisible-strength'
+    | 'invisible-transform';
   options: Option[];
   value: string;
 }

--- a/website/src/components/ImageMarkerPlayground.astro
+++ b/website/src/components/ImageMarkerPlayground.astro
@@ -29,6 +29,7 @@ const strings = isZh
         '位置与旋转',
         '变量与条件 Recipe',
         '隐形追踪水印',
+        'Content Credentials 适配器',
         'PNG、JPEG 与 Web Blob',
       ],
       webBadge: '实时预览',
@@ -61,7 +62,7 @@ const strings = isZh
         { id: 'opacity', title: '半透明文字', meta: '整个文字图层 40%', version: 'v1.8' },
         { id: 'blend', title: '自然融合', meta: 'Screen 文字 + Multiply Logo', version: 'v1.9' },
         { id: 'batch', title: '个性化批量 Recipe', meta: '文件名变量、进度与 Blob', version: 'v1.9' },
-        { id: 'invisible', title: '隐形追踪', meta: '嵌入短 ID 并验证', version: 'v1.10' },
+        { id: 'invisible', title: '隐形追踪', meta: '批量写入，并验证轻度缩放', version: 'v1.11' },
       ],
       textLayer: '文字设置',
       text: '文字内容',
@@ -127,7 +128,7 @@ const strings = isZh
       batchFailed: '批量处理失败',
       batchResults: '处理结果',
       downloadResult: '保存',
-      invisibleEyebrow: 'v1.10 · 隐形追踪水印 Beta',
+      invisibleEyebrow: 'v1.11 · 批量隐形追踪',
       invisibleTitle: '画面看不出变化，也能找回短 ID。',
       invisibleDescription:
         '把短 locator 写入图片像素，再用相同密钥验证。适合素材分发追踪；它不是 DRM，也不能证明图片从未被修改。',
@@ -135,6 +136,8 @@ const strings = isZh
       invisibleKey: '演示密钥',
       invisibleStrength: '强度',
       invisibleStrengths: ['轻微', '均衡', '耐压缩'],
+      invisibleTransform: '验证哪种图片？',
+      invisibleTransforms: ['原始结果', '缩小到 0.9×', '放大到 1.1×'],
       invisibleEmbed: '嵌入并预览',
       invisibleDetect: '验证当前结果',
       invisibleReady: '等待嵌入',
@@ -145,6 +148,11 @@ const strings = isZh
       invisibleNotDetected: '未找到可验证的追踪 ID',
       invisibleWarning:
         '页面中的密钥公开可见，只能用于演示。生产环境请使用随机 locator，并在可信服务端或受控客户端中管理密钥。',
+      invisibleBatchCode: '批量分发代码',
+      invisibleCredentialsCode: '组合签名内容凭证',
+      invisibleCredentialsNote:
+        '此处只展示工作流，不会把图片发送到本站服务。签名必须交给你自己的可信服务端。',
+      invisibleCredentialsLink: '查看 C2PA 服务示例',
       differencesTitle: 'Web 与原生输出有什么不同？',
       differences: [
         ['保存结果', 'Web 返回可直接预览和保存的图片地址；iOS 和 Android 返回临时文件路径。'],
@@ -182,6 +190,7 @@ const strings = isZh
         'Position and rotation',
         'Variable and conditional Recipe',
         'Invisible trace watermark',
+        'Content Credentials adapter',
         'PNG, JPEG, and Web Blob',
       ],
       webBadge: 'Live preview',
@@ -214,7 +223,7 @@ const strings = isZh
         { id: 'opacity', title: 'Translucent text', meta: 'Whole text layer at 40%', version: 'v1.8' },
         { id: 'blend', title: 'Natural compositing', meta: 'Screen text + Multiply logo', version: 'v1.9' },
         { id: 'batch', title: 'Personalized batch Recipe', meta: 'Filename variables, progress, and Blob', version: 'v1.9' },
-        { id: 'invisible', title: 'Invisible trace', meta: 'Embed and verify a short ID', version: 'v1.10' },
+        { id: 'invisible', title: 'Invisible trace', meta: 'Batch locators and verify light resizing', version: 'v1.11' },
       ],
       textLayer: 'Text settings',
       text: 'Watermark text',
@@ -280,7 +289,7 @@ const strings = isZh
       batchFailed: 'Batch failed',
       batchResults: 'Batch results',
       downloadResult: 'Save',
-      invisibleEyebrow: 'v1.10 · Invisible trace watermark Beta',
+      invisibleEyebrow: 'v1.11 · Batched invisible traces',
       invisibleTitle: 'Keep the image clean. Recover a short ID later.',
       invisibleDescription:
         'Write a short locator into the pixels, then authenticate it with the same key. Use it for distribution tracing—not as DRM or proof that an image was never edited.',
@@ -288,6 +297,8 @@ const strings = isZh
       invisibleKey: 'Demo key',
       invisibleStrength: 'Strength',
       invisibleStrengths: ['Subtle', 'Balanced', 'Compression resistant'],
+      invisibleTransform: 'Which image should be verified?',
+      invisibleTransforms: ['Original result', 'Resize to 0.9×', 'Resize to 1.1×'],
       invisibleEmbed: 'Embed and preview',
       invisibleDetect: 'Verify current result',
       invisibleReady: 'Waiting to embed',
@@ -298,6 +309,11 @@ const strings = isZh
       invisibleNotDetected: 'No authenticated trace ID found',
       invisibleWarning:
         'This page exposes its demo key, so do not copy it into production. Use random locators and manage keys on a trusted server or controlled client.',
+      invisibleBatchCode: 'Batch distribution code',
+      invisibleCredentialsCode: 'Compose signed Content Credentials',
+      invisibleCredentialsNote:
+        'This is a workflow example only. The playground never sends images to a signing service; use your own trusted server.',
+      invisibleCredentialsLink: 'Open the C2PA service example',
       differencesTitle: 'How does Web output differ from native?',
       differences: [
         ['Saved result', 'Web returns an image URL you can preview or save. iOS and Android return a temporary file path.'],
@@ -334,6 +350,10 @@ const blendModes = [
 const invisibleStrengths = ['subtle', 'balanced', 'robust'].map((value, index) => ({
   value,
   label: strings.invisibleStrengths[index]!,
+}));
+const invisibleTransforms = ['1', '0.9', '1.1'].map((value, index) => ({
+  value,
+  label: strings.invisibleTransforms[index]!,
 }));
 ---
 
@@ -787,6 +807,13 @@ const invisibleStrengths = ['subtle', 'balanced', 'robust'].map((value, index) =
         options={invisibleStrengths}
         value="robust"
       />
+      <CustomSelect
+        id={`${idPrefix}-invisible-transform`}
+        label={strings.invisibleTransform}
+        name="invisible-transform"
+        options={invisibleTransforms}
+        value="1"
+      />
     </div>
     <div class="invisible-actions">
       <button class="primary-button" type="button" data-invisible-embed>
@@ -797,6 +824,43 @@ const invisibleStrengths = ['subtle', 'balanced', 'robust'].map((value, index) =
       </button>
     </div>
     <p class="invisible-warning">{strings.invisibleWarning}</p>
+    <details class="invisible-code">
+      <summary>{strings.invisibleBatchCode}</summary>
+      <pre><code>{`const embedded = await Marker.embedInvisibleMany(
+  recipients.map((recipient) => ({
+    image: { src: source },
+    payload: recipient.locator,
+    key,
+    strength: 'robust',
+  })),
+  { concurrency: 4, signal, onProgress }
+);
+
+const verified = await Marker.detectInvisibleMany(
+  embedded.flatMap((result) =>
+    result.status === 'fulfilled'
+      ? [{ image: { src: result.value }, key, search: 'robust' }]
+      : []
+  )
+);`}</code></pre>
+    </details>
+    <details class="invisible-code">
+      <summary>{strings.invisibleCredentialsCode}</summary>
+      <p>{strings.invisibleCredentialsNote}</p>
+      <pre><code>{`const signed = await Marker.embedInvisibleWithCredentials({
+  watermark: { image: { src: source }, payload: locator, key },
+  claim: { title: 'distribution-copy.png', format: 'image/png' },
+  adapter: yourServerAdapter,
+});
+
+const credentials = await Marker.verifyContentCredentials({
+  image: signed.signedImage,
+  adapter: yourServerAdapter,
+});`}</code></pre>
+      <a href="https://github.com/JimmyDaddy/react-native-image-marker/tree/master/examples/c2pa-service">
+        {strings.invisibleCredentialsLink}
+      </a>
+    </details>
   </section>
 
   <section
@@ -1059,6 +1123,7 @@ const invisibleStrengths = ['subtle', 'balanced', 'robust'].map((value, index) =
     const invisiblePayload = asElement<HTMLInputElement>(root, '[data-invisible-payload]');
     const invisibleKey = asElement<HTMLInputElement>(root, '[data-invisible-key]');
     const invisibleStrength = asElement<HTMLSelectElement>(root, '[data-invisible-strength]');
+    const invisibleTransform = asElement<HTMLSelectElement>(root, '[data-invisible-transform]');
     const invisibleStatus = asElement<HTMLElement>(root, '[data-invisible-status]');
     const invisibleEmbed = asElement<HTMLButtonElement>(root, '[data-invisible-embed]');
     const invisibleDetect = asElement<HTMLButtonElement>(root, '[data-invisible-detect]');
@@ -1566,6 +1631,20 @@ ${layers}
       download.removeAttribute('aria-disabled');
     };
 
+    const resizeInvisibleResult = async (result: string, scale: number) => {
+      if (scale === 1) return result;
+      const image = new Image();
+      image.src = result;
+      await image.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(image.naturalWidth * scale);
+      canvas.height = Math.round(image.naturalHeight * scale);
+      const context = canvas.getContext('2d');
+      if (!context) throw new Error('Canvas 2D is unavailable.');
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      return canvas.toDataURL('image/png');
+    };
+
     const runInvisibleEmbed = async () => {
       setInvisibleBusy(true);
       invisibleStatus.textContent = root.dataset.invisibleEmbedding ?? '';
@@ -1601,14 +1680,19 @@ ${layers}
       invisibleStatus.textContent = root.dataset.invisibleDetecting ?? '';
       try {
         const sdk = await sdkPromise;
+        const inspected = await resizeInvisibleResult(
+          invisibleResult,
+          Number(invisibleTransform.value)
+        );
+        await showInvisibleResult(inspected);
         const detection = await sdk.default.detectInvisible({
-          image: { src: invisibleResult },
+          image: { src: inspected },
           key: invisibleKey.value,
           strength: invisibleStrength.value as 'subtle' | 'balanced' | 'robust',
-          search: 'fast',
+          search: 'robust',
         });
         invisibleStatus.textContent = detection.detected
-          ? `${root.dataset.invisibleDetected ?? ''}: ${detection.payload ?? '—'} · ${Math.round(detection.confidence * 100)}%`
+          ? `${root.dataset.invisibleDetected ?? ''}: ${detection.payload ?? '—'} · ${Math.round(detection.confidence * 100)}%${detection.scale ? ` · ${detection.scale}×` : ''}`
           : root.dataset.invisibleNotDetected ?? '';
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1873,7 +1957,7 @@ ${layers}
     window.addEventListener('pagehide', clearBatchResults, { once: true });
     invisibleEmbed.addEventListener('click', () => void runInvisibleEmbed());
     invisibleDetect.addEventListener('click', () => void runInvisibleDetect());
-    [invisiblePayload, invisibleKey, invisibleStrength].forEach((input) => {
+    [invisiblePayload, invisibleKey, invisibleStrength, invisibleTransform].forEach((input) => {
       input.addEventListener('input', () => {
         invisibleStatus.textContent = root.dataset.invisibleReady ?? '';
       });
@@ -1903,6 +1987,7 @@ ${layers}
       invisiblePayload.value = 'asset-42';
       invisibleKey.value = 'example-only-key-2026';
       setCustomSelectValue(invisibleStrength, 'robust');
+      setCustomSelectValue(invisibleTransform, '1');
       invisibleStatus.textContent = root.dataset.invisibleReady ?? '';
       updateStrokeOptions();
       scheduleRender();
@@ -2886,7 +2971,7 @@ ${layers}
 
   .invisible-controls {
     display: grid;
-    grid-template-columns: minmax(10rem, 1fr) minmax(12rem, 1.2fr) minmax(9rem, 0.72fr);
+    grid-template-columns: minmax(10rem, 1fr) minmax(12rem, 1.2fr) repeat(2, minmax(9rem, 0.72fr));
     align-items: end;
     gap: 0.75rem;
     margin-top: 1rem;
@@ -2910,6 +2995,44 @@ ${layers}
     color: var(--marker-muted);
     font-size: 0.66rem;
     line-height: 1.5;
+  }
+
+  .invisible-code {
+    margin-top: 0.75rem;
+    color: var(--marker-muted);
+    font-size: 0.68rem;
+  }
+
+  .invisible-code summary {
+    width: fit-content;
+    cursor: pointer;
+    color: var(--marker-blue);
+    font-weight: 700;
+  }
+
+  .invisible-code pre {
+    overflow-x: auto;
+    margin: 0.6rem 0 0;
+    padding: 0.85rem;
+    border: 1px solid var(--playground-line);
+    border-radius: 0.7rem;
+    background: var(--playground-panel-raised);
+    color: var(--marker-ink);
+    font-size: 0.66rem;
+    line-height: 1.55;
+  }
+
+  .invisible-code p {
+    margin: 0.7rem 0;
+    color: var(--marker-muted);
+    font-weight: 500;
+    line-height: 1.55;
+  }
+
+  .invisible-code a {
+    display: inline-flex;
+    margin-top: 0.65rem;
+    color: var(--marker-blue);
   }
 
   .batch-panel {
@@ -3179,6 +3302,12 @@ ${layers}
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+  }
+
+  @media (max-width: 72rem) {
+    .invisible-controls {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 
   @media (max-width: 52rem) {

--- a/website/src/content/docs/api.md
+++ b/website/src/content/docs/api.md
@@ -13,6 +13,8 @@ The API reference is generated from the public TypeScript declarations on every 
 - [`Marker.createRecipe`](/api/classes/marker/#createrecipe) creates reusable batch workflows.
 - [`Marker.embedInvisible`](/api/classes/marker/#embedinvisible) writes an authenticated short trace ID into image pixels.
 - [`Marker.detectInvisible`](/api/classes/marker/#detectinvisible) recovers and verifies an invisible trace ID.
+- `Marker.embedInvisibleMany` and `Marker.detectInvisibleMany` run ordered, independently reported trace batches.
+- `Marker.embedInvisibleWithCredentials` and `Marker.verifyContentCredentials` compose the pixel locator with an application-supplied signing adapter.
 
 ## Start with the main option types
 

--- a/website/src/content/docs/compatibility.md
+++ b/website/src/content/docs/compatibility.md
@@ -20,7 +20,7 @@ Image Marker supports **iOS 13 or newer**, **Android API 24 or newer**, and mode
 
 ## Web behavior
 
-On Web, you can call `Marker.markText`, `Marker.markImage`, `Marker.mark`, `Marker.embedInvisible`, and `Marker.detectInvisible` with the same options used in React Native. The package selects its browser code automatically and does not load `NativeModules`.
+On Web, visible marking, recipes, invisible trace batches, robust detection, and Content Credentials adapters use the same public API as React Native. The package selects its browser code automatically and does not load `NativeModules`.
 
 Web calls resolve with a `data:image/...` URL for every output format. Sources may be a URL string, `{ uri }`, data URL, `Blob`, `File`, or an already-loaded browser image. Numeric React Native asset IDs must first be converted to a URL—for example with `Asset.fromModule(asset).uri` from `expo-asset` in an Expo Web app.
 
@@ -48,7 +48,7 @@ CI keeps three explicit lines instead of treating one example build as proof for
 | React Native 0.73                            | The checked-in bare example builds with the legacy bridge and New Architecture on Android; iOS verifies the legacy bridge.                                                                               |
 | React Native 0.86                            | A clean New Architecture Android app installs the packed library and compiles its generated TurboModule binding.                                                                                         |
 | Expo SDK 57 / React Native 0.86 / React 19.2 | The Expo example type-checks, exports native and Web bundles, generates a development-build project, and compiles on Android.                                                                            |
-| Chromium, Firefox, and WebKit                | The Web example verifies JPG/PNG, `Blob`/`File`, CORS errors, rotation crop, alpha, large-image limits, tolerant pixel differences, invisible-watermark recompression, and a six-image detection corpus. |
+| Chromium, Firefox, and WebKit                | The Web example verifies JPG/PNG, `Blob`/`File`, CORS errors, rotation crop, alpha, large-image limits, tolerant pixel differences, invisible-watermark recompression, responsive batch detection, and 0.9×–1.1× recovery across a six-image corpus. |
 
 ## Verify the architecture path
 

--- a/website/src/content/docs/guides/invisible-watermarks.mdx
+++ b/website/src/content/docs/guides/invisible-watermarks.mdx
@@ -32,7 +32,7 @@ const result = await Marker.detectInvisible({
   image: { src: { uri: output } },
   key,
   strength: 'robust',
-  search: 'fast',
+  search: 'robust',
 });
 
 if (result.detected) {
@@ -41,6 +41,46 @@ if (result.detected) {
 ```
 
 Native embedding returns a cache-file path; Web returns a data URL. Detection does not create a file.
+
+When `robust` recovers a resized image, `result.scale` reports the successful
+0.9, 0.95, 1.05, or 1.1 hypothesis. It is a detector estimate, not a precise
+measurement.
+
+## Distribute recipient-specific copies in a batch
+
+Each item can use a different locator, key, image, and output format. Results
+stay in input order; one failure does not reject the whole batch. Web runs at
+most four items concurrently, while native platforms stay serial to limit peak
+memory.
+
+```ts
+const controller = new AbortController();
+const outputs = await Marker.embedInvisibleMany(
+  recipients.map((recipient) => ({
+    image: { src: source },
+    payload: recipient.locator,
+    key,
+    strength: 'robust',
+    saveFormat: ImageFormat.png,
+  })),
+  {
+    concurrency: 4,
+    signal: controller.signal,
+    onProgress: ({ settled, total }) => console.log(`${settled}/${total}`),
+  }
+);
+
+const verified = await Marker.detectInvisibleMany(
+  outputs.flatMap((output) =>
+    output.status === 'fulfilled'
+      ? [{ image: { src: output.value }, key, search: 'robust' }]
+      : []
+  )
+);
+```
+
+Calling `abort()` stops new items from starting. Work already handed to Canvas
+or a native decoder finishes normally and still reports its result.
 
 ## Payload and key rules
 
@@ -59,15 +99,58 @@ Browser scripts and extensions can read any key available to page JavaScript. Fo
 | `balanced`         | General photos and direct output                 | Default visual/robustness balance |
 | `robust`           | The image will be recompressed                   | Strongest pixel change            |
 | `search: 'fast'`   | Original dimensions and block grid are preserved | Low detection cost                |
-| `search: 'robust'` | A limited crop may have shifted the grid         | Much more CPU work                |
+| `search: 'robust'` | Limited crop or 0.9×–1.1× resizing is expected   | More CPU and temporary memory     |
 
-Use the same `strength` for embedding and detection. `robust` search can recover some crops, but it does not currently compensate for resizing.
+Use the same `strength` for embedding and detection. On Web, detection yields
+to the event loop while collecting blocks and searching candidates, so the page
+can keep responding even though the total CPU work remains substantial.
 
 ## What survives
 
-The project test matrix covers direct PNG output, JPEG re-encoding at quality 90/75/60, mild brightness and contrast changes, wrong-key rejection, and limited crop recovery. Real images and encoders vary, so validate your own delivery pipeline before relying on a threshold.
+The project test matrix covers direct PNG output, JPEG re-encoding at quality
+90/75/60, mild brightness and contrast changes, wrong-key rejection, limited
+crop recovery, and 0.9/0.95/1.05/1.1 resizing across six photographs in
+Chromium, Firefox, and WebKit. JPEG 75 re-encoding followed by light resizing
+is covered too.
+Real images and encoders vary, so validate your own delivery pipeline before
+relying on a threshold.
 
-Heavy blur, aggressive resizing, large crops, painting over the image, generative edits, screenshots, and print-camera workflows are not stable guarantees in v1.10. Detection returns `detected: false` instead of throwing when no authenticated frame is found.
+Heavy blur, resizing outside the tested range, large crops, painting over the
+image, generative edits, screenshots, and print-camera workflows are not stable
+guarantees. Detection returns `detected: false` instead of throwing when no
+authenticated frame is found.
+
+## Add a signed Content Credential
+
+The core package defines a small `ContentCredentialsAdapter` rather than
+shipping a C2PA runtime or signing key. The composition order is fixed: embed
+the locator first, then sign the resulting pixels.
+
+```ts
+const signed = await Marker.embedInvisibleWithCredentials({
+  watermark: {
+    image: { src: source },
+    payload: 'asset-42',
+    key,
+    strength: 'robust',
+    saveFormat: ImageFormat.png,
+  },
+  claim: { title: 'asset-42.png', format: 'image/png' },
+  adapter,
+});
+
+const credentials = await Marker.verifyContentCredentials({
+  image: signed.signedImage,
+  adapter,
+});
+```
+
+The independent [Node.js C2PA service example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/examples/c2pa-service)
+uses the official `@contentauth/c2pa-node` package and injects its certificate
+and private key from the environment. `dct-qim-v1` is not registered in the
+C2PA Soft Binding Algorithm List, so the example uses a normal hard binding and
+a private assertion containing only the algorithm and `SHA-256(locator)`. It
+does not claim `c2pa.watermarked` or standard soft-binding compatibility.
 
 ## Recommended server workflow
 
@@ -77,4 +160,6 @@ Heavy blur, aggressive resizing, large crops, painting over the image, generativ
 4. Keep the original and marked output long enough to investigate false negatives.
 5. When detecting, apply your own confidence policy and confirm the locator against the server record.
 
-The frame format and threat model are specified in [RFC 0003 on GitHub](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0003-v1.10-invisible-trace-watermarks.md).
+The frame format and threat model are specified in [RFC 0003](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0003-v1.10-invisible-trace-watermarks.md).
+Batching, resize recovery, responsive Web detection, and Content Credentials
+integration are specified in [RFC 0004](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0004-v1.11-durable-provenance-workflows.md).

--- a/website/src/content/docs/zh-cn/api.md
+++ b/website/src/content/docs/zh-cn/api.md
@@ -13,6 +13,8 @@ description: React Native Image Marker 的自动生成 API 参考文档。
 - [`Marker.createRecipe`](/zh-cn/api/classes/marker/#createrecipe) 创建可复用的批量处理流程。
 - [`Marker.embedInvisible`](/zh-cn/api/classes/marker/#embedinvisible) 将经过认证的短追踪 ID 写入图片像素。
 - [`Marker.detectInvisible`](/zh-cn/api/classes/marker/#detectinvisible) 恢复并验证隐形追踪 ID。
+- `Marker.embedInvisibleMany` 与 `Marker.detectInvisibleMany` 执行同序、逐项报告的追踪批次。
+- `Marker.embedInvisibleWithCredentials` 与 `Marker.verifyContentCredentials` 把像素 locator 和应用提供的签名适配器组合起来。
 
 ## 从主要选项类型开始
 

--- a/website/src/content/docs/zh-cn/compatibility.md
+++ b/website/src/content/docs/zh-cn/compatibility.md
@@ -20,7 +20,7 @@ Image Marker 支持 **iOS 13 或更高版本**、**Android API 24 或更高版�
 
 ## Web 端行为
 
-在浏览器中可以调用 `Marker.markText`、`Marker.markImage`、`Marker.mark`、`Marker.embedInvisible` 和 `Marker.detectInvisible`，参数与 React Native 相同。软件包会自动选择浏览器代码，不会加载 `NativeModules`。
+在浏览器中，可见水印、Recipe、隐形追踪批次、robust 检测与 Content Credentials 适配器都使用和 React Native 相同的公共 API。软件包会自动选择浏览器代码，不会加载 `NativeModules`。
 
 Web 上的所有输出格式都会返回 `data:image/...` URL。图片来源可以是 URL 字符串、`{ uri }`、data URL、`Blob`、`File` 或已加载的浏览器图片。React Native 的数字资源 ID 需要先转换成 URL；例如 Expo Web 应用可使用 `expo-asset` 的 `Asset.fromModule(asset).uri`。
 
@@ -48,7 +48,7 @@ CI 保留三条明确的测试线，不用单个示例构建笼统代表所有�
 | React Native 0.73                            | 仓库内的裸 React Native 示例在 Android 分别构建旧架构与新架构，iOS 验证旧架构。                                              |
 | React Native 0.86                            | 新建一个启用新架构的 Android 应用，安装打包后的库，并编译生成的 TurboModule 绑定。                                           |
 | Expo SDK 57 / React Native 0.86 / React 19.2 | Expo 示例执行类型检查、导出原生与 Web bundle、生成开发构建工程，并完成 Android 编译。                                        |
-| Chromium、Firefox、WebKit                    | Web 示例验证 JPG/PNG、`Blob`/`File`、CORS 错误、旋转裁剪、透明度、大图限制、带容差的像素差异、隐形水印重编码和六图检测语料。 |
+| Chromium、Firefox、WebKit                    | Web 示例验证 JPG/PNG、`Blob`/`File`、CORS 错误、旋转裁剪、透明度、大图限制、带容差的像素差异、隐形水印重编码、响应式批量检测，以及六图语料的 0.9×–1.1× 恢复。 |
 
 ## 验证架构路径
 

--- a/website/src/content/docs/zh-cn/guides/invisible-watermarks.mdx
+++ b/website/src/content/docs/zh-cn/guides/invisible-watermarks.mdx
@@ -31,7 +31,7 @@ const result = await Marker.detectInvisible({
   image: { src: { uri: output } },
   key,
   strength: 'robust',
-  search: 'fast',
+  search: 'robust',
 });
 
 if (result.detected) {
@@ -40,6 +40,42 @@ if (result.detected) {
 ```
 
 原生端嵌入后返回缓存文件路径，Web 返回 data URL；检测不会创建新文件。
+
+当 `robust` 从缩放图片中恢复水印时，`result.scale` 会返回命中的
+0.9、0.95、1.05 或 1.1 假设。它是检测器采用的比例，不是精密测量结果。
+
+## 批量生成不同接收方的副本
+
+每一项都可以使用不同的 locator、密钥、图片和输出格式。结果始终与输入同序；
+单项失败不会让整个批次 reject。Web 最多并发 4 项，原生端保持串行以控制峰值内存。
+
+```ts
+const controller = new AbortController();
+const outputs = await Marker.embedInvisibleMany(
+  recipients.map((recipient) => ({
+    image: { src: source },
+    payload: recipient.locator,
+    key,
+    strength: 'robust',
+    saveFormat: ImageFormat.png,
+  })),
+  {
+    concurrency: 4,
+    signal: controller.signal,
+    onProgress: ({ settled, total }) => console.log(`${settled}/${total}`),
+  }
+);
+
+const verified = await Marker.detectInvisibleMany(
+  outputs.flatMap((output) =>
+    output.status === 'fulfilled'
+      ? [{ image: { src: output.value }, key, search: 'robust' }]
+      : []
+  )
+);
+```
+
+调用 `abort()` 只会阻止尚未开始的项目。已经交给 Canvas 或原生解码器的任务会正常完成并报告结果。
 
 ## Payload 与密钥规则
 
@@ -58,15 +94,43 @@ if (result.detected) {
 | `balanced`         | 普通照片与直接输出      | 默认的视觉与抗性平衡 |
 | `robust`           | 图片还会被压缩          | 像素改动最强         |
 | `search: 'fast'`   | 尺寸和 8×8 网格没有变化 | 检测开销低           |
-| `search: 'robust'` | 有限裁剪可能移动了网格  | CPU 开销明显更高     |
+| `search: 'robust'` | 可能有有限裁剪或 0.9×–1.1× 缩放 | CPU 与临时内存开销更高 |
 
-嵌入和检测必须使用相同 `strength`。`robust` 搜索可以恢复部分裁剪，但 v1.10 暂时不能补偿缩放。
+嵌入和检测必须使用相同 `strength`。Web 检测会在采集像素块和搜索候选时主动让出事件循环；总 CPU 工作量仍然存在，但页面不会被一个持续很久的同步任务完全卡住。
 
 ## 能承受哪些变化
 
-项目测试矩阵覆盖直接 PNG、JPEG 质量 90/75/60 重新编码、轻微亮度与对比度变化、错误密钥拒绝和有限裁剪恢复。图片内容与编码器会影响结果，因此正式使用前仍要用自己的分发链路做验证。
+项目测试矩阵覆盖直接 PNG、JPEG 质量 90/75/60 重新编码、轻微亮度与对比度变化、错误密钥拒绝、有限裁剪，以及六张照片在 Chromium、Firefox、WebKit 中的 0.9/0.95/1.05/1.1 缩放恢复；先经 JPEG 75 重编码再轻度缩放的链路也在门禁内。图片内容与编码器会影响结果，因此正式使用前仍要用自己的分发链路做验证。
 
-强模糊、明显缩放、大面积裁剪、涂抹、生成式修改、截图以及打印后拍照，不属于 v1.10 的稳定承诺。没有找到可验证水印时，检测器返回 `detected: false`，不会把它当作异常。
+强模糊、超出测试范围的缩放、大面积裁剪、涂抹、生成式修改、截图以及打印后拍照，不属于稳定承诺。没有找到可验证水印时，检测器返回 `detected: false`，不会把它当作异常。
+
+## 再加一份签名 Content Credential
+
+基础包只定义轻量的 `ContentCredentialsAdapter`，不会把 C2PA 运行时或签名私钥塞进 React Native 包。组合顺序固定为：先写入 locator，再对最终像素签名。
+
+```ts
+const signed = await Marker.embedInvisibleWithCredentials({
+  watermark: {
+    image: { src: source },
+    payload: 'asset-42',
+    key,
+    strength: 'robust',
+    saveFormat: ImageFormat.png,
+  },
+  claim: { title: 'asset-42.png', format: 'image/png' },
+  adapter,
+});
+
+const credentials = await Marker.verifyContentCredentials({
+  image: signed.signedImage,
+  adapter,
+});
+```
+
+独立的 [Node.js C2PA 服务示例](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/examples/c2pa-service)
+使用官方 `@contentauth/c2pa-node`，证书与私钥只能从运行环境注入。`dct-qim-v1`
+尚未进入 C2PA Soft Binding Algorithm List，因此示例使用普通 hard binding，并在私有
+assertion 中只保存算法名与 `SHA-256(locator)`；不会声明 `c2pa.watermarked`，也不会冒充标准 soft binding。
 
 ## 推荐的服务端流程
 
@@ -76,4 +140,4 @@ if (result.detected) {
 4. 保留原图和水印输出，以便调查漏检。
 5. 检测时应用自己的置信度策略，并到服务端确认 locator 记录。
 
-帧格式与威胁模型见 GitHub 中的 [RFC 0003](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0003-v1.10-invisible-trace-watermarks.md)。
+帧格式与威胁模型见 [RFC 0003](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0003-v1.10-invisible-trace-watermarks.md)。批量处理、缩放恢复、Web 响应性与 Content Credentials 集成见 [RFC 0004](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/docs/rfcs/0004-v1.11-durable-provenance-workflows.md)。


### PR DESCRIPTION
## Summary

- add ordered, cancellable batch embed and detection APIs across native and Web
- recover authenticated invisible locators after tested 0.9x to 1.1x resizing and keep Web robust detection responsive
- add a dependency-free Content Credentials adapter plus an isolated Node 22 C2PA service example
- update React Native and Expo examples, bilingual docs, Playground, and CI coverage

## Verification

- 103 Jest tests with 87.25% line coverage; Web line coverage 87.81%
- Chromium, Firefox, and WebKit smoke: 30 resize and JPEG recovery cases across six photos
- Android InvisibleWatermarkTest and iOS simulator resize-recovery test
- root, React Native example, Expo example, and C2PA typechecks
- lint, package build, release-notes check, docs build, Playground smoke, and package dry-run
- C2PA service tests and production audit with 0 vulnerabilities

## RFC

- docs/rfcs/0004-v1.11-durable-provenance-workflows.md