### PR TITLE
chore: release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.11.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.10.1...v1.11.0) (2026-07-19)
+
+### Features
+
+* **watermark:** add durable provenance workflows ([7887786](https://github.com/JimmyDaddy/react-native-image-marker/commit/7887786f21d131f685b8a2053028e30b6235b746))
+
 ## [1.10.1](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.10.0...v1.10.1) (2026-07-19)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "packageManager": "npm@10.9.4",
   "description": "Add visible and invisible image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
## Summary

- bump react-native-image-marker to 1.11.0
- add generated changelog entry for durable provenance workflows

## Validation

- npm run check:release-notes
- npm run typecheck
- npm test -- --runInBand (103 tests)
- npm run prepack
- npm pack --dry-run
- git diff --check