### PR TITLE
chore: release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.12.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.11.0...v1.12.0) (2026-07-20)
+
+### Features
+
+* add server trace runtime and worker detection ([b9976c5](https://github.com/JimmyDaddy/react-native-image-marker/commit/b9976c52d2a9e99ae478259e4a7b2f77aa926f7a))
+* **docs:** reorganize playground workflows ([f26524c](https://github.com/JimmyDaddy/react-native-image-marker/commit/f26524c56d0d1359cc9853188853511b16c38032))
+
+### Bug Fixes
+
+* isolate worker types from native consumers ([d79379d](https://github.com/JimmyDaddy/react-native-image-marker/commit/d79379d4660cdac12f35e0f8281fbff85e158e63))
+
 ## [1.11.0](https://github.com/JimmyDaddy/react-native-image-marker/compare/v1.10.1...v1.11.0) (2026-07-19)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "packageManager": "npm@10.9.4",
   "description": "Add visible and invisible image watermarks in React Native and React Native Web",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
## Summary

- bump react-native-image-marker to 1.12.0
- add generated changelog entries for the server trace runtime, Worker detection, and Playground workflows

## Validation

- npm run check:release-notes
- npm run typecheck
- npm run typecheck:example
- npm run typecheck:expo-example
- npm run lint
- npm test -- --runInBand (116 tests)
- npm run prepack
- npm pack --ignore-scripts --dry-run (241 files)
- npm audit --omit=dev --audit-level=moderate (0 vulnerabilities)
- git diff --check