### PR TITLE
fix(website): sync playground workflow code examples

### DIFF
--- a/website/scripts/smoke-playground.mjs
+++ b/website/scripts/smoke-playground.mjs
@@ -95,6 +95,7 @@ try {
   await assertLayoutControlsAndCode(page, playground);
   await assertInvisibleTrace(page, playground);
   await assertBatchRecipe(page, playground);
+  await selectWorkspaceTab(playground, 'visible');
 
   const code = await playground.locator('[data-web-code]').textContent();
   assert.match(
@@ -106,7 +107,6 @@ try {
     /fileToDataUrl|backgroundFile|logoFile|setMarkedImageUri/
   );
 
-  await selectWorkspaceTab(playground, 'visible');
   await playground.locator('[data-live-preview]').uncheck();
   await selectCustomOptionWithKeyboard(playground, 'format', 'jpg');
   await playground.getByText('Changes ready. Update the preview.').waitFor();
@@ -245,6 +245,20 @@ async function assertVisibleLogo(playground) {
 
 async function assertInvisibleTrace(page, playground) {
   await selectWorkspaceTab(playground, 'invisible');
+  assert.equal(
+    await playground.locator('[data-code-title]').textContent(),
+    'Invisible trace code'
+  );
+  let webCode = await playground.locator('[data-web-code]').textContent();
+  let nativeCode = await playground.locator('[data-native-code]').textContent();
+  assert.match(webCode ?? '', /Marker\.embedInvisible/);
+  assert.match(webCode ?? '', /Marker\.detectInvisible/);
+  assert.match(webCode ?? '', /payload: "asset-42"/);
+  assert.match(webCode ?? '', /strength: 'robust'/);
+  assert.match(webCode ?? '', /worker: \{/);
+  assert.match(webCode ?? '', /invisible-watermark\.js/);
+  assert.match(nativeCode ?? '', /image: \{ src: \{ uri: marked \} \}/);
+  assert.doesNotMatch(nativeCode ?? '', /worker: \{/);
   await playground.locator('[data-invisible-embed]').click();
   await page.waitForFunction(() =>
     document
@@ -269,10 +283,31 @@ async function assertInvisibleTrace(page, playground) {
     (await playground.locator('.invisible-code').last().textContent()) ?? '',
     /embedInvisibleWithCredentials/
   );
+
+  await playground.locator('[data-invisible-payload]').fill('asset-84');
+  webCode = await playground.locator('[data-web-code]').textContent();
+  nativeCode = await playground.locator('[data-native-code]').textContent();
+  assert.match(webCode ?? '', /payload: "asset-84"/);
+  assert.match(nativeCode ?? '', /payload: "asset-84"/);
 }
 
 async function assertBatchRecipe(page, playground) {
   await selectWorkspaceTab(playground, 'batch');
+  assert.equal(
+    await playground.locator('[data-code-title]').textContent(),
+    'Batch processing code'
+  );
+  const webCode = await playground.locator('[data-web-code]').textContent();
+  const nativeCode = await playground.locator('[data-native-code]').textContent();
+  assert.match(webCode ?? '', /Marker\.createRecipe/);
+  assert.match(webCode ?? '', /resultType: 'blob'/);
+  assert.match(webCode ?? '', /recipe\.applyMany/);
+  assert.match(webCode ?? '', /\{\{sourceName\}\}/);
+  assert.match(webCode ?? '', /concurrency: 4/);
+  assert.match(nativeCode ?? '', /Marker\.createRecipe/);
+  assert.match(nativeCode ?? '', /recipe\.applyMany/);
+  assert.match(nativeCode ?? '', /concurrency: 1/);
+  assert.doesNotMatch(nativeCode ?? '', /resultType: 'blob'/);
   const batchFiles = playground.locator('[data-batch-files]');
   const fixtureNames = [
     'playground-background.jpg',
@@ -449,6 +484,10 @@ async function selectWorkspaceTab(playground, workspace) {
   await tab.click();
   assert.equal(await tab.getAttribute('aria-selected'), 'true');
   assert.equal(await panel.getAttribute('hidden'), null);
+  assert.equal(
+    await playground.locator('.code-panel').getAttribute('data-code-workspace'),
+    workspace
+  );
   assert(
     await panel.isVisible(),
     `${workspace} workspace panel should be visible.`

--- a/website/src/components/ImageMarkerPlayground.astro
+++ b/website/src/components/ImageMarkerPlayground.astro
@@ -104,6 +104,11 @@ const strings = isZh
       autoPreviewHint: '关闭后可一次调整多项，再点击更新预览。',
       codeTitle: '把这个效果用到项目里',
       codeDescription: '下面的代码已经包含当前设置，可直接复制。',
+      batchCodeTitle: '批量处理代码',
+      batchCodeDescription: '使用当前水印设置创建 Recipe，并按顺序处理多张图片。',
+      invisibleCodeTitle: '隐形追踪代码',
+      invisibleCodeDescription:
+        '下面展示写入和验证流程；批量分发与内容凭证示例仍可在上方展开。',
       webTab: 'Web',
       nativeTab: 'React Native',
       copyCode: '复制代码',
@@ -276,6 +281,12 @@ const strings = isZh
       autoPreviewHint: 'Turn this off to make several changes before rendering again.',
       codeTitle: 'Use this result in your project',
       codeDescription: 'The code below already includes your current settings.',
+      batchCodeTitle: 'Batch processing code',
+      batchCodeDescription:
+        'Create a Recipe from the current watermark settings and process images in order.',
+      invisibleCodeTitle: 'Invisible trace code',
+      invisibleCodeDescription:
+        'Embed and verify a trace below. Batch distribution and Content Credentials examples remain expandable above.',
       webTab: 'Web',
       nativeTab: 'React Native',
       copyCode: 'Copy code',
@@ -423,6 +434,12 @@ const invisibleExecutors = ['main', 'worker'].map((value, index) => ({
   data-invisible-cancelled={strings.invisibleCancelled}
   data-invisible-detected={strings.invisibleDetected}
   data-invisible-not-detected={strings.invisibleNotDetected}
+  data-visible-code-title={strings.codeTitle}
+  data-visible-code-description={strings.codeDescription}
+  data-batch-code-title={strings.batchCodeTitle}
+  data-batch-code-description={strings.batchCodeDescription}
+  data-invisible-code-title={strings.invisibleCodeTitle}
+  data-invisible-code-description={strings.invisibleCodeDescription}
 >
   <header class="playground-heading">
     <div>
@@ -1016,8 +1033,8 @@ const credentials = await Marker.verifyContentCredentials({
   <section class="code-panel" aria-labelledby={`${idPrefix}-code-title`}>
     <div class="code-heading">
       <div>
-        <h3 id={`${idPrefix}-code-title`}>{strings.codeTitle}</h3>
-        <p>{strings.codeDescription}</p>
+        <h3 id={`${idPrefix}-code-title`} data-code-title>{strings.codeTitle}</h3>
+        <p data-code-description>{strings.codeDescription}</p>
       </div>
       <button class="quiet-button" type="button" data-copy-code>{strings.copyCode}</button>
     </div>
@@ -1215,6 +1232,9 @@ const credentials = await Marker.verifyContentCredentials({
     const imageStagger = asElement<HTMLInputElement>(root, '[data-image-stagger]');
     const format = asElement<HTMLSelectElement>(root, '[data-format]');
     const quality = asElement<HTMLInputElement>(root, '[data-quality]');
+    const codePanel = asElement<HTMLElement>(root, '.code-panel');
+    const codeTitle = asElement<HTMLElement>(root, '[data-code-title]');
+    const codeDescription = asElement<HTMLElement>(root, '[data-code-description]');
     const webCode = asElement<HTMLElement>(root, '[data-web-code]');
     const nativeCode = asElement<HTMLElement>(root, '[data-native-code]');
     const batchFiles = asElement<HTMLInputElement>(root, '[data-batch-files]');
@@ -1336,8 +1356,8 @@ const credentials = await Marker.verifyContentCredentials({
     stagger: ${stagger.checked},
   }`;
 
-    const textLayerCode = () => `{
-  text: ${JSON.stringify(textInput.value || 'IMAGE MARKER')},
+    const textLayerCode = (text = textInput.value || 'IMAGE MARKER') => `{
+  text: ${JSON.stringify(text)},
   alpha: ${Number(textOpacity.value)},
   blendMode: '${textBlend.value}',
   ${state.textLayout === 'tile'
@@ -1370,7 +1390,7 @@ const credentials = await Marker.verifyContentCredentials({
     const indentCode = (value: string, spaces: number) =>
       value.replace(/^/gm, ' '.repeat(spaces));
 
-    const createCode = (target: CodeTarget): string => {
+    const createVisibleCode = (target: CodeTarget): string => {
       const method = methodName();
       const background = target === 'web' ? "'/photo.jpg'" : "require('./photo.jpg')";
       const outputFormat = format.value === 'jpg' ? 'jpg' : 'png';
@@ -1404,7 +1424,163 @@ ${layers}
 }`;
     };
 
+    const recipeLayersCode = (target: CodeTarget): string => {
+      const textCode = textLayerCode(
+        `${textInput.value || 'IMAGE MARKER'} · {{sourceName}}`
+      ).replace(/^\{/, "{\n  type: 'text',");
+      const imageCode = imageLayerCode(target).replace(
+        /^\{/,
+        "{\n  type: 'image',"
+      );
+      const layers = state.mode === 'text'
+        ? [textCode]
+        : state.mode === 'image'
+          ? [imageCode]
+          : [imageCode, textCode];
+      return `[\n${layers.map((layer) => indentCode(layer, 4)).join(',\n')}\n  ]`;
+    };
+
+    const createBatchCode = (target: CodeTarget): string => {
+      const outputFormat = format.value === 'jpg' ? 'jpg' : 'png';
+      const recipeOptions = `{
+  schemaVersion: 1,
+  watermarks: ${recipeLayersCode(target)},
+  saveFormat: ImageFormat.${outputFormat},
+  quality: ${Number(quality.value)},
+}`;
+
+      if (target === 'web') {
+        return `import Marker, { ImageFormat, Position } from 'react-native-image-marker';
+
+const recipe = Marker.createRecipe(
+${indentCode(recipeOptions, 2)},
+  { resultType: 'blob' }
+);
+
+export async function markFiles(
+  files: readonly File[],
+  signal?: AbortSignal
+) {
+  const results = await recipe.applyMany(
+    files.map((file) => ({
+      backgroundImage: { src: file },
+      filename: file.name.replace(/\\.[^.]+$/, ''),
+      variables: { sourceName: file.name },
+    })),
+    {
+      concurrency: 4,
+      signal,
+      onProgress: ({ settled, total }) => console.log(\`${'${settled}'}/${'${total}'}\`),
+    }
+  );
+  // Fulfilled values are Blobs. Create and revoke object URLs in your UI.
+  return results;
+}`;
+      }
+
+      return `import type { ImageSourcePropType } from 'react-native';
+import Marker, { ImageFormat, Position } from 'react-native-image-marker';
+
+const recipe = Marker.createRecipe(${recipeOptions});
+
+export async function markPhotos(
+  photos: ReadonlyArray<ImageSourcePropType>,
+  signal?: AbortSignal
+) {
+  return recipe.applyMany(
+    photos.map((src, index) => ({
+      backgroundImage: { src },
+      filename: \`marked-${'${index + 1}'}\`,
+      variables: { sourceName: \`photo-${'${index + 1}'}\` },
+    })),
+    {
+      concurrency: 1,
+      signal,
+      onProgress: ({ settled, total }) => console.log(\`${'${settled}'}/${'${total}'}\`),
+    }
+  );
+}`;
+    };
+
+    const createInvisibleCode = (target: CodeTarget): string => {
+      const strength = invisibleStrength.value;
+      const payload = JSON.stringify(invisiblePayload.value || 'asset-42');
+      const transformNote = invisibleTransform.value === '1'
+        ? ''
+        : `  // The playground also checks ${invisibleTransform.value}× resize tolerance.\n`;
+
+      if (target === 'web') {
+        const worker = invisibleExecutor.value === 'worker'
+          ? `
+    worker: {
+      scriptUrl: '/worker/invisible-watermark.js',
+      signal,
+    },`
+          : '';
+        const signalParameter = invisibleExecutor.value === 'worker'
+          ? ', signal?: AbortSignal'
+          : '';
+        return `import Marker, { ImageFormat } from 'react-native-image-marker';
+
+export async function embedAndVerifyTrace(file: File${signalParameter}) {
+  // Keep production keys in trusted storage, not in browser source code.
+  const key = await loadTraceKeyFromTrustedStorage();
+  const marked = await Marker.embedInvisible({
+    image: { src: file },
+    payload: ${payload},
+    key,
+    strength: '${strength}',
+    saveFormat: ImageFormat.png,
+    filename: 'traced-photo',
+  });
+
+${transformNote}  const detection = await Marker.detectInvisible({
+    image: { src: marked },
+    key,
+    strength: '${strength}',
+    search: 'robust',${worker}
+  });
+
+  return { marked, detection };
+}`;
+      }
+
+      return `import type { ImageSourcePropType } from 'react-native';
+import Marker, { ImageFormat } from 'react-native-image-marker';
+
+export async function embedAndVerifyTrace(source: ImageSourcePropType) {
+  const key = await loadTraceKeyFromTrustedStorage();
+  const marked = await Marker.embedInvisible({
+    image: { src: source },
+    payload: ${payload},
+    key,
+    strength: '${strength}',
+    saveFormat: ImageFormat.png,
+    filename: 'traced-photo',
+  });
+
+${transformNote}  const detection = await Marker.detectInvisible({
+    image: { src: { uri: marked } },
+    key,
+    strength: '${strength}',
+    search: 'robust',
+  });
+
+  return { marked, detection };
+}`;
+    };
+
     const updateCode = () => {
+      const createCode = state.workspace === 'batch'
+        ? createBatchCode
+        : state.workspace === 'invisible'
+          ? createInvisibleCode
+          : createVisibleCode;
+      const titleKey = `${state.workspace}CodeTitle` as keyof DOMStringMap;
+      const descriptionKey = `${state.workspace}CodeDescription` as keyof DOMStringMap;
+      codePanel.dataset.codeWorkspace = state.workspace;
+      codeTitle.textContent = root.dataset[titleKey] ?? '';
+      codeDescription.textContent = root.dataset[descriptionKey] ?? '';
       webCode.textContent = createCode('web');
       nativeCode.textContent = createCode('native');
     };
@@ -1451,6 +1627,7 @@ ${layers}
         panel.hidden = !selected;
         if (selected && focusPanel) panel.focus({ preventScroll: true });
       });
+      updateCode();
     };
     updateWorkspace(state.workspace);
 
@@ -2127,9 +2304,12 @@ ${layers}
     invisibleDetect.addEventListener('click', () => void runInvisibleDetect());
     invisibleCancel.addEventListener('click', () => invisibleController?.abort());
     [invisiblePayload, invisibleKey, invisibleStrength, invisibleTransform, invisibleExecutor].forEach((input) => {
-      input.addEventListener('input', () => {
+      const handleInvisibleOptionChange = () => {
         invisibleStatus.textContent = root.dataset.invisibleReady ?? '';
-      });
+        updateCode();
+      };
+      input.addEventListener('input', handleInvisibleOptionChange);
+      input.addEventListener('change', handleInvisibleOptionChange);
     });
 
     asElement<HTMLButtonElement>(root, '[data-default-background]').addEventListener('click', () => {


### PR DESCRIPTION
## What changed

- switch the Playground code panel with the active visible, batch, or invisible workflow
- generate Web and React Native examples for Recipe batch processing and invisible trace embedding/detection
- keep invisible trace snippets in sync with payload, strength, resize test, and Worker choices
- add browser smoke coverage for workspace-specific titles and generated APIs

## Why

The shared code panel always showed visible-watermark code, even while the batch or invisible workflow was selected. Batch users had no dedicated snippet, and invisible examples were limited to collapsed secondary recipes.

## Impact

Each Playground workflow now exposes copyable code that matches the selected feature and platform. Existing visible-watermark code generation remains unchanged.

## Validation

- `npm --prefix website run check`
- `npm --prefix website run build`
- `npm --prefix website run smoke`
- local browser verification for Chinese batch/invisible workflow switching and the React Native code tab
