### PR TITLE
docs: promote v2 documentation to current

### DIFF
--- a/website/versions.json
+++ b/website/versions.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": 1,
-  "releaseStage": "pre-ga",
-  "current": "v1",
+  "releaseStage": "ga",
+  "current": "v2",
   "versions": [
     {
       "id": "v2",
-      "label": "v2 Preview",
-      "status": "preview",
-      "basePath": "/next/",
+      "label": "v2 Current",
+      "status": "current",
+      "basePath": "/v2/",
       "source": "master",
-      "packageRange": "2.0.0 prerelease"
+      "packageRange": "2.0.x"
     },
     {
       "id": "v1",


### PR DESCRIPTION
## Summary
- switch the version manifest from pre-GA to GA
- publish v2 under `/v2/` as the current documentation
- preserve v1 LTS and the immutable v1.0.0 archive
- keep `/next/` as a compatibility redirect to v2

## Verification
- `npm --prefix website run build`
- three-source v1/v2/archive site assembly
- `node website/scripts/check-versioned-site.mjs --dir website/versioned-dist`
- Core 2.0.0 confirmed as npm `latest` with SLSA provenance before this switch