### PR TITLE
ci(release): bootstrap Editor npm package

### DIFF
--- a/.github/workflows/npm-bootstrap-editor.yml
+++ b/.github/workflows/npm-bootstrap-editor.yml
@@ -1,0 +1,111 @@
+name: Bootstrap Editor npm package
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: npm-bootstrap-editor-v0.0.1
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish and verify Editor 0.0.1
+    if: github.repository == 'JimmyDaddy/react-native-image-marker'
+    runs-on: ubuntu-latest
+    environment: npm-bootstrap
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout the immutable Editor tag
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: editor-v0.0.1
+
+      - name: Verify the release target
+        run: |
+          git fetch origin release/2.0
+          node scripts/verify-release-target.mjs --tag editor-v0.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
+
+      - name: Use the current publishing npm CLI
+        run: npm install --global npm@12.0.1
+
+      - name: Install immutable dependencies
+        run: npm ci
+
+      - name: Test Editor
+        run: npm run test:editor
+
+      - name: Build Core type dependency
+        run: npm run prepack
+
+      - name: Build and inspect Editor package
+        working-directory: packages/editor
+        run: |
+          npm run prepack
+          npm pack --dry-run
+
+      - name: Detect an existing Editor package
+        id: editor
+        run: |
+          if npm view react-native-image-marker-editor@0.0.1 version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Editor 0.0.1 already exists; continuing with immutable verification."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Editor with provenance
+        if: steps.editor.outputs.publish == 'true'
+        working-directory: packages/editor
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "The environment-scoped NPM_BOOTSTRAP_TOKEN is required."
+            exit 1
+          fi
+          npm publish --provenance --access public --tag latest
+
+      - name: Add Core v1 maintenance dist-tags
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "The environment-scoped NPM_BOOTSTRAP_TOKEN is required."
+            exit 1
+          fi
+          npm dist-tag add react-native-image-marker@1.12.0 v1
+          npm dist-tag add react-native-image-marker@1.12.0 lts
+
+      - name: Verify published provenance and dist-tags
+        run: |
+          for _ in $(seq 1 12); do
+            predicate_type="$(npm view react-native-image-marker-editor@0.0.1 dist.attestations.provenance.predicateType 2>/dev/null || true)"
+            if [ "$predicate_type" = "https://slsa.dev/provenance/v1" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ "$predicate_type" != "https://slsa.dev/provenance/v1" ]; then
+            echo "Editor 0.0.1 did not expose provenance metadata in time."
+            exit 1
+          fi
+          test "$(npm view react-native-image-marker dist-tags.v1)" = "1.12.0"
+          test "$(npm view react-native-image-marker dist-tags.lts)" = "1.12.0"
+          test "$(npm view react-native-image-marker@1 version)" = "1.12.0"
+
+      - name: Verify a fresh Editor registry consumer
+        run: >-
+          node scripts/verify-registry-consumer.mjs
+          --package-name react-native-image-marker-editor
+          --version 0.0.1
+          --channel editor


### PR DESCRIPTION
## Summary

- add a one-shot, manually dispatched workflow for the first `react-native-image-marker-editor@0.0.1` publish
- pin the workflow to immutable `editor-v0.0.1` and verify it belongs to protected `release/2.0`
- scope the temporary credential to the `npm-bootstrap` GitHub Environment
- require provenance, registry metadata, dist-tag, and fresh-consumer verification
- add the Core `v1` and `lts` maintenance tags to `1.12.0`

## Security / cleanup

- the workflow cannot publish an arbitrary package or version
- `NPM_BOOTSTRAP_TOKEN` will be created only after merge and removed with the temporary environment immediately after use
- the npm token will be revoked after Editor OIDC trusted publishing is configured

## Validation

- `actionlint .github/workflows/npm-bootstrap-editor.yml`
- `git diff --check`