### PR TITLE
fix(editor): add repository provenance metadata

### DIFF
--- a/.github/workflows/npm-bootstrap-editor.yml
+++ b/.github/workflows/npm-bootstrap-editor.yml
@@ -47,6 +47,14 @@ jobs:
       - name: Build Core type dependency
         run: npm run prepack
 
+      - name: Restore Editor repository metadata for provenance
+        working-directory: packages/editor
+        run: >-
+          npm pkg set
+          repository.type=git
+          repository.url=git+https://github.com/JimmyDaddy/react-native-image-marker.git
+          repository.directory=packages/editor
+
       - name: Build and inspect Editor package
         working-directory: packages/editor
         run: |

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JimmyDaddy/react-native-image-marker.git",
+    "directory": "packages/editor"
+  },
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/module/index.d.ts",


### PR DESCRIPTION
## Summary

- declare the Editor workspace repository and package directory explicitly
- deterministically restore the same metadata while bootstrapping the immutable `editor-v0.0.1` tag
- preserve provenance and avoid moving the already-published Git tag

## Evidence

- npm rejected the unsigned registry write before version creation because the Editor manifest had an empty `repository.url`
- `actionlint .github/workflows/npm-bootstrap-editor.yml`
- Editor: 3 suites / 9 tests passed
- Editor TypeScript build passed
- `npm pack --dry-run --workspace react-native-image-marker-editor` passed