### PR TITLE
fix(editor): declare package repository metadata

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JimmyDaddy/react-native-image-marker.git",
+    "directory": "packages/editor"
+  },
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/module/index.d.ts",


### PR DESCRIPTION
## Summary
- declare the Editor package repository and workspace directory
- keep the protected release/2.0 branch aligned with published npm provenance metadata

## Validation
- npm run test:editor
- npm run build:editor
- npm pack --workspace packages/editor --dry-run --json
- git diff --check