### PR TITLE
fix(release): route v1 maintenance to lts

### DIFF
--- a/scripts/__tests__/release-target.test.mjs
+++ b/scripts/__tests__/release-target.test.mjs
@@ -9,8 +9,8 @@ test('routes a v1 maintenance release to the LTS branch', () => {
     packagePath: '.',
     version: '1.12.1',
     branch: 'release/1.x',
-    npmTag: 'v1',
-    additionalDistTags: ['lts'],
+    npmTag: 'lts',
+    additionalDistTags: [],
     channel: 'core-v1',
   });
 });

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -22,8 +22,8 @@ export function resolveReleaseTarget(tag) {
       packagePath: '.',
       version: v1[1],
       branch: 'release/1.x',
-      npmTag: 'v1',
-      additionalDistTags: ['lts'],
+      npmTag: 'lts',
+      additionalDistTags: [],
       channel: 'core-v1',
     };
   }


### PR DESCRIPTION
## Summary
- publish v1 maintenance releases directly under the valid npm lts dist-tag
- rely on npm's native @1 SemVer selector for the major line
- avoid the invalid v1 dist-tag and remove the redundant post-publish token step for v1

## Validation
- node --test scripts/__tests__/release-target.test.mjs
- node scripts/resolve-release-target.mjs --tag v1.12.1
- actionlint -color
- git diff --check