### PR TITLE
fix(release): route v1 maintenance to lts

### DIFF
--- a/scripts/__tests__/release-target.test.mjs
+++ b/scripts/__tests__/release-target.test.mjs
@@ -9,8 +9,8 @@ test('routes a v1 maintenance release to the LTS branch', () => {
     packagePath: '.',
     version: '1.12.1',
     branch: 'release/1.x',
-    npmTag: 'v1',
-    additionalDistTags: ['lts'],
+    npmTag: 'lts',
+    additionalDistTags: [],
     channel: 'core-v1',
   });
 });

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -22,8 +22,8 @@ export function resolveReleaseTarget(tag) {
       packagePath: '.',
       version: v1[1],
       branch: 'release/1.x',
-      npmTag: 'v1',
-      additionalDistTags: ['lts'],
+      npmTag: 'lts',
+      additionalDistTags: [],
       channel: 'core-v1',
     };
   }


### PR DESCRIPTION
## Summary
- make the protected v1 maintenance line publish directly under npm lts
- preserve npm @1 as the native SemVer selector for latest 1.x
- prevent future v1 bugfix releases from attempting the invalid v1 dist-tag

## Validation
- node --test scripts/__tests__/release-target.test.mjs
- node scripts/resolve-release-target.mjs --tag v1.12.1
- actionlint -color
- git diff --check