### PR TITLE
docs(site): align support policy with v2 GA

### DIFF
--- a/website/src/content/docs/support-policy.md
+++ b/website/src/content/docs/support-policy.md
@@ -1,18 +1,18 @@
 ---
 title: Versions and support
-description: Choose between v1 LTS, the v2 preview, and immutable historical documentation.
+description: Choose between current Core v2, v1 LTS, and immutable historical documentation.
 ---
 
 React Native Image Marker maintains independent documentation and release
-lines so existing v1 applications can keep receiving critical fixes while v2
-is developed.
+lines so Core v2 can evolve while existing v1 applications continue receiving
+critical fixes.
 
 | Version | Status | Documentation | Install |
 | --- | --- | --- | --- |
 | v1 LTS (`1.12.x`) | Current maintenance line | [v1 documentation](/v1/) | `npm install react-native-image-marker@1` |
-| v2 | Preview | [v2 preview](/next/) | Published prereleases use the `next` npm tag |
+| Core v2 (`2.0.x`) | Current release | [v2 documentation](/next/) | `npm install react-native-image-marker@latest` |
 | v1.0.0 | Immutable archive | [v1.0.0 archive](/versions/1.0.0/) | `npm install react-native-image-marker@1.0.0` |
-| Editor `0.0.x` | Experimental | [Editor status](/editor/) | Requires Core `^2.0.0` |
+| Editor `0.0.x` | Experimental | [Editor status](/editor/) | `npm install react-native-image-marker-editor@0.0.1` |
 
 ## v1 LTS commitment
 

--- a/website/src/content/docs/zh-cn/support-policy.md
+++ b/website/src/content/docs/zh-cn/support-policy.md
@@ -1,17 +1,17 @@
 ---
 title: 版本与支持政策
-description: 在 v1 LTS、v2 预览版和不可变历史文档之间进行选择。
+description: 在当前 Core v2、v1 LTS 和不可变历史文档之间进行选择。
 ---
 
 React Native Image Marker 使用彼此独立的发布和文档线路，让现有 v1
-应用在 v2 开发期间仍能继续获得关键修复。
+应用继续获得关键修复，同时允许 Core v2 独立演进。
 
 | 版本 | 状态 | 文档 | 安装方式 |
 | --- | --- | --- | --- |
 | v1 LTS（`1.12.x`） | 当前维护线 | [v1 文档](/v1/) | `npm install react-native-image-marker@1` |
-| v2 | 预览版 | [v2 预览文档](/next/) | 预发布版本使用 npm `next` 标签 |
+| Core v2（`2.0.x`） | 当前正式版本 | [v2 文档](/next/) | `npm install react-native-image-marker@latest` |
 | v1.0.0 | 不可变归档 | [v1.0.0 归档](/versions/1.0.0/) | `npm install react-native-image-marker@1.0.0` |
-| Editor `0.0.x` | 实验性 | [Editor 状态](/editor/) | 依赖 Core `^2.0.0` |
+| Editor `0.0.x` | 实验性 | [Editor 状态](/editor/) | `npm install react-native-image-marker-editor@0.0.1` |
 
 ## v1 LTS 承诺
 


### PR DESCRIPTION
## Summary
- update the protected v1 documentation line to describe Core 2.0 as the current release
- keep the source link compatible with the standalone v1 build; the GA assembler rewrites /next/ to /v2/
- document the published Editor 0.0.1 install command in English and Chinese

## Validation
- DOCS_CHANNEL=v1 DOCS_GIT_REF=release/1.x npm --prefix website run check
- DOCS_CHANNEL=v1 DOCS_GIT_REF=release/1.x npm --prefix website run build
- git diff --check