### PR TITLE
fix(docs): preserve locale across version links

### DIFF
--- a/website/src/components/VersionBanner.astro
+++ b/website/src/components/VersionBanner.astro
@@ -1,17 +1,34 @@
 ---
+import versions from '../../versions.json';
+
 const { banner } = Astro.locals.starlightRoute.entry.data;
-const channel = process.env.DOCS_CHANNEL || 'v1';
+const channel =
+  process.env.DOCS_CHANNEL ||
+  (versions.releaseStage === 'ga' ? 'current' : 'preview');
 const isZh = Astro.url.pathname.includes('/zh-cn/');
+const v2Base =
+  versions.releaseStage === 'ga'
+    ? isZh
+      ? '/zh-cn/'
+      : '/'
+    : isZh
+      ? '/next/zh-cn/'
+      : '/next/';
+const v1Base = isZh ? '/v1/zh-cn/' : '/v1/';
 
 const versionNotice =
   channel === 'preview'
     ? isZh
-      ? '这是 v2 预览文档，API 在正式发布前仍可能调整。查看 <a href="/v1/">v1 LTS 文档</a>。'
-      : 'These are the v2 preview docs. APIs may still change before release. See the <a href="/v1/">v1 LTS docs</a>.'
+      ? `这是 v2 预览文档，API 在正式发布前仍可能调整。查看 <a href="${v1Base}">v1 LTS 文档</a>。`
+      : `These are the v2 preview docs. APIs may still change before release. See the <a href="${v1Base}">v1 LTS docs</a>.`
     : channel === 'v1'
       ? isZh
-        ? 'v1 处于长期维护状态，将继续接收兼容性、安全和严重错误修复。查看 <a href="/next/">v2 预览</a>。'
-        : 'v1 is in long-term maintenance and continues to receive compatibility, security, and critical bug fixes. See the <a href="/next/">v2 preview</a>.'
+        ? `v1 处于长期维护状态，将继续接收兼容性、安全和严重错误修复。查看 <a href="${v2Base}">${versions.releaseStage === 'ga' ? '当前 v2 文档' : 'v2 预览'}</a>。`
+        : `v1 is in long-term maintenance and continues to receive compatibility, security, and critical bug fixes. See the <a href="${v2Base}">${versions.releaseStage === 'ga' ? 'current v2 docs' : 'v2 preview'}</a>.`
+      : channel === 'current'
+        ? isZh
+          ? `这是当前 v2 文档。需要兼容旧接口？查看 <a href="${v1Base}">v1 LTS 文档</a>。`
+          : `These are the current v2 docs. Need the compatible API? See the <a href="${v1Base}">v1 LTS docs</a>.`
       : undefined;
 ---
 

--- a/website/src/components/VersionSelect.astro
+++ b/website/src/components/VersionSelect.astro
@@ -1,28 +1,42 @@
 ---
+import versions from '../../versions.json';
+
 const pathname = Astro.url.pathname;
-const channel = process.env.DOCS_CHANNEL || 'v1';
+const channel =
+  process.env.DOCS_CHANNEL ||
+  (versions.releaseStage === 'ga' ? 'current' : 'preview');
 const selected =
-  channel === 'preview'
+  channel === 'preview' || channel === 'current'
     ? 'v2'
     : channel === 'editor'
       ? 'editor'
       : channel === 'archive'
         ? 'v1.0.0'
         : 'v1';
-const label = pathname.includes('/zh-cn/')
-  ? '文档版本'
-  : 'Documentation version';
+const isZh = pathname.includes('/zh-cn/');
+const label = isZh ? '文档版本' : 'Documentation version';
+const v2Base =
+  channel === 'current'
+    ? isZh
+      ? '/zh-cn/'
+      : '/'
+    : isZh
+      ? '/next/zh-cn/'
+      : '/next/';
+const v1Base = isZh ? '/v1/zh-cn/' : '/v1/';
+const editorBase = isZh ? '/editor/zh-cn/' : '/editor/';
+const v2Label = channel === 'current' ? 'v2 Current' : 'v2 Preview';
 ---
 
 <label class="version-select print:hidden">
   <span class="sr-only">{label}</span>
   <select aria-label={label} data-version-select>
-    <option value="/next/" selected={selected === 'v2'}>v2 Preview</option>
-    <option value="/v1/" selected={selected === 'v1'}>v1 LTS</option>
+    <option value={v2Base} selected={selected === 'v2'}>{v2Label}</option>
+    <option value={v1Base} selected={selected === 'v1'}>v1 LTS</option>
     <option value="/versions/1.0.0/" selected={selected === 'v1.0.0'}>
       v1.0.0 Archive
     </option>
-    <option value="/editor/" selected={selected === 'editor'}>
+    <option value={editorBase} selected={selected === 'editor'}>
       Editor 0.0.x
     </option>
   </select>

--- a/website/src/content/docs/zh-cn/support-policy.md
+++ b/website/src/content/docs/zh-cn/support-policy.md
@@ -9,7 +9,7 @@ React Native Image Marker 使用彼此独立的发布和文档线路，让现有
 | 版本 | 状态 | 文档 | 安装方式 |
 | --- | --- | --- | --- |
 | v1 LTS（`1.12.x`） | 当前维护线 | [v1 文档](/v1/) | `npm install react-native-image-marker@1` |
-| Core v2（`2.0.x`） | 当前正式版本 | [v2 文档](/next/) | `npm install react-native-image-marker@latest` |
+| Core v2（`2.0.x`） | 当前正式版本 | [v2 文档](/next/zh-cn/) | `npm install react-native-image-marker@latest` |
 | v1.0.0 | 不可变归档 | [v1.0.0 归档](/versions/1.0.0/) | `npm install react-native-image-marker@1.0.0` |
 | Editor `0.0.x` | 实验性 | [Editor 状态](/editor/) | `npm install react-native-image-marker-editor@0.0.1` |
 


### PR DESCRIPTION
## Summary
- keep v1, v2, and Editor version destinations in the current locale
- point Chinese v1 support-policy navigation at the Chinese v2 site
- keep release-stage-aware version labels and banners aligned with the v2 root deployment

## Validation
- npm --prefix website run check
- npm --prefix website run build
- npm --prefix website run smoke