### PR TITLE
chore(editor): prepare 0.0.2 release

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -269,17 +269,20 @@ Browser Canvas and native graphics stacks share the API and positioning model bu
 ## Optional interaction editor
 
 The independently versioned
-`react-native-image-marker-editor@0.0.1` package provides Recipe v2 layer
+`react-native-image-marker-editor@0.0.2` package provides Recipe v2 layer
 selection, drag/scale/rotate/reorder, visibility and locking, snapping,
 undo/redo, accessible keyboard controls, preview rendering, and final export.
 It requires Core `^2.0.0` and delegates image processing back to Core.
 
 ```sh
-npm install react-native-image-marker-editor@0.0.1
+npm install react-native-image-marker-editor@0.0.2
 ```
 
 Import `react-native-image-marker-editor/core-adapter` only when the editor
 should invoke Core directly; a custom adapter can render on a server instead.
+See the [Editor integration guide](https://image-marker.corerobin.com/guides/editor/),
+[generated API reference](https://image-marker.corerobin.com/guides/editor/reference/),
+or [open the Editor workflow](https://image-marker.corerobin.com/playground/?workflow=editor#editor-playground).
 
 ## Choose an API
 
@@ -312,11 +315,14 @@ See the full [compatibility guide](https://image-marker.corerobin.com/compatibil
 
 - [简体中文文档](https://image-marker.corerobin.com/zh-cn/)
 - [Installation](https://image-marker.corerobin.com/getting-started/)
+- [What’s new in Core 2](https://image-marker.corerobin.com/whats-new-2/)
 - [Live playground](https://image-marker.corerobin.com/playground/)
 - [Free online image tools](https://image-marker.corerobin.com/tools/)
 - [Guides](https://image-marker.corerobin.com/guides/choose-an-api/)
 - [Visual cookbook](https://image-marker.corerobin.com/cookbook/)
 - [Invisible trace watermarks](https://image-marker.corerobin.com/guides/invisible-watermarks/)
+- [Optional interaction editor](https://image-marker.corerobin.com/guides/editor/)
+- [Editor API reference](https://image-marker.corerobin.com/guides/editor/reference/)
 - [Troubleshooting](https://image-marker.corerobin.com/troubleshooting/)
 - [API reference](https://image-marker.corerobin.com/api/)
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
                 surface === value && styles.surfaceTabTextSelected,
               ]}
             >
-              {value === 'core' ? 'Core lab' : 'Editor 0.0.1'}
+              {value === 'core' ? 'Core lab' : 'Editor 0.0.2'}
             </Text>
           </Pressable>
         ))}

--- a/example/src/EditorExample.tsx
+++ b/example/src/EditorExample.tsx
@@ -141,7 +141,7 @@ export default function EditorExample() {
     >
       <View style={styles.heading}>
         <View>
-          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.1</Text>
+          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.2</Text>
           <Text style={styles.title}>Interactive Recipe v2 editor</Text>
         </View>
         <Text style={styles.subtitle}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16287,7 +16287,7 @@
     },
     "packages/editor": {
       "name": "react-native-image-marker-editor",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "react-native-image-marker": "file:../.."

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.2 (2026-07-28)
+
+- Added canonical package metadata and direct links to the integration guide,
+  generated API reference, and Editor workflow in the browser Playground.
+- Aligned the npm README and site version labels with the current root-hosted
+  Core 2 documentation.
+- Added site-level mobile discovery, categorized Tools placement, and
+  deep-link regression coverage without changing the Editor runtime API.
+
 ## 0.0.1 (2026-07-28)
 
 - Added the headless Recipe v2 controller with stable layer IDs, selection,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -32,7 +32,12 @@ The main entry owns only UI and Recipe state. Import the opt-in `core-adapter`
 entry to render previews or final output through Core, or inject your own
 adapter for a server renderer.
 
-Run the repository's React Native example and choose **Editor 0.0.1**, or use
-the [browser playground](https://image-marker.corerobin.com/next/playground/)
+Run the repository's React Native example and choose **Editor 0.0.2**, or use
+the [browser playground](https://image-marker.corerobin.com/playground/?workflow=editor#editor-playground)
 to exercise drag, scale, rotation, ordering, locks, undo/redo, and a real Core
 render.
+
+Read the [integration guide](https://image-marker.corerobin.com/guides/editor/)
+or browse the
+[generated API reference](https://image-marker.corerobin.com/guides/editor/reference/)
+for controller methods, component props, adapters, state, and export types.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,8 +1,20 @@
 {
   "name": "react-native-image-marker-editor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
+  "homepage": "https://image-marker.corerobin.com/guides/editor/",
+  "bugs": {
+    "url": "https://github.com/JimmyDaddy/react-native-image-marker/issues"
+  },
+  "keywords": [
+    "react-native",
+    "image",
+    "watermark",
+    "editor",
+    "recipe",
+    "layers"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JimmyDaddy/react-native-image-marker.git",
@@ -15,6 +27,7 @@
   "source": "src/index.ts",
   "files": [
     "src",
+    "!src/__tests__",
     "lib",
     "README.md",
     "CHANGELOG.md"

--- a/scripts/verify-package-consumer.mjs
+++ b/scripts/verify-package-consumer.mjs
@@ -1,19 +1,10 @@
 import { execFileSync } from 'node:child_process';
-import {
-  mkdtemp,
-  readFile,
-  rm,
-  symlink,
-  writeFile,
-} from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const repositoryRoot = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '..'
-);
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const consumerDirectory = await mkdtemp(
   join(tmpdir(), 'image-marker-consumer-')
 );
@@ -49,6 +40,9 @@ function pack(packagePath) {
 }
 
 try {
+  const expectedEditorManifest = JSON.parse(
+    await readFile(join(repositoryRoot, 'packages/editor/package.json'), 'utf8')
+  );
   const coreTarball = pack('.');
   const editorTarball = pack('./packages/editor');
   await writeFile(
@@ -98,10 +92,12 @@ try {
     )
   );
   if (
-    editorManifest.version !== '0.0.1' ||
+    editorManifest.version !== expectedEditorManifest.version ||
     editorManifest.peerDependencies?.['react-native-image-marker'] !== '^2.0.0'
   ) {
-    throw new Error('The packed Editor manifest has an invalid version or Core peer range.');
+    throw new Error(
+      'The packed Editor manifest has an invalid version or Core peer range.'
+    );
   }
 
   run('node', [
@@ -114,7 +110,7 @@ try {
       'const { ImageMarkerEditorController } = await import(url);',
       "const editor = new ImageMarkerEditorController({schemaVersion:2,layers:[{id:'title',type:'text',text:'Hello'}],output:{}});",
       "if (editor.exportRecipe().layers[0]?.id !== 'title') process.exit(1);",
-    ].join('')
+    ].join(''),
   ]);
   run('node', [
     '-e',


### PR DESCRIPTION
## Summary

- bump the optional Editor package to 0.0.2
- repair npm README links and add canonical homepage, issue, and keyword metadata
- keep examples and consumer verification aligned with the independently versioned package
- exclude source tests from the published tarball

## Verification

- npm run typecheck
- npm run test:editor
- npm run verify:consumer
- npm pack --dry-run --json ./packages/editor
- Prettier check for all changed files
- pre-commit type and lint hooks