### PR TITLE
fix(editor): align canvas preview and export

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -269,13 +269,13 @@ Browser Canvas and native graphics stacks share the API and positioning model bu
 ## Optional interaction editor
 
 The independently versioned
-`react-native-image-marker-editor@0.0.2` package provides Recipe v2 layer
+`react-native-image-marker-editor@0.0.3` package provides Recipe v2 layer
 selection, drag/scale/rotate/reorder, visibility and locking, snapping,
 undo/redo, accessible keyboard controls, preview rendering, and final export.
 It requires Core `^2.0.0` and delegates image processing back to Core.
 
 ```sh
-npm install react-native-image-marker-editor@0.0.2
+npm install react-native-image-marker-editor@0.0.3
 ```
 
 Import `react-native-image-marker-editor/core-adapter` only when the editor

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
                 surface === value && styles.surfaceTabTextSelected,
               ]}
             >
-              {value === 'core' ? 'Core lab' : 'Editor 0.0.2'}
+              {value === 'core' ? 'Core lab' : 'Editor 0.0.3'}
             </Text>
           </Pressable>
         ))}

--- a/example/src/EditorExample.tsx
+++ b/example/src/EditorExample.tsx
@@ -21,6 +21,7 @@ import { ImageFormat } from 'react-native-image-marker';
 const background = require('./bg.png');
 const logo = require('./icon.jpeg');
 const adapter = createCoreEditorAdapter(960);
+const backgroundSize = { width: 1920, height: 1080 };
 
 function actionStyle(pressed: boolean) {
   return [styles.action, pressed && styles.actionPressed];
@@ -29,7 +30,9 @@ function actionStyle(pressed: boolean) {
 export default function EditorExample() {
   const { width } = useWindowDimensions();
   const canvasWidth = Math.min(Math.max(width - 32, 280), 720);
-  const canvasHeight = Math.round(canvasWidth * 0.62);
+  const canvasHeight = Math.round(
+    canvasWidth * (backgroundSize.height / backgroundSize.width)
+  );
   const controller = React.useMemo(
     () =>
       new ImageMarkerEditorController({
@@ -40,16 +43,16 @@ export default function EditorExample() {
             name: 'Campaign title',
             type: 'text',
             text: 'IMAGE MARKER 2.0',
-            position: { X: 32, Y: 40 },
+            position: { X: 86, Y: 104 },
             style: {
               color: '#FFFFFF',
-              fontSize: 24,
+              fontSize: 64,
               bold: true,
               shadowStyle: {
                 color: '#0F172A',
-                dx: 1,
-                dy: 2,
-                radius: 3,
+                dx: 3,
+                dy: 5,
+                radius: 8,
               },
             },
           },
@@ -58,8 +61,8 @@ export default function EditorExample() {
             name: 'Brand mark',
             type: 'image',
             src: logo,
-            position: { X: 190, Y: 130 },
-            scale: 0.65,
+            position: { X: 1120, Y: 620 },
+            scale: 0.32,
           },
         ],
         output: {
@@ -87,6 +90,7 @@ export default function EditorExample() {
         const request = {
           recipe: controller.exportRecipe(),
           input: { backgroundImage: { src: background } },
+          sourceSize: backgroundSize,
           control: {
             timeoutMs: 20_000,
             onProgress: ({
@@ -120,8 +124,8 @@ export default function EditorExample() {
     controller.addLayer({
       type: 'text',
       text: 'New text',
-      position: { X: 80, Y: 90 },
-      style: { color: '#F8FAFC', fontSize: 20, bold: true },
+      position: { X: 214, Y: 240 },
+      style: { color: '#F8FAFC', fontSize: 54, bold: true },
     });
   }, [controller]);
 
@@ -129,8 +133,8 @@ export default function EditorExample() {
     controller.addLayer({
       type: 'image',
       src: logo,
-      position: { X: 120, Y: 120 },
-      scale: 0.5,
+      position: { X: 640, Y: 320 },
+      scale: 0.28,
     });
   }, [controller]);
 
@@ -141,7 +145,7 @@ export default function EditorExample() {
     >
       <View style={styles.heading}>
         <View>
-          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.2</Text>
+          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.3</Text>
           <Text style={styles.title}>Interactive Recipe v2 editor</Text>
         </View>
         <Text style={styles.subtitle}>
@@ -188,7 +192,7 @@ export default function EditorExample() {
         <ImageMarkerEditor
           background={
             <Image
-              resizeMode="cover"
+              resizeMode="contain"
               source={background}
               style={StyleSheet.absoluteFill}
             />
@@ -197,6 +201,7 @@ export default function EditorExample() {
           height={canvasHeight}
           onStateChange={setState}
           snapThreshold={8}
+          sourceSize={backgroundSize}
           style={styles.canvas}
           width={canvasWidth}
         />
@@ -216,7 +221,10 @@ export default function EditorExample() {
             accessibilityLabel="Exported editor result"
             resizeMode="contain"
             source={{ uri: resultUri }}
-            style={[styles.result, { width: canvasWidth }]}
+            style={[
+              styles.result,
+              { width: canvasWidth, height: canvasHeight },
+            ]}
           />
         </View>
       )}
@@ -314,7 +322,6 @@ const styles = StyleSheet.create({
   result: {
     backgroundColor: '#E2E8F0',
     borderRadius: 10,
-    height: 280,
   },
   recipeCard: {
     backgroundColor: '#0F172A',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16287,7 +16287,7 @@
     },
     "packages/editor": {
       "name": "react-native-image-marker-editor",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "react-native-image-marker": "file:../.."

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.3 (2026-07-29)
+
+- Added an explicit `sourceSize` coordinate space so the interactive surface,
+  bounded Core preview, and original export preserve the same normalized layer
+  geometry.
+- Added reusable viewport and Recipe projection helpers, including scaling for
+  text metrics, image layers, shadows, strokes, backgrounds, tiles, and
+  numeric positioning values.
+- Fixed the default Editor surface and Web/React Native examples so font and
+  image scale are applied exactly once and source images are not cropped.
+- Added projection and Core-adapter regression coverage for preview parity.
+
 ## 0.0.2 (2026-07-28)
 
 - Added canonical package metadata and direct links to the integration guide,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -17,22 +17,35 @@ const controller = new ImageMarkerEditorController({
   output: { saveFormat: ImageFormat.png },
 });
 const adapter = createCoreEditorAdapter(1024);
+const sourceSize = { width: 1920, height: 1080 };
 
-<ImageMarkerEditor controller={controller} width={360} height={240} />;
+<ImageMarkerEditor
+  controller={controller}
+  sourceSize={sourceSize}
+  width={360}
+  height={240}
+/>;
 <ImageMarkerEditorToolbar controller={controller} />;
 
 const recipe = controller.exportRecipe();
 const result = await adapter.exportOriginal({
   recipe,
   input: { backgroundImage: { src: imageSource } },
+  sourceSize,
 });
 ```
+
+Use original-image pixels for numeric Recipe positions and sizes, then pass
+the same `sourceSize` to the surface and render adapter. The Editor projects
+that source coordinate space into its viewport, and the Core adapter projects
+it into bounded previews. Omit `sourceSize` only when the viewport itself is
+the intended Recipe coordinate space.
 
 The main entry owns only UI and Recipe state. Import the opt-in `core-adapter`
 entry to render previews or final output through Core, or inject your own
 adapter for a server renderer.
 
-Run the repository's React Native example and choose **Editor 0.0.2**, or use
+Run the repository's React Native example and choose **Editor 0.0.3**, or use
 the [browser playground](https://image-marker.corerobin.com/playground/?workflow=editor#editor-playground)
 to exercise drag, scale, rotation, ordering, locks, undo/redo, and a real Core
 render.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker-editor",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
   "homepage": "https://image-marker.corerobin.com/guides/editor/",

--- a/packages/editor/src/EditorSurface.tsx
+++ b/packages/editor/src/EditorSurface.tsx
@@ -17,6 +17,7 @@ import {
 import type { WatermarkRecipeDefinitionLayer } from 'react-native-image-marker';
 import { angle, distance } from './geometry';
 import { ImageMarkerEditorController } from './controller';
+import { createEditorViewportProjection } from './projection';
 import type {
   EditorKeyCommand,
   EditorPoint,
@@ -25,17 +26,30 @@ import type {
   EditorState,
 } from './types';
 
+export interface EditorLayerRenderContext {
+  sourceSize: EditorSize;
+  viewportSize: EditorSize;
+  scale: number;
+}
+
 export interface ImageMarkerEditorProps {
   controller: ImageMarkerEditorController;
   width: number;
   height: number;
+  /**
+   * Original background dimensions used by Recipe pixel coordinates. When
+   * omitted, the viewport dimensions remain the coordinate space for backward
+   * compatibility.
+   */
+  sourceSize?: EditorSize;
   background?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
   snapThreshold?: number;
   getLayerSize?: (layer: WatermarkRecipeDefinitionLayer) => EditorSize;
   renderLayer?: (
     layer: WatermarkRecipeDefinitionLayer,
-    selected: boolean
+    selected: boolean,
+    context: EditorLayerRenderContext
   ) => React.ReactNode;
   onStateChange?: (state: EditorState) => void;
 }
@@ -85,60 +99,98 @@ function defaultLayerSize(layer: WatermarkRecipeDefinitionLayer): EditorSize {
       height: Math.max(fontSize * 1.4, 32),
     };
   }
+  const resolved = Image.resolveAssetSource(layer.src as ImageSourcePropType);
+  if (resolved?.width && resolved?.height) {
+    return { width: resolved.width, height: resolved.height };
+  }
   return { width: 120, height: 80 };
 }
 
 function defaultTextStyle(
-  layer: Extract<WatermarkRecipeDefinitionLayer, { type: 'text' }>
+  layer: Extract<WatermarkRecipeDefinitionLayer, { type: 'text' }>,
+  viewportScale: number
 ): TextStyle {
   return {
     color: layer.style?.color ?? '#FFFFFF',
-    fontSize: layer.style?.fontSize ?? 14,
+    fontSize: (layer.style?.fontSize ?? 14) * viewportScale,
     fontWeight: layer.style?.bold ? '700' : '400',
     fontStyle: layer.style?.italic ? 'italic' : 'normal',
+    textAlign: layer.style?.textAlign ?? 'left',
+    textShadowColor: layer.style?.shadowStyle?.color,
+    textShadowOffset: layer.style?.shadowStyle
+      ? {
+          width: layer.style.shadowStyle.dx * viewportScale,
+          height: layer.style.shadowStyle.dy * viewportScale,
+        }
+      : undefined,
+    textShadowRadius: (layer.style?.shadowStyle?.radius ?? 0) * viewportScale,
   };
 }
 
-function defaultImageStyle(size: EditorSize): ImageStyle {
-  return { width: size.width, height: size.height };
+function defaultImageStyle(
+  size: EditorSize,
+  viewportScale: number
+): ImageStyle {
+  return {
+    width: size.width * viewportScale,
+    height: size.height * viewportScale,
+  };
 }
 
 function positionedLayerStyle(
   layer: WatermarkRecipeDefinitionLayer,
   start: EditorPoint,
-  size: EditorSize
+  size: EditorSize,
+  viewportScale: number
 ): ViewStyle {
+  const transformScale = layer.type === 'image' ? layer.scale ?? 1 : 1;
   return {
-    left: start.x,
-    top: start.y,
-    width: size.width,
-    height: size.height,
-    opacity: layer.locked ? 0.72 : 1,
+    left: start.x * viewportScale,
+    top: start.y * viewportScale,
+    width: size.width * viewportScale,
+    height: size.height * viewportScale,
+    opacity: layer.alpha ?? 1,
     transform: [
-      { scale: layerScale(layer) },
+      { scale: transformScale },
       { rotate: `${layerRotation(layer)}deg` },
     ],
   };
 }
 
-function snapGuideStyle(guide: EditorSnapGuide, canvas: EditorSize): ViewStyle {
+function snapGuideStyle(
+  guide: EditorSnapGuide,
+  canvas: EditorSize,
+  viewportScale: number
+): ViewStyle {
   return guide.axis === 'x'
-    ? { left: guide.position, top: 0, width: 1, height: canvas.height }
-    : { top: guide.position, left: 0, height: 1, width: canvas.width };
+    ? {
+        left: guide.position * viewportScale,
+        top: 0,
+        width: 1,
+        height: canvas.height * viewportScale,
+      }
+    : {
+        top: guide.position * viewportScale,
+        left: 0,
+        height: 1,
+        width: canvas.width * viewportScale,
+      };
 }
 
 function DefaultLayer({
   layer,
   size,
+  viewportScale,
 }: {
   layer: WatermarkRecipeDefinitionLayer;
   size: EditorSize;
+  viewportScale: number;
 }) {
   if (layer.type === 'text') {
     return (
       <Text
         numberOfLines={3}
-        style={[styles.defaultText, defaultTextStyle(layer)]}
+        style={[styles.defaultText, defaultTextStyle(layer, viewportScale)]}
       >
         {layer.text}
       </Text>
@@ -148,13 +200,15 @@ function DefaultLayer({
     <Image
       resizeMode="contain"
       source={layer.src as ImageSourcePropType}
-      style={defaultImageStyle(size)}
+      style={defaultImageStyle(size, viewportScale)}
     />
   );
 }
 
 interface EditorLayerProps {
-  canvas: EditorSize;
+  sourceCanvas: EditorSize;
+  viewportSize: EditorSize;
+  viewportScale: number;
   controller: ImageMarkerEditorController;
   layer: WatermarkRecipeDefinitionLayer;
   selected: boolean;
@@ -164,7 +218,9 @@ interface EditorLayerProps {
 }
 
 function EditorLayer({
-  canvas,
+  sourceCanvas,
+  viewportSize,
+  viewportScale,
   controller,
   layer,
   selected,
@@ -175,10 +231,15 @@ function EditorLayer({
   const baseline = React.useRef<LayerGestureBaseline>();
   const start = React.useMemo(
     () => ({
-      x: coordinate(layer.position?.X, canvas.width),
-      y: coordinate(layer.position?.Y, canvas.height),
+      x: coordinate(layer.position?.X, sourceCanvas.width),
+      y: coordinate(layer.position?.Y, sourceCanvas.height),
     }),
-    [canvas.height, canvas.width, layer.position?.X, layer.position?.Y]
+    [
+      layer.position?.X,
+      layer.position?.Y,
+      sourceCanvas.height,
+      sourceCanvas.width,
+    ]
   );
 
   const responder = React.useMemo(
@@ -231,11 +292,11 @@ function EditorLayer({
           controller.moveLayer(
             layer.id,
             {
-              x: initial.position.x + gesture.dx,
-              y: initial.position.y + gesture.dy,
+              x: initial.position.x + gesture.dx / viewportScale,
+              y: initial.position.y + gesture.dy / viewportScale,
             },
             {
-              canvas,
+              canvas: sourceCanvas,
               layer: size,
               threshold: snapThreshold,
             }
@@ -252,7 +313,7 @@ function EditorLayer({
           controller.endHistoryGroup();
         },
       }),
-    [canvas, controller, layer, size, snapThreshold, start]
+    [controller, layer, size, snapThreshold, sourceCanvas, start, viewportScale]
   );
 
   if (layer.visible === false) return null;
@@ -282,12 +343,16 @@ function EditorLayer({
       }}
       style={[
         styles.layer,
-        positionedLayerStyle(layer, start, size),
+        positionedLayerStyle(layer, start, size, viewportScale),
         selected && styles.selectedLayer,
       ]}
     >
-      {renderLayer?.(layer, selected) ?? (
-        <DefaultLayer layer={layer} size={size} />
+      {renderLayer?.(layer, selected, {
+        sourceSize: sourceCanvas,
+        viewportSize,
+        scale: viewportScale,
+      }) ?? (
+        <DefaultLayer layer={layer} size={size} viewportScale={viewportScale} />
       )}
     </View>
   );
@@ -296,14 +361,16 @@ function EditorLayer({
 function Guide({
   guide,
   canvas,
+  viewportScale,
 }: {
   guide: EditorSnapGuide;
   canvas: EditorSize;
+  viewportScale: number;
 }) {
   return (
     <View
       pointerEvents="none"
-      style={[styles.guide, snapGuideStyle(guide, canvas)]}
+      style={[styles.guide, snapGuideStyle(guide, canvas, viewportScale)]}
     />
   );
 }
@@ -329,6 +396,7 @@ export function ImageMarkerEditor({
   controller,
   width,
   height,
+  sourceSize,
   background,
   style,
   snapThreshold,
@@ -337,7 +405,12 @@ export function ImageMarkerEditor({
   onStateChange,
 }: ImageMarkerEditorProps) {
   const state = useEditorState(controller, onStateChange);
-  const canvas = React.useMemo(() => ({ width, height }), [height, width]);
+  const viewport = React.useMemo(() => ({ width, height }), [height, width]);
+  const sourceCanvas = sourceSize ?? viewport;
+  const projection = React.useMemo(
+    () => createEditorViewportProjection(sourceCanvas, viewport),
+    [sourceCanvas, viewport]
+  );
   const handleKeyDown = React.useCallback(
     (event: { nativeEvent?: EditorKeyCommand } | EditorKeyCommand) => {
       const command =
@@ -356,26 +429,41 @@ export function ImageMarkerEditor({
       style={[styles.canvas, { width, height }, style]}
       {...({ onKeyDown: handleKeyDown } as object)}
     >
-      {background}
-      {state.recipe.layers.map((layer) => (
-        <EditorLayer
-          key={layer.id}
-          canvas={canvas}
-          controller={controller}
-          layer={layer}
-          selected={state.selectedLayerId === layer.id}
-          size={getLayerSize(layer)}
-          snapThreshold={snapThreshold}
-          renderLayer={renderLayer}
-        />
-      ))}
-      {state.snapGuides.map((guide, index) => (
-        <Guide
-          key={`${guide.axis}-${guide.position}-${index}`}
-          guide={guide}
-          canvas={canvas}
-        />
-      ))}
+      <View
+        style={[
+          styles.content,
+          {
+            left: projection.content.x,
+            top: projection.content.y,
+            width: projection.content.width,
+            height: projection.content.height,
+          },
+        ]}
+      >
+        {background}
+        {state.recipe.layers.map((layer) => (
+          <EditorLayer
+            key={layer.id}
+            controller={controller}
+            layer={layer}
+            renderLayer={renderLayer}
+            selected={state.selectedLayerId === layer.id}
+            size={getLayerSize(layer)}
+            snapThreshold={snapThreshold}
+            sourceCanvas={sourceCanvas}
+            viewportScale={projection.scale}
+            viewportSize={projection.content}
+          />
+        ))}
+        {state.snapGuides.map((guide, index) => (
+          <Guide
+            key={`${guide.axis}-${guide.position}-${index}`}
+            canvas={sourceCanvas}
+            guide={guide}
+            viewportScale={projection.scale}
+          />
+        ))}
+      </View>
     </View>
   );
 }
@@ -450,6 +538,10 @@ const styles = StyleSheet.create({
   canvas: {
     overflow: 'hidden',
     position: 'relative',
+  },
+  content: {
+    overflow: 'hidden',
+    position: 'absolute',
   },
   layer: {
     alignItems: 'center',

--- a/packages/editor/src/__tests__/core-adapter.test.ts
+++ b/packages/editor/src/__tests__/core-adapter.test.ts
@@ -62,6 +62,52 @@ describe('Core editor adapter', () => {
     expect(mockApply).toHaveBeenCalledWith(request.input, request.control);
   });
 
+  it('projects source-space geometry into the bounded Core preview', async () => {
+    mockApply.mockResolvedValue(result('/preview.png'));
+    const adapter = createCoreEditorAdapter(960);
+    const sourceRecipe = {
+      ...request.recipe,
+      layers: [
+        {
+          id: 'title',
+          type: 'text' as const,
+          text: 'Hello',
+          position: { X: 119, Y: 132 },
+          style: { fontSize: 62 },
+        },
+        {
+          id: 'logo',
+          type: 'image' as const,
+          src: '/logo.png',
+          position: { X: 1101, Y: 590 },
+          scale: 0.68,
+        },
+      ],
+    };
+
+    await adapter.renderPreview({
+      ...request,
+      recipe: sourceRecipe,
+      sourceSize: { width: 1586, height: 992 },
+    });
+
+    const previewRecipe = mockCreateRecipe.mock.calls.at(-1)?.[0];
+    expect(previewRecipe.output.maxSize).toBe(960);
+    expect(previewRecipe.layers[0].position.X).toBeCloseTo(119 * (960 / 1586));
+    expect(previewRecipe.layers[0].style.fontSize).toBeCloseTo(
+      62 * (600 / 992)
+    );
+    expect(previewRecipe.layers[1].position.X).toBeCloseTo(1101 * (960 / 1586));
+    expect(previewRecipe.layers[1].position.Y).toBeCloseTo(590 * (600 / 992));
+    expect(previewRecipe.layers[1].scale).toBeCloseTo(0.68 * (600 / 992));
+    expect(sourceRecipe.layers[1]).toEqual(
+      expect.objectContaining({
+        position: { X: 1101, Y: 590 },
+        scale: 0.68,
+      })
+    );
+  });
+
   it('exports visible pixels and optionally adds an invisible locator', async () => {
     mockApply.mockResolvedValue(result('/visible.png'));
     mockEmbedInvisible.mockResolvedValue({

--- a/packages/editor/src/__tests__/projection.test.ts
+++ b/packages/editor/src/__tests__/projection.test.ts
@@ -1,0 +1,115 @@
+import {
+  createEditorViewportProjection,
+  fitEditorSizeWithinMax,
+  projectEditorPoint,
+  projectEditorRecipe,
+  unprojectEditorPoint,
+} from '../projection';
+
+describe('editor projection', () => {
+  it('fits a source image within the preview boundary without stretching it', () => {
+    expect(fitEditorSizeWithinMax({ width: 1586, height: 992 }, 960)).toEqual({
+      width: 960,
+      height: 600,
+    });
+    expect(fitEditorSizeWithinMax({ width: 320, height: 180 }, 960)).toEqual({
+      width: 320,
+      height: 180,
+    });
+  });
+
+  it('letterboxes the source and round-trips source coordinates', () => {
+    const projection = createEditorViewportProjection(
+      { width: 1600, height: 900 },
+      { width: 720, height: 450 }
+    );
+
+    expect(projection).toEqual({
+      source: { width: 1600, height: 900 },
+      viewport: { width: 720, height: 450 },
+      content: { x: 0, y: 22.5, width: 720, height: 405 },
+      scale: 0.45,
+    });
+    const projected = projectEditorPoint({ x: 1100, y: 590 }, projection);
+    expect(projected).toEqual({ x: 495, y: 288 });
+    expect(unprojectEditorPoint(projected, projection)).toEqual({
+      x: 1100,
+      y: 590,
+    });
+  });
+
+  it('projects numeric Recipe geometry while preserving percentages and source data', () => {
+    const recipe = {
+      schemaVersion: 2 as const,
+      layers: [
+        {
+          id: 'title',
+          type: 'text' as const,
+          text: 'IMAGE MARKER 2.0',
+          position: { X: 119, Y: '10%' },
+          style: {
+            fontSize: 62,
+            shadowStyle: { dx: 2, dy: 3, radius: 4, color: '#000000' },
+            strokeStyle: { width: 2, color: '#FFFFFF' },
+            textBackgroundStyle: {
+              color: '#000000',
+              paddingX: 8,
+              paddingY: 6,
+            },
+          },
+        },
+        {
+          id: 'logo',
+          type: 'image' as const,
+          src: '/logo.png',
+          position: { X: 1101, Y: 590 },
+          scale: 0.68,
+        },
+      ],
+      output: { saveFormat: 'png' as const },
+    };
+
+    const projected = projectEditorRecipe(
+      recipe,
+      { width: 1586, height: 992 },
+      { width: 960, height: 600 }
+    );
+    const title = projected.layers[0];
+    const logo = projected.layers[1];
+
+    expect(title?.position?.X).toBeCloseTo(119 * (960 / 1586));
+    expect(title?.position?.Y).toBe('10%');
+    if (title?.type !== 'text') throw new Error('Expected text layer');
+    expect(title.style?.fontSize).toBeCloseTo(62 * (600 / 992));
+    expect(title.style?.shadowStyle).toEqual({
+      dx: expect.closeTo(2 * (960 / 1586)),
+      dy: expect.closeTo(3 * (600 / 992)),
+      radius: expect.closeTo(4 * (600 / 992)),
+      color: '#000000',
+    });
+    expect(title.style?.textBackgroundStyle?.paddingX).toBeCloseTo(
+      8 * (960 / 1586)
+    );
+    expect(title.style?.textBackgroundStyle?.paddingY).toBeCloseTo(
+      6 * (600 / 992)
+    );
+    expect(logo?.position?.X).toBeCloseTo(1101 * (960 / 1586));
+    expect(logo?.position?.Y).toBeCloseTo(590 * (600 / 992));
+    if (logo?.type !== 'image') throw new Error('Expected image layer');
+    expect(logo.scale).toBeCloseTo(0.68 * (600 / 992));
+    expect(recipe.layers[0]?.position).toEqual({ X: 119, Y: '10%' });
+    expect(recipe.layers[1]).toEqual(expect.objectContaining({ scale: 0.68 }));
+  });
+
+  it('rejects invalid projection sizes', () => {
+    expect(() =>
+      createEditorViewportProjection(
+        { width: 0, height: 100 },
+        { width: 100, height: 100 }
+      )
+    ).toThrow('sourceSize');
+    expect(() =>
+      fitEditorSizeWithinMax({ width: 100, height: 100 }, 0)
+    ).toThrow('maxSize');
+  });
+});

--- a/packages/editor/src/core-adapter.ts
+++ b/packages/editor/src/core-adapter.ts
@@ -7,6 +7,7 @@ import type {
   EditorRenderRequest,
   ImageMarkerEditorRenderAdapter,
 } from './types';
+import { fitEditorSizeWithinMax, projectEditorRecipe } from './projection';
 
 function withMaxSize(
   recipe: WatermarkRecipeDefinition,
@@ -41,11 +42,23 @@ function signedResult(
 export function createCoreEditorAdapter(
   previewMaxSize = 1024
 ): ImageMarkerEditorRenderAdapter {
-  const renderVisible = (request: EditorRenderRequest, maxSize?: number) =>
-    Marker.createRecipe(withMaxSize(request.recipe, maxSize)).apply(
+  const renderVisible = (request: EditorRenderRequest, maxSize?: number) => {
+    const targetSize =
+      request.sourceSize && maxSize
+        ? fitEditorSizeWithinMax(request.sourceSize, maxSize)
+        : undefined;
+    const recipe =
+      request.sourceSize &&
+      targetSize &&
+      (targetSize.width !== request.sourceSize.width ||
+        targetSize.height !== request.sourceSize.height)
+        ? projectEditorRecipe(request.recipe, request.sourceSize, targetSize)
+        : request.recipe;
+    return Marker.createRecipe(withMaxSize(recipe, maxSize)).apply(
       request.input,
       request.control
     );
+  };
 
   return {
     renderPreview(request) {
@@ -53,7 +66,10 @@ export function createCoreEditorAdapter(
     },
 
     async exportOriginal(request): Promise<EditorExportResult> {
-      const visible = await renderVisible(request);
+      const visible = await renderVisible(
+        request,
+        request.recipe.output.maxSize
+      );
       const invisible = request.options?.invisible;
       const credentials = request.options?.contentCredentials;
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -2,6 +2,7 @@ export { ImageMarkerEditorController } from './controller';
 export {
   ImageMarkerEditor,
   ImageMarkerEditorToolbar,
+  type EditorLayerRenderContext,
   type ImageMarkerEditorProps,
   type ImageMarkerEditorToolbarProps,
 } from './EditorSurface';
@@ -11,6 +12,14 @@ export {
   normalizeSafeArea,
   snapLayerPosition,
 } from './geometry';
+export {
+  createEditorViewportProjection,
+  fitEditorSizeWithinMax,
+  projectEditorPoint,
+  projectEditorRecipe,
+  unprojectEditorPoint,
+  type EditorViewportProjection,
+} from './projection';
 export type {
   EditorContentCredentialsExport,
   EditorExportOptions,

--- a/packages/editor/src/projection.ts
+++ b/packages/editor/src/projection.ts
@@ -1,0 +1,263 @@
+import type {
+  EditorPoint,
+  EditorRect,
+  EditorSize,
+  WatermarkRecipeDefinition,
+  WatermarkRecipeDefinitionLayer,
+} from './types';
+
+type Measure = number | string | undefined;
+
+export interface EditorViewportProjection {
+  source: EditorSize;
+  viewport: EditorSize;
+  content: EditorRect;
+  scale: number;
+}
+
+function assertSize(size: EditorSize, label: string): void {
+  if (
+    !Number.isFinite(size.width) ||
+    !Number.isFinite(size.height) ||
+    size.width <= 0 ||
+    size.height <= 0
+  ) {
+    throw new Error(
+      `${label} dimensions must be finite numbers greater than 0.`
+    );
+  }
+}
+
+function scaleMeasure(value: Measure, factor: number): Measure {
+  if (typeof value === 'number') return value * factor;
+  if (typeof value !== 'string') return value;
+  const normalized = value.trim();
+  if (!normalized || normalized.endsWith('%')) return value;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? String(parsed * factor) : value;
+}
+
+function scalePadding(value: Measure, factor: number): Measure {
+  if (typeof value === 'number') return value * factor;
+  if (typeof value !== 'string') return value;
+  return value
+    .trim()
+    .split(/\s+/)
+    .map((part) => scaleMeasure(part, factor))
+    .join(' ');
+}
+
+function projectPosition(
+  layer: WatermarkRecipeDefinitionLayer,
+  scaleX: number,
+  scaleY: number,
+  scale: number
+) {
+  const position = layer.position;
+  const defaultInset = layer.type === 'text' ? 20 : 0;
+  if (position?.position) {
+    return {
+      ...position,
+      X: scaleMeasure(position.X, scaleX),
+      Y: scaleMeasure(position.Y, scaleY),
+      edgeInset:
+        position.edgeInset === undefined
+          ? 20 * scale
+          : scaleMeasure(position.edgeInset, scale),
+    };
+  }
+  return {
+    ...position,
+    X:
+      position?.X === undefined
+        ? defaultInset * scaleX
+        : scaleMeasure(position.X, scaleX),
+    Y:
+      position?.Y === undefined
+        ? defaultInset * scaleY
+        : scaleMeasure(position.Y, scaleY),
+    edgeInset:
+      position?.edgeInset === undefined
+        ? undefined
+        : scaleMeasure(position.edgeInset, scale),
+  };
+}
+
+function projectLayout(
+  layer: WatermarkRecipeDefinitionLayer,
+  scaleX: number,
+  scaleY: number
+) {
+  if (layer.layout?.type !== 'tile') return layer.layout && { ...layer.layout };
+  return {
+    ...layer.layout,
+    gapX: scaleMeasure(layer.layout.gapX, scaleX),
+    gapY: scaleMeasure(layer.layout.gapY, scaleY),
+    offsetX: scaleMeasure(layer.layout.offsetX, scaleX),
+    offsetY: scaleMeasure(layer.layout.offsetY, scaleY),
+  };
+}
+
+function projectTextLayer(
+  layer: Extract<WatermarkRecipeDefinitionLayer, { type: 'text' }>,
+  scaleX: number,
+  scaleY: number,
+  scale: number
+): WatermarkRecipeDefinitionLayer {
+  const style = layer.style;
+  const background = style?.textBackgroundStyle;
+  const cornerRadius = background?.cornerRadius;
+  return {
+    ...layer,
+    position: projectPosition(layer, scaleX, scaleY, scale),
+    layout: projectLayout(layer, scaleX, scaleY),
+    style: {
+      ...style,
+      fontSize:
+        style?.fontSizeRatio === undefined
+          ? (style?.fontSize ?? 14) * scale
+          : style.fontSize,
+      shadowStyle: style?.shadowStyle
+        ? {
+            ...style.shadowStyle,
+            dx: style.shadowStyle.dx * scaleX,
+            dy: style.shadowStyle.dy * scaleY,
+            radius: style.shadowStyle.radius * scale,
+          }
+        : style?.shadowStyle,
+      strokeStyle: style?.strokeStyle
+        ? {
+            ...style.strokeStyle,
+            width: style.strokeStyle.width * scale,
+          }
+        : style?.strokeStyle,
+      textBackgroundStyle: background
+        ? {
+            ...background,
+            padding: scalePadding(background.padding, scale),
+            paddingLeft: scaleMeasure(background.paddingLeft, scaleX),
+            paddingRight: scaleMeasure(background.paddingRight, scaleX),
+            paddingTop: scaleMeasure(background.paddingTop, scaleY),
+            paddingBottom: scaleMeasure(background.paddingBottom, scaleY),
+            paddingHorizontal: scaleMeasure(
+              background.paddingHorizontal,
+              scaleX
+            ),
+            paddingVertical: scaleMeasure(background.paddingVertical, scaleY),
+            paddingX: scaleMeasure(background.paddingX, scaleX),
+            paddingY: scaleMeasure(background.paddingY, scaleY),
+            cornerRadius: cornerRadius
+              ? Object.fromEntries(
+                  Object.entries(cornerRadius).map(([key, value]) => [
+                    key,
+                    value
+                      ? {
+                          x: scaleMeasure(value.x, scaleX),
+                          y: scaleMeasure(value.y, scaleY),
+                        }
+                      : value,
+                  ])
+                )
+              : cornerRadius,
+          }
+        : background,
+    },
+  };
+}
+
+function projectImageLayer(
+  layer: Extract<WatermarkRecipeDefinitionLayer, { type: 'image' }>,
+  scaleX: number,
+  scaleY: number,
+  scale: number
+): WatermarkRecipeDefinitionLayer {
+  return {
+    ...layer,
+    position: projectPosition(layer, scaleX, scaleY, scale),
+    layout: projectLayout(layer, scaleX, scaleY),
+    scale: (layer.scale ?? 1) * scale,
+  };
+}
+
+export function fitEditorSizeWithinMax(
+  source: EditorSize,
+  maxSize: number
+): EditorSize {
+  assertSize(source, 'sourceSize');
+  if (!Number.isFinite(maxSize) || maxSize <= 0) {
+    throw new Error('maxSize must be a finite number greater than 0.');
+  }
+  const largest = Math.max(source.width, source.height);
+  if (largest <= maxSize) return { ...source };
+  const scale = maxSize / largest;
+  return {
+    width: Math.max(1, Math.round(source.width * scale)),
+    height: Math.max(1, Math.round(source.height * scale)),
+  };
+}
+
+export function createEditorViewportProjection(
+  source: EditorSize,
+  viewport: EditorSize
+): EditorViewportProjection {
+  assertSize(source, 'sourceSize');
+  assertSize(viewport, 'viewport');
+  const scale = Math.min(
+    viewport.width / source.width,
+    viewport.height / source.height
+  );
+  const width = source.width * scale;
+  const height = source.height * scale;
+  return {
+    source: { ...source },
+    viewport: { ...viewport },
+    scale,
+    content: {
+      x: (viewport.width - width) / 2,
+      y: (viewport.height - height) / 2,
+      width,
+      height,
+    },
+  };
+}
+
+export function projectEditorPoint(
+  point: EditorPoint,
+  projection: EditorViewportProjection
+): EditorPoint {
+  return {
+    x: projection.content.x + point.x * projection.scale,
+    y: projection.content.y + point.y * projection.scale,
+  };
+}
+
+export function unprojectEditorPoint(
+  point: EditorPoint,
+  projection: EditorViewportProjection
+): EditorPoint {
+  return {
+    x: (point.x - projection.content.x) / projection.scale,
+    y: (point.y - projection.content.y) / projection.scale,
+  };
+}
+
+export function projectEditorRecipe(
+  recipe: WatermarkRecipeDefinition,
+  source: EditorSize,
+  target: EditorSize
+): WatermarkRecipeDefinition {
+  assertSize(source, 'sourceSize');
+  assertSize(target, 'targetSize');
+  const scaleX = target.width / source.width;
+  const scaleY = target.height / source.height;
+  const scale = Math.min(scaleX, scaleY);
+  return {
+    schemaVersion: 2,
+    layers: recipe.layers.map((layer) =>
+      layer.type === 'text'
+        ? projectTextLayer(layer, scaleX, scaleY, scale)
+        : projectImageLayer(layer, scaleX, scaleY, scale)
+    ),
+    output: { ...recipe.output },
+  };
+}

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -76,6 +76,12 @@ export interface EditorKeyCommand {
 export interface EditorRenderRequest {
   recipe: WatermarkRecipeDefinition;
   input: WatermarkRecipeInput;
+  /**
+   * Pixel dimensions of the background before Core applies output.maxSize.
+   * Providing this keeps numeric Recipe coordinates visually stable between
+   * the interactive surface, bounded previews, and original export.
+   */
+  sourceSize?: EditorSize;
   control?: MarkerJobOptions;
 }
 


### PR DESCRIPTION
## Summary
- project source-space recipes consistently into the Editor viewport and Core preview
- preserve original source coordinates for export while honoring optional max output size
- update the React Native example, package docs, changelog, and Editor version to 0.0.3

## Verification
- npm test -- --runInBand
- npm run typecheck
- npm run lint
- npm --prefix packages/editor test -- --runInBand
- npm --prefix packages/editor run build
- npm --prefix example run typecheck
- npm run verify:consumer

Core remains 2.0.0; this PR only prepares react-native-image-marker-editor@0.0.3.