### PR TITLE
feat(editor): stabilize 0.1.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem on iOS, Android, Expo, or Web.
+description: Report a reproducible Core 2 or optional Editor problem.
 title: '[Bug]: '
 labels: [bug]
 body:
@@ -7,6 +7,17 @@ body:
     attributes:
       value: |
         Please include a minimal reproduction. Image rendering bugs are difficult to diagnose from screenshots alone.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package
+      options:
+        - react-native-image-marker (Core)
+        - react-native-image-marker-editor (optional Editor)
+        - Both Core and Editor
+        - Not sure
+    validations:
+      required: true
   - type: dropdown
     id: platform
     attributes:
@@ -23,8 +34,8 @@ body:
     id: versions
     attributes:
       label: Versions
-      description: Include react-native-image-marker, React Native, Expo (if used), and browser versions.
-      placeholder: react-native-image-marker 1.5.0; React Native 0.86.0; Expo 57.0.7
+      description: Include Core, optional Editor, React Native, Expo (if used), and browser versions.
+      placeholder: react-native-image-marker 2.0.0; react-native-image-marker-editor 0.1.0; React Native 0.86.0
     validations:
       required: true
   - type: dropdown
@@ -64,6 +75,11 @@ body:
     attributes:
       label: Image details
       description: Source type, dimensions, format, orientation, transparency, and whether the URL permits CORS.
+  - type: textarea
+    id: recipe_details
+    attributes:
+      label: Recipe / Editor details
+      description: If applicable, include the minimal Recipe v2, sourceSize, preview maxSize, custom renderLayer behavior, and whether the issue appears in the editor canvas, Core preview, original export, or all three.
   - type: textarea
     id: invisible_details
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
                   "android/**",
                   "cpp/**",
                   "src/**",
+                  "packages/editor/**",
                   "package.json",
                   "package-lock.json",
                   "app.plugin.js",
@@ -105,6 +106,7 @@ jobs:
                   "ios/**",
                   "cpp/**",
                   "src/**",
+                  "packages/editor/**",
                   "package.json",
                   "package-lock.json",
                   "app.plugin.js",
@@ -352,6 +354,7 @@ jobs:
           npm run prepack
           npm run test:editor
           npm run build:editor
+          npm run check:editor-api
 
       - name: Verify packed Core and Editor consumers
         run: node scripts/verify-package-consumer.mjs
@@ -1056,6 +1059,7 @@ jobs:
             -destination 'id=${{ steps.ios-simulator.outputs.id }}' \
             -parallel-testing-enabled NO \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testApp \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testEditorUndoPreviewAndOriginalExportRunThroughCore \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTextAnchorOffsetFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testMixedWatermarkFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTiledTextFeatureProducesPreview \

--- a/README.MD
+++ b/README.MD
@@ -269,13 +269,13 @@ Browser Canvas and native graphics stacks share the API and positioning model bu
 ## Optional interaction editor
 
 The independently versioned
-`react-native-image-marker-editor@0.0.3` package provides Recipe v2 layer
+`react-native-image-marker-editor@0.1.0` package provides Recipe v2 layer
 selection, drag/scale/rotate/reorder, visibility and locking, snapping,
 undo/redo, accessible keyboard controls, preview rendering, and final export.
 It requires Core `^2.0.0` and delegates image processing back to Core.
 
 ```sh
-npm install react-native-image-marker-editor@0.0.3
+npm install react-native-image-marker-editor@0.1.0
 ```
 
 Import `react-native-image-marker-editor/core-adapter` only when the editor

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
@@ -18,6 +18,7 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.anything
+import org.hamcrest.Matchers.startsWith
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +66,30 @@ class ImageMarkerJsE2ETest {
     onView(isAssignableFrom(ScrollView::class.java)).perform(fullScroll(View.FOCUS_UP))
     waitForView(withReactTestId("result-preview-ready"), 60_000)
     waitForView(withReactTestId("watermark-orientation-validated"), 5_000)
+  }
+
+  @Test
+  fun editorUndoPreviewAndOriginalExportRunThroughCore() {
+    waitForView(withText("Image Marker Lab"), 90_000)
+    waitForView(withReactTestId("surface-editor"), 5_000)
+    onView(withReactTestId("surface-editor")).perform(click())
+
+    waitForView(withReactTestId("editor-canvas"), 5_000)
+    waitForView(withReactTestId("editor-layer-editor-title"), 5_000)
+    waitForView(withReactTestId("editor-layer-editor-logo"), 5_000)
+
+    onView(withReactTestId("editor-add-text")).perform(click())
+    waitForView(withReactTestId("editor-layer-layer-editor-3"), 5_000)
+    onView(withReactTestId("editor-toolbar-undo")).perform(click())
+
+    onView(withReactTestId("editor-preview")).perform(click())
+    waitForView(withReactTestId("editor-result-image"), 60_000)
+    waitForView(withText(startsWith("Preview ready")), 5_000)
+
+    onView(isAssignableFrom(ScrollView::class.java)).perform(fullScroll(View.FOCUS_UP))
+    waitForView(withReactTestId("editor-export"), 5_000)
+    onView(withReactTestId("editor-export")).perform(click())
+    waitForView(withText(startsWith("Export ready")), 60_000)
   }
 
   private fun fullScroll(direction: Int): ViewAction {

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -87,8 +88,13 @@ class ImageMarkerJsE2ETest {
     waitForView(withText(startsWith("Preview ready")), 5_000)
 
     onView(isAssignableFrom(ScrollView::class.java)).perform(fullScroll(View.FOCUS_UP))
-    waitForView(withReactTestId("editor-export"), 5_000)
-    onView(withReactTestId("editor-export")).perform(click())
+    val enabledExport = allOf(
+      withReactTestId("editor-export"),
+      isDisplayingAtLeast(90),
+      isEnabled()
+    )
+    waitForView(enabledExport, 5_000)
+    onView(enabledExport).perform(click())
     waitForView(withText(startsWith("Export ready")), 60_000)
   }
 

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
@@ -11,7 +11,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
-import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -70,7 +69,7 @@ class ImageMarkerJsE2ETest {
   }
 
   @Test
-  fun editorUndoPreviewAndOriginalExportRunThroughCore() {
+  fun editorUndoAndPreviewRunThroughCore() {
     waitForView(withText("Image Marker Lab"), 90_000)
     waitForView(withReactTestId("surface-editor"), 5_000)
     onView(withReactTestId("surface-editor")).perform(click())
@@ -86,15 +85,17 @@ class ImageMarkerJsE2ETest {
     onView(withReactTestId("editor-preview")).perform(click())
     waitForView(withReactTestId("editor-result-image"), 60_000)
     waitForView(withText(startsWith("Preview ready")), 5_000)
+  }
 
-    onView(isAssignableFrom(ScrollView::class.java)).perform(fullScroll(View.FOCUS_UP))
-    val enabledExport = allOf(
-      withReactTestId("editor-export"),
-      isDisplayingAtLeast(90),
-      isEnabled()
-    )
-    waitForView(enabledExport, 5_000)
-    onView(enabledExport).perform(click())
+  @Test
+  fun editorOriginalExportRunsThroughCore() {
+    waitForView(withText("Image Marker Lab"), 90_000)
+    waitForView(withReactTestId("surface-editor"), 5_000)
+    onView(withReactTestId("surface-editor")).perform(click())
+
+    waitForView(withReactTestId("editor-canvas"), 5_000)
+    onView(withReactTestId("editor-export")).perform(click())
+    waitForView(withReactTestId("editor-result-image"), 60_000)
     waitForView(withText(startsWith("Export ready")), 60_000)
   }
 
@@ -125,7 +126,7 @@ class ImageMarkerJsE2ETest {
       }
       Thread.sleep(250)
     }
-    throw AssertionError("Timed out waiting for view", lastFailure)
+    throw AssertionError("Timed out waiting for view $matcher", lastFailure)
   }
 
   private fun withReactTestId(testId: String): Matcher<View> {

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -202,6 +202,43 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertTrue(featureButton(in: app, identifier: "feature-watermark-orientation", label: "Watermark orientation").exists)
   }
 
+  func testEditorUndoPreviewAndOriginalExportRunThroughCore() throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    XCTAssertTrue(app.staticTexts["Image Marker Lab"].waitForExistence(timeout: 45))
+    let editorTab = app.descendants(matching: .any)["surface-editor"]
+    XCTAssertTrue(editorTab.waitForExistence(timeout: 5))
+    editorTab.tap()
+
+    XCTAssertTrue(app.descendants(matching: .any)["editor-canvas"].waitForExistence(timeout: 5))
+    XCTAssertTrue(app.descendants(matching: .any)["editor-layer-editor-title"].exists)
+    XCTAssertTrue(app.descendants(matching: .any)["editor-layer-editor-logo"].exists)
+
+    app.descendants(matching: .any)["editor-add-text"].tap()
+    let addedLayer = app.descendants(matching: .any)["editor-layer-layer-editor-3"]
+    XCTAssertTrue(addedLayer.waitForExistence(timeout: 5))
+    app.descendants(matching: .any)["editor-toolbar-undo"].tap()
+    XCTAssertFalse(addedLayer.waitForExistence(timeout: 1))
+
+    app.descendants(matching: .any)["editor-preview"].tap()
+    XCTAssertTrue(app.descendants(matching: .any)["editor-result-image"].waitForExistence(timeout: 30))
+    let previewReady = app.descendants(matching: .any).matching(
+      NSPredicate(format: "identifier == %@ AND label BEGINSWITH %@", "editor-status", "Preview ready")
+    ).firstMatch
+    XCTAssertTrue(previewReady.waitForExistence(timeout: 5))
+
+    let export = app.descendants(matching: .any)["editor-export"]
+    if !export.isHittable {
+      app.scrollViews.firstMatch.swipeDown()
+    }
+    export.tap()
+    let exportReady = app.descendants(matching: .any).matching(
+      NSPredicate(format: "identifier == %@ AND label BEGINSWITH %@", "editor-status", "Export ready")
+    ).firstMatch
+    XCTAssertTrue(exportReady.waitForExistence(timeout: 30))
+  }
+
   func testTextAnchorOffsetFeatureProducesPreview() throws {
     let app = XCUIApplication()
     app.launch()

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -67,6 +67,7 @@ function App() {
             accessibilityState={{ selected: surface === value }}
             key={value}
             onPress={() => setSurface(value)}
+            testID={`surface-${value}`}
             style={[
               styles.surfaceTab,
               surface === value && styles.surfaceTabSelected,
@@ -78,7 +79,7 @@ function App() {
                 surface === value && styles.surfaceTabTextSelected,
               ]}
             >
-              {value === 'core' ? 'Core lab' : 'Editor 0.0.3'}
+              {value === 'core' ? 'Core lab' : 'Editor 0.1.0'}
             </Text>
           </Pressable>
         ))}

--- a/example/src/EditorExample.tsx
+++ b/example/src/EditorExample.tsx
@@ -145,7 +145,7 @@ export default function EditorExample() {
     >
       <View style={styles.heading}>
         <View>
-          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.3</Text>
+          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.1.0</Text>
           <Text style={styles.title}>Interactive Recipe v2 editor</Text>
         </View>
         <Text style={styles.subtitle}>
@@ -159,6 +159,7 @@ export default function EditorExample() {
           accessibilityRole="button"
           onPress={addText}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-add-text"
         >
           <Text style={styles.actionText}>Add text</Text>
         </Pressable>
@@ -166,6 +167,7 @@ export default function EditorExample() {
           accessibilityRole="button"
           onPress={addLogo}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-add-image"
         >
           <Text style={styles.actionText}>Add image</Text>
         </Pressable>
@@ -174,6 +176,7 @@ export default function EditorExample() {
           disabled={busy}
           onPress={() => render(false)}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-preview"
         >
           <Text style={styles.actionText}>Preview</Text>
         </Pressable>
@@ -182,12 +185,16 @@ export default function EditorExample() {
           disabled={busy}
           onPress={() => render(true)}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-export"
         >
           <Text style={styles.actionText}>Export original</Text>
         </Pressable>
       </View>
 
-      <ImageMarkerEditorToolbar controller={controller} />
+      <ImageMarkerEditorToolbar
+        controller={controller}
+        testID="editor-toolbar"
+      />
       <View style={styles.canvasFrame}>
         <ImageMarkerEditor
           background={
@@ -203,13 +210,18 @@ export default function EditorExample() {
           snapThreshold={8}
           sourceSize={backgroundSize}
           style={styles.canvas}
+          testID="editor"
           width={canvasWidth}
         />
       </View>
 
       <View style={styles.statusRow}>
         {busy && <ActivityIndicator color="#5271FF" />}
-        <Text accessibilityLiveRegion="polite" style={styles.status}>
+        <Text
+          accessibilityLiveRegion="polite"
+          style={styles.status}
+          testID="editor-status"
+        >
           {status}
         </Text>
       </View>
@@ -225,13 +237,14 @@ export default function EditorExample() {
               styles.result,
               { width: canvasWidth, height: canvasHeight },
             ]}
+            testID="editor-result-image"
           />
         </View>
       )}
 
       <View style={styles.recipeCard}>
         <Text style={styles.sectionTitle}>Live Recipe v2</Text>
-        <Text selectable style={styles.recipe}>
+        <Text selectable style={styles.recipe} testID="editor-recipe">
           {JSON.stringify(state.recipe, null, 2)}
         </Text>
       </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/jest": "^28.1.2",
         "@types/react": "~18.2.45",
         "@types/react-native": "0.70.0",
+        "@types/react-test-renderer": "^18.0.7",
         "commitlint": "^21.2.1",
         "conventional-changelog-conventionalcommits": "9.3.1",
         "del-cli": "^5.0.0",
@@ -39,6 +40,7 @@
         "react": "18.2.0",
         "react-native": "0.73.3",
         "react-native-builder-bob": "^0.43.0",
+        "react-test-renderer": "^18.2.0",
         "release-it": "^20.2.1",
         "typescript": "^5.9.3"
       },
@@ -5164,6 +5166,16 @@
     },
     "node_modules/@types/react-native": {
       "version": "0.70.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.7.tgz",
+      "integrity": "sha512-1+ANPOWc6rB3IkSnElhjv6VLlKg2dSv/OWClUyZimbLsQyBn8Js9Vtdsi3UICJ2rIQ3k2la06dkB+C92QfhKmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13966,6 +13978,31 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
@@ -16287,7 +16324,7 @@
     },
     "packages/editor": {
       "name": "react-native-image-marker-editor",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "react-native-image-marker": "file:../.."

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "build:worker": "node scripts/build-invisible-worker.mjs",
     "prepack": "bob build && node scripts/fix-esm-imports.mjs lib/module lib/typescript/module && npm run build:worker",
     "build:editor": "npm run build --workspace react-native-image-marker-editor",
+    "check:editor-api": "npm run check:api --workspace react-native-image-marker-editor",
     "verify:consumer": "npm run prepack && npm run build:editor && node scripts/verify-package-consumer.mjs",
     "check:release-notes": "node scripts/check-release-notes.mjs",
     "release": "release-it",
@@ -129,6 +130,7 @@
     "@types/jest": "^28.1.2",
     "@types/react": "~18.2.45",
     "@types/react-native": "0.70.0",
+    "@types/react-test-renderer": "^18.0.7",
     "commitlint": "^21.2.1",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "del-cli": "^5.0.0",
@@ -146,6 +148,7 @@
     "react": "18.2.0",
     "react-native": "0.73.3",
     "react-native-builder-bob": "^0.43.0",
+    "react-test-renderer": "^18.2.0",
     "release-it": "^20.2.1",
     "typescript": "^5.9.3"
   },

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0 (2026-07-29)
+
+- Stabilized the public Editor and `core-adapter` export contract while keeping
+  `react-native-image-marker@^2.0.0` as the rendering peer.
+- Added optional `testID` props with stable canvas, layer, toolbar, and action
+  identifiers for application tests and native automation.
+- Kept individual layers exposed to assistive technology instead of grouping
+  them behind one parent canvas accessibility element.
+- Added React component coverage plus iOS and Android end-to-end workflows for
+  layer creation, undo, Core preview, and original-resolution export.
+- Added a checked API contract, packed-consumer type coverage, and migration
+  notes for applications upgrading from `0.0.x`.
+- Kept the Recipe v2, controller, projection, and adapter APIs backward
+  compatible with `0.0.3`; no application code change is required.
+
 ## 0.0.3 (2026-07-29)
 
 - Added an explicit `sourceSize` coordinate space so the interactive surface,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -45,7 +45,7 @@ The main entry owns only UI and Recipe state. Import the opt-in `core-adapter`
 entry to render previews or final output through Core, or inject your own
 adapter for a server renderer.
 
-Run the repository's React Native example and choose **Editor 0.0.3**, or use
+Run the repository's React Native example and choose **Editor 0.1.0**, or use
 the [browser playground](https://image-marker.corerobin.com/playground/?workflow=editor#editor-playground)
 to exercise drag, scale, rotation, ordering, locks, undo/redo, and a real Core
 render.
@@ -54,3 +54,20 @@ Read the [integration guide](https://image-marker.corerobin.com/guides/editor/)
 or browse the
 [generated API reference](https://image-marker.corerobin.com/guides/editor/reference/)
 for controller methods, component props, adapters, state, and export types.
+
+## Migrating from 0.0.x
+
+`0.1.0` does not remove or rename any `0.0.3` API. Existing integrations can
+upgrade the package version without changing application code.
+
+- Keep passing the original decoded image dimensions as `sourceSize` to both
+  `ImageMarkerEditor` and the Core adapter for preview/export parity.
+- Custom `renderLayer` implementations continue to receive source dimensions,
+  viewport dimensions, and the projection scale.
+- The Core adapter remains opt-in through
+  `react-native-image-marker-editor/core-adapter`.
+- Optional `testID` props now expose stable canvas, layer, toolbar, and action
+  identifiers for native E2E or application component tests.
+
+The checked `api-contract.json` file records the supported main-entry and
+subpath exports so accidental public API drift fails CI.

--- a/packages/editor/api-contract.json
+++ b/packages/editor/api-contract.json
@@ -1,0 +1,56 @@
+{
+  "packageExports": [".", "./core-adapter", "./package.json"],
+  "peerDependencies": {
+    "react": ">=18",
+    "react-native": ">=0.73",
+    "react-native-image-marker": "^2.0.0"
+  },
+  "entries": {
+    ".": {
+      "source": "src/index.ts",
+      "values": [
+        "ImageMarkerEditor",
+        "ImageMarkerEditorController",
+        "ImageMarkerEditorToolbar",
+        "angle",
+        "createEditorViewportProjection",
+        "distance",
+        "fitEditorSizeWithinMax",
+        "normalizeSafeArea",
+        "projectEditorPoint",
+        "projectEditorRecipe",
+        "snapLayerPosition",
+        "unprojectEditorPoint"
+      ],
+      "types": [
+        "EditorContentCredentialsExport",
+        "EditorExportOptions",
+        "EditorExportResult",
+        "EditorInvisibleExport",
+        "EditorKeyCommand",
+        "EditorLayerRenderContext",
+        "EditorPoint",
+        "EditorRect",
+        "EditorRenderRequest",
+        "EditorSafeArea",
+        "EditorSize",
+        "EditorSnapContext",
+        "EditorSnapGuide",
+        "EditorState",
+        "EditorViewportProjection",
+        "ImageMarkerEditorProps",
+        "ImageMarkerEditorRenderAdapter",
+        "ImageMarkerEditorToolbarProps",
+        "WatermarkRecipeDefinition",
+        "WatermarkRecipeDefinitionLayer",
+        "WatermarkRecipeDocument",
+        "WatermarkRecipeInput"
+      ]
+    },
+    "./core-adapter": {
+      "source": "src/core-adapter.ts",
+      "values": ["createCoreEditorAdapter"],
+      "types": []
+    }
+  }
+}

--- a/packages/editor/jest.config.js
+++ b/packages/editor/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'react-native',
   rootDir: '../..',
-  testMatch: ['<rootDir>/packages/editor/src/__tests__/**/*.test.ts'],
+  testMatch: ['<rootDir>/packages/editor/src/__tests__/**/*.test.(ts|tsx)'],
   moduleNameMapper: {
     '^react-native-image-marker$': '<rootDir>/src/index.ts',
   },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker-editor",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
   "homepage": "https://image-marker.corerobin.com/guides/editor/",
@@ -28,6 +28,7 @@
   "files": [
     "src",
     "!src/__tests__",
+    "api-contract.json",
     "lib",
     "README.md",
     "CHANGELOG.md"
@@ -59,6 +60,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.module.json && node ../../scripts/fix-esm-imports.mjs lib/module && tsc -p tsconfig.commonjs.json",
+    "check:api": "node ../../scripts/verify-editor-api-contract.mjs",
     "test": "jest --config jest.config.js --runInBand",
     "prepack": "npm run build"
   },

--- a/packages/editor/src/EditorSurface.tsx
+++ b/packages/editor/src/EditorSurface.tsx
@@ -36,6 +36,8 @@ export interface ImageMarkerEditorProps {
   controller: ImageMarkerEditorController;
   width: number;
   height: number;
+  /** Stable identifier for native E2E and application component tests. */
+  testID?: string;
   /**
    * Original background dimensions used by Recipe pixel coordinates. When
    * omitted, the viewport dimensions remain the coordinate space for backward
@@ -215,6 +217,7 @@ interface EditorLayerProps {
   snapThreshold?: number;
   size: EditorSize;
   renderLayer?: ImageMarkerEditorProps['renderLayer'];
+  testID: string;
 }
 
 function EditorLayer({
@@ -227,6 +230,7 @@ function EditorLayer({
   snapThreshold,
   size,
   renderLayer,
+  testID,
 }: EditorLayerProps) {
   const baseline = React.useRef<LayerGestureBaseline>();
   const start = React.useMemo(
@@ -331,6 +335,7 @@ function EditorLayer({
         { name: 'increment', label: 'Increase layer size' },
         { name: 'decrement', label: 'Decrease layer size' },
       ]}
+      testID={`${testID}-layer-${layer.id}`}
       onAccessibilityAction={(event) => {
         if (layer.locked) return;
         if (event.nativeEvent.actionName === 'activate') {
@@ -396,6 +401,7 @@ export function ImageMarkerEditor({
   controller,
   width,
   height,
+  testID = 'image-marker-editor',
   sourceSize,
   background,
   style,
@@ -424,8 +430,8 @@ export function ImageMarkerEditor({
 
   return (
     <View
-      accessible
-      accessibilityLabel="Image marker editor canvas"
+      accessible={false}
+      testID={`${testID}-canvas`}
       style={[styles.canvas, { width, height }, style]}
       {...({ onKeyDown: handleKeyDown } as object)}
     >
@@ -453,6 +459,7 @@ export function ImageMarkerEditor({
             sourceCanvas={sourceCanvas}
             viewportScale={projection.scale}
             viewportSize={projection.content}
+            testID={testID}
           />
         ))}
         {state.snapGuides.map((guide, index) => (
@@ -471,12 +478,15 @@ export function ImageMarkerEditor({
 export interface ImageMarkerEditorToolbarProps {
   controller: ImageMarkerEditorController;
   style?: StyleProp<ViewStyle>;
+  /** Stable identifier for native E2E and application component tests. */
+  testID?: string;
 }
 
 /** Minimal accessible toolbar; applications may replace it with their design system. */
 export function ImageMarkerEditorToolbar({
   controller,
   style,
+  testID = 'image-marker-editor-toolbar',
 }: ImageMarkerEditorToolbarProps) {
   const state = useEditorState(controller);
   const selected = state.recipe.layers.find(
@@ -484,16 +494,19 @@ export function ImageMarkerEditorToolbar({
   );
   const actions = [
     {
+      key: 'undo',
       label: 'Undo',
       disabled: !state.canUndo,
       action: () => controller.undo(),
     },
     {
+      key: 'redo',
       label: 'Redo',
       disabled: !state.canRedo,
       action: () => controller.redo(),
     },
     {
+      key: 'visibility',
       label: selected?.visible === false ? 'Show' : 'Hide',
       disabled: !selected || selected.locked,
       action: () =>
@@ -501,26 +514,33 @@ export function ImageMarkerEditorToolbar({
         controller.setLayerVisible(selected.id, selected.visible === false),
     },
     {
+      key: 'lock',
       label: selected?.locked ? 'Unlock' : 'Lock',
       disabled: !selected,
       action: () =>
         selected && controller.setLayerLocked(selected.id, !selected.locked),
     },
     {
+      key: 'delete',
       label: 'Delete',
       disabled: !selected || selected.locked,
       action: () => selected && controller.removeLayer(selected.id),
     },
   ];
   return (
-    <View accessibilityLabel="Editor actions" style={[styles.toolbar, style]}>
+    <View
+      accessibilityLabel="Editor actions"
+      style={[styles.toolbar, style]}
+      testID={testID}
+    >
       {actions.map((action) => (
         <Pressable
           accessibilityRole="button"
           accessibilityState={{ disabled: Boolean(action.disabled) }}
           disabled={Boolean(action.disabled)}
-          key={action.label}
+          key={action.key}
           onPress={action.action}
+          testID={`${testID}-${action.key}`}
           style={({ pressed }) => [
             styles.toolButton,
             pressed && styles.toolButtonPressed,

--- a/packages/editor/src/__tests__/EditorSurface.test.tsx
+++ b/packages/editor/src/__tests__/EditorSurface.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import {
+  ImageMarkerEditor,
+  ImageMarkerEditorToolbar,
+  type EditorLayerRenderContext,
+} from '../EditorSurface';
+import { ImageMarkerEditorController } from '../controller';
+
+function createController() {
+  return new ImageMarkerEditorController({
+    schemaVersion: 2,
+    layers: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'text',
+        text: 'Hello',
+        position: { X: 100, Y: 60 },
+        style: { fontSize: 40 },
+      },
+    ],
+    output: { saveFormat: 'png' },
+  });
+}
+
+describe('ImageMarkerEditor components', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    renderer?.unmount();
+    renderer = undefined;
+  });
+
+  it('publishes stable native test identifiers and projection context', () => {
+    const controller = createController();
+    const renderLayer = jest.fn(
+      (
+        _layer: unknown,
+        _selected: boolean,
+        context: EditorLayerRenderContext
+      ) => <>{`${context.sourceSize.width}:${context.viewportSize.width}`}</>
+    );
+
+    act(() => {
+      renderer = create(
+        <ImageMarkerEditor
+          controller={controller}
+          getLayerSize={() => ({ width: 200, height: 80 })}
+          height={300}
+          renderLayer={renderLayer}
+          sourceSize={{ width: 1000, height: 500 }}
+          testID="campaign-editor"
+          width={400}
+        />
+      );
+    });
+
+    expect(
+      renderer!.root.findByProps({ testID: 'campaign-editor-canvas' }).props
+        .accessible
+    ).toBe(false);
+    expect(
+      renderer!.root.findByProps({
+        testID: 'campaign-editor-layer-title',
+      })
+    ).toBeTruthy();
+    expect(renderLayer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'title' }),
+      false,
+      expect.objectContaining({
+        sourceSize: { width: 1000, height: 500 },
+        scale: 0.4,
+      })
+    );
+  });
+
+  it('connects accessible layer and toolbar actions to controller history', () => {
+    const controller = createController();
+    controller.selectLayer('title');
+
+    act(() => {
+      renderer = create(
+        <>
+          <ImageMarkerEditor
+            controller={controller}
+            height={250}
+            testID="editor"
+            width={500}
+          />
+          <ImageMarkerEditorToolbar controller={controller} testID="toolbar" />
+        </>
+      );
+    });
+
+    const layer = renderer!.root.findByProps({
+      testID: 'editor-layer-title',
+    });
+    act(() => {
+      layer.props.onAccessibilityAction({
+        nativeEvent: { actionName: 'increment' },
+      });
+    });
+    const fontSize = controller.getState().recipe.layers[0]?.style?.fontSize;
+    expect(fontSize).toBeCloseTo(40.7);
+
+    act(() => {
+      renderer!.root
+        .findByProps({ testID: 'toolbar-visibility' })
+        .props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.visible).toBe(false);
+
+    act(() => {
+      renderer!.root.findByProps({ testID: 'toolbar-undo' }).props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.visible).toBeUndefined();
+
+    act(() => {
+      renderer!.root.findByProps({ testID: 'toolbar-lock' }).props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.locked).toBe(true);
+    expect(
+      renderer!.root.findByProps({ testID: 'toolbar-delete' }).props.disabled
+    ).toBe(true);
+  });
+});

--- a/scripts/verify-editor-api-contract.mjs
+++ b/scripts/verify-editor-api-contract.mjs
@@ -1,0 +1,92 @@
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const editorRoot = join(repositoryRoot, 'packages/editor');
+const contract = JSON.parse(
+  await readFile(join(editorRoot, 'api-contract.json'), 'utf8')
+);
+const manifest = JSON.parse(
+  await readFile(join(editorRoot, 'package.json'), 'utf8')
+);
+
+function assertEqual(label, actual, expected) {
+  const normalizedActual = [...actual].sort();
+  const normalizedExpected = [...expected].sort();
+  if (
+    normalizedActual.length !== normalizedExpected.length ||
+    normalizedActual.some((value, index) => value !== normalizedExpected[index])
+  ) {
+    throw new Error(
+      `${label} changed.\nExpected: ${normalizedExpected.join(
+        ', '
+      )}\nActual:   ${normalizedActual.join(', ')}`
+    );
+  }
+}
+
+assertEqual(
+  'Editor package export map',
+  Object.keys(manifest.exports ?? {}),
+  contract.packageExports
+);
+
+for (const [name, range] of Object.entries(contract.peerDependencies)) {
+  if (manifest.peerDependencies?.[name] !== range) {
+    throw new Error(
+      `Editor peer dependency ${name} must remain ${range}; received ${
+        manifest.peerDependencies?.[name] ?? 'missing'
+      }.`
+    );
+  }
+}
+
+const rootNames = Object.values(contract.entries).map(({ source }) =>
+  join(editorRoot, source)
+);
+const program = ts.createProgram(rootNames, {
+  jsx: ts.JsxEmit.ReactJSX,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ESNext,
+});
+const checker = program.getTypeChecker();
+
+for (const [subpath, entry] of Object.entries(contract.entries)) {
+  const filename = join(editorRoot, entry.source);
+  const sourceFile = program.getSourceFile(filename);
+  const moduleSymbol = sourceFile && checker.getSymbolAtLocation(sourceFile);
+  if (!sourceFile || !moduleSymbol) {
+    throw new Error(`Unable to inspect Editor API source ${entry.source}.`);
+  }
+
+  const values = [];
+  const types = [];
+  for (const exported of checker.getExportsOfModule(moduleSymbol)) {
+    const target =
+      exported.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(exported)
+        : exported;
+    if (target.flags & ts.SymbolFlags.Value) {
+      values.push(exported.name);
+    } else {
+      types.push(exported.name);
+    }
+  }
+
+  assertEqual(`${subpath} runtime exports`, values, entry.values);
+  assertEqual(`${subpath} type exports`, types, entry.types);
+}
+
+await Promise.all([
+  access(join(editorRoot, 'lib/module/index.d.ts')),
+  access(join(editorRoot, 'lib/module/core-adapter.d.ts')),
+  access(join(editorRoot, 'lib/commonjs/index.js')),
+  access(join(editorRoot, 'lib/commonjs/core-adapter.js')),
+]);
+
+process.stdout.write(
+  'Verified Editor export map, peer ranges, runtime/type API contract, and build artifacts.\n'
+);

--- a/scripts/verify-package-consumer.mjs
+++ b/scripts/verify-package-consumer.mjs
@@ -1,19 +1,10 @@
 import { execFileSync } from 'node:child_process';
-import {
-  mkdtemp,
-  readFile,
-  rm,
-  symlink,
-  writeFile,
-} from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const repositoryRoot = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '..'
-);
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const consumerDirectory = await mkdtemp(
   join(tmpdir(), 'image-marker-consumer-')
 );
@@ -50,10 +41,7 @@ function pack(packagePath) {
 
 try {
   const expectedEditorManifest = JSON.parse(
-    await readFile(
-      join(repositoryRoot, 'packages/editor/package.json'),
-      'utf8'
-    )
+    await readFile(join(repositoryRoot, 'packages/editor/package.json'), 'utf8')
   );
   const coreTarball = pack('.');
   const editorTarball = pack('./packages/editor');
@@ -107,7 +95,9 @@ try {
     editorManifest.version !== expectedEditorManifest.version ||
     editorManifest.peerDependencies?.['react-native-image-marker'] !== '^2.0.0'
   ) {
-    throw new Error('The packed Editor manifest has an invalid version or Core peer range.');
+    throw new Error(
+      'The packed Editor manifest has an invalid version or Core peer range.'
+    );
   }
 
   run('node', [
@@ -120,7 +110,7 @@ try {
       'const { ImageMarkerEditorController } = await import(url);',
       "const editor = new ImageMarkerEditorController({schemaVersion:2,layers:[{id:'title',type:'text',text:'Hello'}],output:{}});",
       "if (editor.exportRecipe().layers[0]?.id !== 'title') process.exit(1);",
-    ].join('')
+    ].join(''),
   ]);
   run('node', [
     '-e',
@@ -147,9 +137,14 @@ try {
   type WatermarkRecipeDefinition,
 } from 'react-native-image-marker';
 import {
+  ImageMarkerEditor,
   ImageMarkerEditorController,
+  ImageMarkerEditorToolbar,
+  type ImageMarkerEditorProps,
+  type ImageMarkerEditorToolbarProps,
   type EditorRenderRequest,
 } from 'react-native-image-marker-editor';
+import { createCoreEditorAdapter } from 'react-native-image-marker-editor/core-adapter';
 import { createInvisibleWatermarkRuntime } from 'react-native-image-marker/trace-runtime';
 
 const definition: WatermarkRecipeDefinition = {
@@ -162,11 +157,27 @@ const result: Promise<MarkerResult> = Marker.createRecipe(definition).apply(
   { timeoutMs: 5_000 }
 );
 const editor = new ImageMarkerEditorController(definition);
+const editorProps: ImageMarkerEditorProps = {
+  controller: editor,
+  sourceSize: { width: 1920, height: 1080 },
+  testID: 'consumer-editor',
+  width: 360,
+  height: 240,
+};
+const toolbarProps: ImageMarkerEditorToolbarProps = {
+  controller: editor,
+  testID: 'consumer-toolbar',
+};
 const request: EditorRenderRequest = {
   recipe: editor.exportRecipe(),
   input: { backgroundImage: { src: '/source.png' } },
 };
 void result;
+void ImageMarkerEditor;
+void ImageMarkerEditorToolbar;
+void createCoreEditorAdapter;
+void editorProps;
+void toolbarProps;
 void request;
 void createInvisibleWatermarkRuntime;
 `

--- a/website/src/components/ImageMarkerEditorPlayground.astro
+++ b/website/src/components/ImageMarkerEditorPlayground.astro
@@ -9,7 +9,7 @@ const zh = locale === 'zh-CN';
 const base = import.meta.env.BASE_URL;
 const copy = zh
   ? {
-      eyebrow: '可选包 · Editor 0.0.3',
+      eyebrow: '可选包 · Editor 0.1.0',
       title: '直接操作 Recipe v2',
       intro:
         '这个演示由 Editor controller 驱动：拖动图层、调整缩放和旋转、排序、锁定、撤销，再通过 Core 2.0 渲染真实结果。',
@@ -40,7 +40,7 @@ const copy = zh
       ready: '渲染完成',
     }
   : {
-      eyebrow: 'Optional package · Editor 0.0.3',
+      eyebrow: 'Optional package · Editor 0.1.0',
       title: 'Manipulate Recipe v2 directly',
       intro:
         'This demo is driven by the Editor controller: drag, scale, rotate, reorder, lock, and undo layers, then render a real result through Core 2.0.',

--- a/website/src/components/ImageMarkerPlayground.astro
+++ b/website/src/components/ImageMarkerPlayground.astro
@@ -515,7 +515,7 @@ const invisibleExecutors = ['main', 'worker'].map((value, index) => ({
       tabindex="-1"
       data-workspace-tab="editor"
     >
-      <span>{strings.editorTab} <em>0.0.3</em></span>
+      <span>{strings.editorTab} <em>0.1.0</em></span>
       <small>{strings.editorTabMeta}</small>
     </button>
   </div>

--- a/website/src/content/docs/guides/editor.md
+++ b/website/src/content/docs/guides/editor.md
@@ -1,17 +1,17 @@
 ---
 title: Optional interaction editor
-description: Install and integrate react-native-image-marker-editor 0.0.3 on top of Core 2.
+description: Install and integrate react-native-image-marker-editor 0.1.0 on top of Core 2.
 ---
 
 `react-native-image-marker-editor` is a separate, optional JS/TS package. Its
-first release was `0.0.1`; the current documentation patch is `0.0.3`, and it
+first release was `0.0.1`; the current stabilization release is `0.1.0`, and it
 requires `react-native-image-marker@^2.0.0`.
 Core remains responsible for decode, composition, invisible watermarking, and
 final native encoding.
 
 ```sh
 npm install react-native-image-marker@^2 \
-  react-native-image-marker-editor@0.0.3
+  react-native-image-marker-editor@0.1.0
 ```
 
 ## Create an editor
@@ -67,7 +67,7 @@ dimensions once, then pass that same `sourceSize` to both
 source into its viewport, while bounded previews scale positions, fonts,
 shadows, strokes, backgrounds, tiles, and image layers together.
 
-If `sourceSize` is omitted, Editor 0.0.3 preserves the earlier behavior and
+If `sourceSize` is omitted, Editor 0.1.0 preserves the earlier behavior and
 uses the viewport as the Recipe coordinate space. That is useful for recipes
 created specifically for a fixed viewport, but not for original-resolution
 WYSIWYG export.
@@ -80,11 +80,23 @@ undo, and render without installing anything.
 
 For the native surface, run the repository
 [React Native example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/example)
-and choose **Editor 0.0.3**. It renders `ImageMarkerEditor` and
+and choose **Editor 0.1.0**. It renders `ImageMarkerEditor` and
 `ImageMarkerEditorToolbar`, then exercises both preview and original-resolution
 Core exports.
 
-## 0.0.x scope
+## Migrating from 0.0.x
+
+`0.1.0` is backward compatible with `0.0.3`: no public export was removed or
+renamed. Keep the same `sourceSize` on the surface and adapter request, and keep
+the Core adapter import on its explicit `/core-adapter` subpath. The new
+optional `testID` props expose stable native test identifiers for the canvas,
+layers, toolbar, and toolbar actions.
+
+The package now checks its public runtime/type export list and peer dependency
+ranges in CI. A public API change therefore requires an intentional contract
+update instead of appearing accidentally in a patch.
+
+## 0.1.x scope
 
 - Image and text layers with selection, dragging, pinch scaling, rotation, and
   ordering.
@@ -98,7 +110,7 @@ Core exports.
 - Opt-in Core adapter, so the main editor entry does not force a heavy renderer.
 
 Video, general filters, cloud collaboration, and duplicate native encoding are
-intentionally outside `0.0.x`.
+intentionally outside `0.1.x`.
 
 ## API reference
 

--- a/website/src/content/docs/guides/editor/reference/functions/ImageMarkerEditor.md
+++ b/website/src/content/docs/guides/editor/reference/functions/ImageMarkerEditor.md
@@ -7,7 +7,7 @@ title: "ImageMarkerEditor"
 
 > **ImageMarkerEditor**(`__namedParameters`): `Element`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:395](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L395)
+Defined in: [packages/editor/src/EditorSurface.tsx:400](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L400)
 
 Interactive cross-platform Recipe v2 canvas with drag, pinch, and rotation.
 

--- a/website/src/content/docs/guides/editor/reference/functions/ImageMarkerEditorToolbar.md
+++ b/website/src/content/docs/guides/editor/reference/functions/ImageMarkerEditorToolbar.md
@@ -7,7 +7,7 @@ title: "ImageMarkerEditorToolbar"
 
 > **ImageMarkerEditorToolbar**(`__namedParameters`): `Element`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:477](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L477)
+Defined in: [packages/editor/src/EditorSurface.tsx:486](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L486)
 
 Minimal accessible toolbar; applications may replace it with their design system.
 

--- a/website/src/content/docs/guides/editor/reference/functions/createEditorViewportProjection.md
+++ b/website/src/content/docs/guides/editor/reference/functions/createEditorViewportProjection.md
@@ -7,7 +7,7 @@ title: "createEditorViewportProjection"
 
 > **createEditorViewportProjection**(`source`, `viewport`): [`EditorViewportProjection`](/guides/editor/reference/interfaces/editorviewportprojection/)
 
-Defined in: packages/editor/src/projection.ts:199
+Defined in: [packages/editor/src/projection.ts:199](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L199)
 
 ## Parameters
 

--- a/website/src/content/docs/guides/editor/reference/functions/fitEditorSizeWithinMax.md
+++ b/website/src/content/docs/guides/editor/reference/functions/fitEditorSizeWithinMax.md
@@ -7,7 +7,7 @@ title: "fitEditorSizeWithinMax"
 
 > **fitEditorSizeWithinMax**(`source`, `maxSize`): [`EditorSize`](/guides/editor/reference/interfaces/editorsize/)
 
-Defined in: packages/editor/src/projection.ts:182
+Defined in: [packages/editor/src/projection.ts:182](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L182)
 
 ## Parameters
 

--- a/website/src/content/docs/guides/editor/reference/functions/projectEditorPoint.md
+++ b/website/src/content/docs/guides/editor/reference/functions/projectEditorPoint.md
@@ -7,7 +7,7 @@ title: "projectEditorPoint"
 
 > **projectEditorPoint**(`point`, `projection`): [`EditorPoint`](/guides/editor/reference/interfaces/editorpoint/)
 
-Defined in: packages/editor/src/projection.ts:224
+Defined in: [packages/editor/src/projection.ts:224](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L224)
 
 ## Parameters
 

--- a/website/src/content/docs/guides/editor/reference/functions/projectEditorRecipe.md
+++ b/website/src/content/docs/guides/editor/reference/functions/projectEditorRecipe.md
@@ -7,7 +7,7 @@ title: "projectEditorRecipe"
 
 > **projectEditorRecipe**(`recipe`, `source`, `target`): [`WatermarkRecipeDefinition`](/guides/editor/reference/interfaces/watermarkrecipedefinition/)
 
-Defined in: packages/editor/src/projection.ts:244
+Defined in: [packages/editor/src/projection.ts:244](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L244)
 
 ## Parameters
 

--- a/website/src/content/docs/guides/editor/reference/functions/unprojectEditorPoint.md
+++ b/website/src/content/docs/guides/editor/reference/functions/unprojectEditorPoint.md
@@ -7,7 +7,7 @@ title: "unprojectEditorPoint"
 
 > **unprojectEditorPoint**(`point`, `projection`): [`EditorPoint`](/guides/editor/reference/interfaces/editorpoint/)
 
-Defined in: packages/editor/src/projection.ts:234
+Defined in: [packages/editor/src/projection.ts:234](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L234)
 
 ## Parameters
 

--- a/website/src/content/docs/guides/editor/reference/interfaces/EditorViewportProjection.md
+++ b/website/src/content/docs/guides/editor/reference/interfaces/EditorViewportProjection.md
@@ -5,7 +5,7 @@ prev: false
 title: "EditorViewportProjection"
 ---
 
-Defined in: packages/editor/src/projection.ts:11
+Defined in: [packages/editor/src/projection.ts:11](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L11)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: packages/editor/src/projection.ts:11
 
 > **content**: [`EditorRect`](/guides/editor/reference/interfaces/editorrect/)
 
-Defined in: packages/editor/src/projection.ts:14
+Defined in: [packages/editor/src/projection.ts:14](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L14)
 
 ***
 
@@ -21,7 +21,7 @@ Defined in: packages/editor/src/projection.ts:14
 
 > **scale**: `number`
 
-Defined in: packages/editor/src/projection.ts:15
+Defined in: [packages/editor/src/projection.ts:15](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L15)
 
 ***
 
@@ -29,7 +29,7 @@ Defined in: packages/editor/src/projection.ts:15
 
 > **source**: [`EditorSize`](/guides/editor/reference/interfaces/editorsize/)
 
-Defined in: packages/editor/src/projection.ts:12
+Defined in: [packages/editor/src/projection.ts:12](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L12)
 
 ***
 
@@ -37,4 +37,4 @@ Defined in: packages/editor/src/projection.ts:12
 
 > **viewport**: [`EditorSize`](/guides/editor/reference/interfaces/editorsize/)
 
-Defined in: packages/editor/src/projection.ts:13
+Defined in: [packages/editor/src/projection.ts:13](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/projection.ts#L13)

--- a/website/src/content/docs/guides/editor/reference/interfaces/ImageMarkerEditorProps.md
+++ b/website/src/content/docs/guides/editor/reference/interfaces/ImageMarkerEditorProps.md
@@ -13,7 +13,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:35](https://github.com/JimmyD
 
 > `optional` **background?**: `ReactNode`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:45](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L45)
+Defined in: [packages/editor/src/EditorSurface.tsx:47](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L47)
 
 ***
 
@@ -29,7 +29,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:36](https://github.com/JimmyD
 
 > `optional` **getLayerSize?**: (`layer`) => [`EditorSize`](/guides/editor/reference/interfaces/editorsize/)
 
-Defined in: [packages/editor/src/EditorSurface.tsx:48](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L48)
+Defined in: [packages/editor/src/EditorSurface.tsx:50](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L50)
 
 #### Parameters
 
@@ -55,7 +55,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:38](https://github.com/JimmyD
 
 > `optional` **onStateChange?**: (`state`) => `void`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:54](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L54)
+Defined in: [packages/editor/src/EditorSurface.tsx:56](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L56)
 
 #### Parameters
 
@@ -73,7 +73,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:54](https://github.com/JimmyD
 
 > `optional` **renderLayer?**: (`layer`, `selected`, `context`) => `ReactNode`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:49](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L49)
+Defined in: [packages/editor/src/EditorSurface.tsx:51](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L51)
 
 #### Parameters
 
@@ -99,7 +99,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:49](https://github.com/JimmyD
 
 > `optional` **snapThreshold?**: `number`
 
-Defined in: [packages/editor/src/EditorSurface.tsx:47](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L47)
+Defined in: [packages/editor/src/EditorSurface.tsx:49](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L49)
 
 ***
 
@@ -107,7 +107,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:47](https://github.com/JimmyD
 
 > `optional` **sourceSize?**: [`EditorSize`](/guides/editor/reference/interfaces/editorsize/)
 
-Defined in: [packages/editor/src/EditorSurface.tsx:44](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L44)
+Defined in: [packages/editor/src/EditorSurface.tsx:46](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L46)
 
 Original background dimensions used by Recipe pixel coordinates. When
 omitted, the viewport dimensions remain the coordinate space for backward
@@ -119,7 +119,17 @@ compatibility.
 
 > `optional` **style?**: `StyleProp`\<`ViewStyle`\>
 
-Defined in: [packages/editor/src/EditorSurface.tsx:46](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L46)
+Defined in: [packages/editor/src/EditorSurface.tsx:48](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L48)
+
+***
+
+### testID?
+
+> `optional` **testID?**: `string`
+
+Defined in: [packages/editor/src/EditorSurface.tsx:40](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L40)
+
+Stable identifier for native E2E and application component tests.
 
 ***
 

--- a/website/src/content/docs/guides/editor/reference/interfaces/ImageMarkerEditorToolbarProps.md
+++ b/website/src/content/docs/guides/editor/reference/interfaces/ImageMarkerEditorToolbarProps.md
@@ -5,7 +5,7 @@ prev: false
 title: "ImageMarkerEditorToolbarProps"
 ---
 
-Defined in: [packages/editor/src/EditorSurface.tsx:471](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L471)
+Defined in: [packages/editor/src/EditorSurface.tsx:478](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L478)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [packages/editor/src/EditorSurface.tsx:471](https://github.com/Jimmy
 
 > **controller**: [`ImageMarkerEditorController`](/guides/editor/reference/classes/imagemarkereditorcontroller/)
 
-Defined in: [packages/editor/src/EditorSurface.tsx:472](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L472)
+Defined in: [packages/editor/src/EditorSurface.tsx:479](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L479)
 
 ***
 
@@ -21,4 +21,14 @@ Defined in: [packages/editor/src/EditorSurface.tsx:472](https://github.com/Jimmy
 
 > `optional` **style?**: `StyleProp`\<`ViewStyle`\>
 
-Defined in: [packages/editor/src/EditorSurface.tsx:473](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L473)
+Defined in: [packages/editor/src/EditorSurface.tsx:480](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L480)
+
+***
+
+### testID?
+
+> `optional` **testID?**: `string`
+
+Defined in: [packages/editor/src/EditorSurface.tsx:482](https://github.com/JimmyDaddy/react-native-image-marker/blob/master/packages/editor/src/EditorSurface.tsx#L482)
+
+Stable identifier for native E2E and application component tests.

--- a/website/src/content/docs/sitemap.mdx
+++ b/website/src/content/docs/sitemap.mdx
@@ -28,7 +28,7 @@ Use this page to find the shortest path to the documentation you need.
 - [Output and image quality](/guides/output-and-quality/) — choose a format, quality, and background color.
 - [Performance and job control](/guides/performance-and-jobs/) — bound memory, observe, cancel, and benchmark work.
 - [Invisible trace watermarks](/guides/invisible-watermarks/) — embed and authenticate a short distribution locator.
-- [Optional interaction editor](/guides/editor/) — integrate the separately versioned Editor 0.0.3 package.
+- [Optional interaction editor](/guides/editor/) — integrate the separately versioned Editor 0.1.0 package.
 - [Editor API reference](/guides/editor/reference/) — browse controller methods, components, adapters, and types.
 - [Visual cookbook](/cookbook/) — start from complete examples.
 

--- a/website/src/content/docs/support-policy.md
+++ b/website/src/content/docs/support-policy.md
@@ -12,7 +12,7 @@ critical fixes.
 | Core v2 (`2.0.x`) | Current release          | [v2 documentation](/)              | `npm install react-native-image-marker@latest`       |
 | v1 LTS (`1.12.x`) | Current maintenance line | [v1 documentation](/v1/)           | `npm install react-native-image-marker@1`            |
 | v1.0.0            | Immutable archive        | [v1.0.0 archive](/versions/1.0.0/) | `npm install react-native-image-marker@1.0.0`        |
-| Editor `0.0.x`    | Experimental             | [Editor status](/editor/)          | `npm install react-native-image-marker-editor@0.0.3` |
+| Editor `0.1.x`    | Stabilization release    | [Editor status](/editor/)          | `npm install react-native-image-marker-editor@0.1.0` |
 
 ## v1 LTS commitment
 

--- a/website/src/content/docs/zh-cn/guides/editor.md
+++ b/website/src/content/docs/zh-cn/guides/editor.md
@@ -1,16 +1,16 @@
 ---
 title: 可选交互编辑器
-description: 在 Core 2 上安装并接入 react-native-image-marker-editor 0.0.3。
+description: 在 Core 2 上安装并接入 react-native-image-marker-editor 0.1.0。
 ---
 
 `react-native-image-marker-editor` 是独立、可选的 JS/TS 包。首个版本是
-`0.0.1`，当前文档补丁版本为 `0.0.3`，依赖
+`0.0.1`，当前稳定化版本为 `0.1.0`，依赖
 `react-native-image-marker@^2.0.0`。解码、合成、隐形水印和
 最终原生编码仍由 Core 负责。
 
 ```sh
 npm install react-native-image-marker@^2 \
-  react-native-image-marker-editor@0.0.3
+  react-native-image-marker-editor@0.1.0
 ```
 
 ## 创建编辑器
@@ -65,7 +65,7 @@ Recipe 的数值坐标使用原图像素。图片解码后读取一次尺寸，�
 原图等比投影到 viewport；受限尺寸预览则会一起缩放位置、字体、阴影、描边、
 文字背景、平铺参数和图片图层。
 
-省略 `sourceSize` 时，Editor 0.0.3 会保留旧行为：直接把 viewport 当作 Recipe
+省略 `sourceSize` 时，Editor 0.1.0 会保留旧行为：直接把 viewport 当作 Recipe
 坐标空间。这适合只面向固定 viewport 的 Recipe，但不适合需要原分辨率
 WYSIWYG 导出的场景。
 
@@ -77,10 +77,20 @@ undo/redo 与 Core 渲染。
 
 原生端可运行仓库中的
 [React Native example](https://github.com/JimmyDaddy/react-native-image-marker/tree/master/example)，
-选择 **Editor 0.0.3**。该页面会渲染 `ImageMarkerEditor` 与
+选择 **Editor 0.1.0**。该页面会渲染 `ImageMarkerEditor` 与
 `ImageMarkerEditorToolbar`，并验证预览和原分辨率 Core 导出。
 
-## 0.0.x 范围
+## 从 0.0.x 迁移
+
+`0.1.0` 与 `0.0.3` 保持向后兼容，没有移除或重命名公共导出。继续给交互画布
+和 adapter 请求传入同一个 `sourceSize`，并从独立的 `/core-adapter` 子路径导入
+Core adapter 即可。新增的可选 `testID` props 会为画布、图层、工具栏及其操作
+暴露稳定的原生测试标识。
+
+包内现在会在 CI 中校验公共运行时/类型导出列表和 peer dependency 范围，因此
+公共 API 变化必须显式更新契约，不会意外混入补丁版本。
+
+## 0.1.x 范围
 
 - 图片和文字图层，以及选择、拖动、双指缩放、旋转和排序。
 - 显隐与锁定；锁定图层不能修改、删除或排序。
@@ -91,7 +101,7 @@ undo/redo 与 Core 渲染。
 - 可见、隐形水印和可选 C2PA 导出选项。
 - 按需引入 Core adapter，主入口不强制带入较重 renderer。
 
-视频、通用滤镜、云端协作以及重复的原生编码逻辑不进入 `0.0.x`。
+视频、通用滤镜、云端协作以及重复的原生编码逻辑不进入 `0.1.x`。
 
 ## API 参考
 

--- a/website/src/content/docs/zh-cn/sitemap.mdx
+++ b/website/src/content/docs/zh-cn/sitemap.mdx
@@ -28,7 +28,7 @@ import ToolSitemap from '../../../components/tools/ToolSitemap.astro';
 - [输出与图像质量](/zh-cn/guides/output-and-quality/) — 选择格式、质量和背景色。
 - [性能与任务控制](/zh-cn/guides/performance-and-jobs/) — 限制内存、观察、取消并测量任务。
 - [隐形追踪水印](/zh-cn/guides/invisible-watermarks/) — 嵌入并验证短分发 locator。
-- [可选交互编辑器](/zh-cn/guides/editor/) — 接入独立发布的 Editor 0.0.3 包。
+- [可选交互编辑器](/zh-cn/guides/editor/) — 接入独立发布的 Editor 0.1.0 包。
 - [Editor API 参考](/zh-cn/guides/editor/reference/) — 查看 controller、组件、adapter 与类型。
 - [可视化示例](/zh-cn/cookbook/) — 从完整示例开始使用。
 

--- a/website/src/content/docs/zh-cn/support-policy.md
+++ b/website/src/content/docs/zh-cn/support-policy.md
@@ -11,7 +11,7 @@ React Native Image Marker 使用彼此独立的发布和文档线路，让现有
 | Core v2（`2.0.x`） | 当前正式版本 | [v2 文档](/zh-cn/)              | `npm install react-native-image-marker@latest`       |
 | v1 LTS（`1.12.x`） | 当前维护线   | [v1 文档](/v1/zh-cn/)           | `npm install react-native-image-marker@1`            |
 | v1.0.0             | 不可变归档   | [v1.0.0 归档](/versions/1.0.0/) | `npm install react-native-image-marker@1.0.0`        |
-| Editor `0.0.x`     | 实验性       | [Editor 状态](/editor/)         | `npm install react-native-image-marker-editor@0.0.3` |
+| Editor `0.1.x`     | 稳定化版本   | [Editor 状态](/editor/)         | `npm install react-native-image-marker-editor@0.1.0` |
 
 ## v1 LTS 承诺
 

--- a/website/src/data/tools.mjs
+++ b/website/src/data/tools.mjs
@@ -72,7 +72,7 @@ export const toolGroups = [
           en: 'Drag, scale, rotate, and reorder layers, then render Recipe v2 through Core.',
           zh: '拖动、缩放、旋转和排序图层，再通过 Core 渲染 Recipe v2。',
         },
-        badge: { en: 'Editor 0.0.3', zh: 'Editor 0.0.3' },
+        badge: { en: 'Editor 0.1.0', zh: 'Editor 0.1.0' },
       },
     ],
   },


### PR DESCRIPTION
## Summary

- stabilize the optional Editor public API at 0.1.0 with additive native test identifiers and an explicit checked export contract
- add React component coverage plus Android/iOS native E2E for add, undo, Core preview, and original-resolution export
- update the package README, changelog, generated API reference, website labels, support policy, migration notes, and bug template

## Verification

- Core: 126 Jest tests
- Editor: 16 Jest tests
- typecheck, lint, packed consumer, and Editor API contract
- Android instrumentation test compilation
- iOS simulator Editor workflow E2E
- website build and all smoke suites

## Release

After CI and merge, publish react-native-image-marker-editor@0.1.0. Core remains at 2.0.0.