### PR TITLE
chore(release): sync Editor 0.1.0 to release/2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible problem on iOS, Android, Expo, or Web.
+description: Report a reproducible Core 2 or optional Editor problem.
 title: '[Bug]: '
 labels: [bug]
 body:
@@ -7,6 +7,17 @@ body:
     attributes:
       value: |
         Please include a minimal reproduction. Image rendering bugs are difficult to diagnose from screenshots alone.
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package
+      options:
+        - react-native-image-marker (Core)
+        - react-native-image-marker-editor (optional Editor)
+        - Both Core and Editor
+        - Not sure
+    validations:
+      required: true
   - type: dropdown
     id: platform
     attributes:
@@ -23,8 +34,8 @@ body:
     id: versions
     attributes:
       label: Versions
-      description: Include react-native-image-marker, React Native, Expo (if used), and browser versions.
-      placeholder: react-native-image-marker 1.5.0; React Native 0.86.0; Expo 57.0.7
+      description: Include Core, optional Editor, React Native, Expo (if used), and browser versions.
+      placeholder: react-native-image-marker 2.0.0; react-native-image-marker-editor 0.1.0; React Native 0.86.0
     validations:
       required: true
   - type: dropdown
@@ -64,6 +75,11 @@ body:
     attributes:
       label: Image details
       description: Source type, dimensions, format, orientation, transparency, and whether the URL permits CORS.
+  - type: textarea
+    id: recipe_details
+    attributes:
+      label: Recipe / Editor details
+      description: If applicable, include the minimal Recipe v2, sourceSize, preview maxSize, custom renderLayer behavior, and whether the issue appears in the editor canvas, Core preview, original export, or all three.
   - type: textarea
     id: invisible_details
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
                   "android/**",
                   "cpp/**",
                   "src/**",
+                  "packages/editor/**",
                   "package.json",
                   "package-lock.json",
                   "app.plugin.js",
@@ -105,6 +106,7 @@ jobs:
                   "ios/**",
                   "cpp/**",
                   "src/**",
+                  "packages/editor/**",
                   "package.json",
                   "package-lock.json",
                   "app.plugin.js",
@@ -352,6 +354,7 @@ jobs:
           npm run prepack
           npm run test:editor
           npm run build:editor
+          npm run check:editor-api
 
       - name: Verify packed Core and Editor consumers
         run: node scripts/verify-package-consumer.mjs
@@ -1056,6 +1059,7 @@ jobs:
             -destination 'id=${{ steps.ios-simulator.outputs.id }}' \
             -parallel-testing-enabled NO \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testApp \
+            -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testEditorUndoPreviewAndOriginalExportRunThroughCore \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTextAnchorOffsetFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testMixedWatermarkFeatureProducesPreview \
             -only-testing:ImageMarkerExampleUITests/ImageMarkerExampleUITests/testTiledTextFeatureProducesPreview \

--- a/README.MD
+++ b/README.MD
@@ -269,13 +269,13 @@ Browser Canvas and native graphics stacks share the API and positioning model bu
 ## Optional interaction editor
 
 The independently versioned
-`react-native-image-marker-editor@0.0.3` package provides Recipe v2 layer
+`react-native-image-marker-editor@0.1.0` package provides Recipe v2 layer
 selection, drag/scale/rotate/reorder, visibility and locking, snapping,
 undo/redo, accessible keyboard controls, preview rendering, and final export.
 It requires Core `^2.0.0` and delegates image processing back to Core.
 
 ```sh
-npm install react-native-image-marker-editor@0.0.3
+npm install react-native-image-marker-editor@0.1.0
 ```
 
 Import `react-native-image-marker-editor/core-adapter` only when the editor

--- a/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
+++ b/example/android/app/src/androidTest/java/com/imagemarkerexample/ImageMarkerJsE2ETest.kt
@@ -18,6 +18,7 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.anything
+import org.hamcrest.Matchers.startsWith
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Rule
 import org.junit.Test
@@ -67,6 +68,37 @@ class ImageMarkerJsE2ETest {
     waitForView(withReactTestId("watermark-orientation-validated"), 5_000)
   }
 
+  @Test
+  fun editorUndoAndPreviewRunThroughCore() {
+    waitForView(withText("Image Marker Lab"), 90_000)
+    waitForView(withReactTestId("surface-editor"), 5_000)
+    onView(withReactTestId("surface-editor")).perform(click())
+
+    waitForView(withReactTestId("editor-canvas"), 5_000)
+    waitForView(withReactTestId("editor-layer-editor-title"), 5_000)
+    waitForView(withReactTestId("editor-layer-editor-logo"), 5_000)
+
+    onView(withReactTestId("editor-add-text")).perform(click())
+    waitForView(withReactTestId("editor-layer-layer-editor-3"), 5_000)
+    onView(withReactTestId("editor-toolbar-undo")).perform(click())
+
+    onView(withReactTestId("editor-preview")).perform(click())
+    waitForView(withReactTestId("editor-result-image"), 60_000)
+    waitForView(withText(startsWith("Preview ready")), 5_000)
+  }
+
+  @Test
+  fun editorOriginalExportRunsThroughCore() {
+    waitForView(withText("Image Marker Lab"), 90_000)
+    waitForView(withReactTestId("surface-editor"), 5_000)
+    onView(withReactTestId("surface-editor")).perform(click())
+
+    waitForView(withReactTestId("editor-canvas"), 5_000)
+    onView(withReactTestId("editor-export")).perform(click())
+    waitForView(withReactTestId("editor-result-image"), 60_000)
+    waitForView(withText(startsWith("Export ready")), 60_000)
+  }
+
   private fun fullScroll(direction: Int): ViewAction {
     return object : ViewAction {
       override fun getConstraints(): Matcher<View> = isAssignableFrom(ScrollView::class.java)
@@ -94,7 +126,7 @@ class ImageMarkerJsE2ETest {
       }
       Thread.sleep(250)
     }
-    throw AssertionError("Timed out waiting for view", lastFailure)
+    throw AssertionError("Timed out waiting for view $matcher", lastFailure)
   }
 
   private fun withReactTestId(testId: String): Matcher<View> {

--- a/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
+++ b/example/ios/ImageMarkerExampleUITests/ImageMarkerExampleUITests.swift
@@ -202,6 +202,43 @@ final class ImageMarkerExampleUITests: XCTestCase {
     XCTAssertTrue(featureButton(in: app, identifier: "feature-watermark-orientation", label: "Watermark orientation").exists)
   }
 
+  func testEditorUndoPreviewAndOriginalExportRunThroughCore() throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    XCTAssertTrue(app.staticTexts["Image Marker Lab"].waitForExistence(timeout: 45))
+    let editorTab = app.descendants(matching: .any)["surface-editor"]
+    XCTAssertTrue(editorTab.waitForExistence(timeout: 5))
+    editorTab.tap()
+
+    XCTAssertTrue(app.descendants(matching: .any)["editor-canvas"].waitForExistence(timeout: 5))
+    XCTAssertTrue(app.descendants(matching: .any)["editor-layer-editor-title"].exists)
+    XCTAssertTrue(app.descendants(matching: .any)["editor-layer-editor-logo"].exists)
+
+    app.descendants(matching: .any)["editor-add-text"].tap()
+    let addedLayer = app.descendants(matching: .any)["editor-layer-layer-editor-3"]
+    XCTAssertTrue(addedLayer.waitForExistence(timeout: 5))
+    app.descendants(matching: .any)["editor-toolbar-undo"].tap()
+    XCTAssertFalse(addedLayer.waitForExistence(timeout: 1))
+
+    app.descendants(matching: .any)["editor-preview"].tap()
+    XCTAssertTrue(app.descendants(matching: .any)["editor-result-image"].waitForExistence(timeout: 30))
+    let previewReady = app.descendants(matching: .any).matching(
+      NSPredicate(format: "identifier == %@ AND label BEGINSWITH %@", "editor-status", "Preview ready")
+    ).firstMatch
+    XCTAssertTrue(previewReady.waitForExistence(timeout: 5))
+
+    let export = app.descendants(matching: .any)["editor-export"]
+    if !export.isHittable {
+      app.scrollViews.firstMatch.swipeDown()
+    }
+    export.tap()
+    let exportReady = app.descendants(matching: .any).matching(
+      NSPredicate(format: "identifier == %@ AND label BEGINSWITH %@", "editor-status", "Export ready")
+    ).firstMatch
+    XCTAssertTrue(exportReady.waitForExistence(timeout: 30))
+  }
+
   func testTextAnchorOffsetFeatureProducesPreview() throws {
     let app = XCUIApplication()
     app.launch()

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -67,6 +67,7 @@ function App() {
             accessibilityState={{ selected: surface === value }}
             key={value}
             onPress={() => setSurface(value)}
+            testID={`surface-${value}`}
             style={[
               styles.surfaceTab,
               surface === value && styles.surfaceTabSelected,
@@ -78,7 +79,7 @@ function App() {
                 surface === value && styles.surfaceTabTextSelected,
               ]}
             >
-              {value === 'core' ? 'Core lab' : 'Editor 0.0.3'}
+              {value === 'core' ? 'Core lab' : 'Editor 0.1.0'}
             </Text>
           </Pressable>
         ))}

--- a/example/src/EditorExample.tsx
+++ b/example/src/EditorExample.tsx
@@ -145,7 +145,7 @@ export default function EditorExample() {
     >
       <View style={styles.heading}>
         <View>
-          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.0.3</Text>
+          <Text style={styles.eyebrow}>OPTIONAL PACKAGE · 0.1.0</Text>
           <Text style={styles.title}>Interactive Recipe v2 editor</Text>
         </View>
         <Text style={styles.subtitle}>
@@ -159,6 +159,7 @@ export default function EditorExample() {
           accessibilityRole="button"
           onPress={addText}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-add-text"
         >
           <Text style={styles.actionText}>Add text</Text>
         </Pressable>
@@ -166,6 +167,7 @@ export default function EditorExample() {
           accessibilityRole="button"
           onPress={addLogo}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-add-image"
         >
           <Text style={styles.actionText}>Add image</Text>
         </Pressable>
@@ -174,6 +176,7 @@ export default function EditorExample() {
           disabled={busy}
           onPress={() => render(false)}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-preview"
         >
           <Text style={styles.actionText}>Preview</Text>
         </Pressable>
@@ -182,12 +185,16 @@ export default function EditorExample() {
           disabled={busy}
           onPress={() => render(true)}
           style={({ pressed }) => actionStyle(pressed)}
+          testID="editor-export"
         >
           <Text style={styles.actionText}>Export original</Text>
         </Pressable>
       </View>
 
-      <ImageMarkerEditorToolbar controller={controller} />
+      <ImageMarkerEditorToolbar
+        controller={controller}
+        testID="editor-toolbar"
+      />
       <View style={styles.canvasFrame}>
         <ImageMarkerEditor
           background={
@@ -203,13 +210,18 @@ export default function EditorExample() {
           snapThreshold={8}
           sourceSize={backgroundSize}
           style={styles.canvas}
+          testID="editor"
           width={canvasWidth}
         />
       </View>
 
       <View style={styles.statusRow}>
         {busy && <ActivityIndicator color="#5271FF" />}
-        <Text accessibilityLiveRegion="polite" style={styles.status}>
+        <Text
+          accessibilityLiveRegion="polite"
+          style={styles.status}
+          testID="editor-status"
+        >
           {status}
         </Text>
       </View>
@@ -225,13 +237,14 @@ export default function EditorExample() {
               styles.result,
               { width: canvasWidth, height: canvasHeight },
             ]}
+            testID="editor-result-image"
           />
         </View>
       )}
 
       <View style={styles.recipeCard}>
         <Text style={styles.sectionTitle}>Live Recipe v2</Text>
-        <Text selectable style={styles.recipe}>
+        <Text selectable style={styles.recipe} testID="editor-recipe">
           {JSON.stringify(state.recipe, null, 2)}
         </Text>
       </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/jest": "^28.1.2",
         "@types/react": "~18.2.45",
         "@types/react-native": "0.70.0",
+        "@types/react-test-renderer": "^18.0.7",
         "commitlint": "^21.2.1",
         "conventional-changelog-conventionalcommits": "9.3.1",
         "del-cli": "^5.0.0",
@@ -39,6 +40,7 @@
         "react": "18.2.0",
         "react-native": "0.73.3",
         "react-native-builder-bob": "^0.43.0",
+        "react-test-renderer": "^18.2.0",
         "release-it": "^20.2.1",
         "typescript": "^5.9.3"
       },
@@ -5164,6 +5166,16 @@
     },
     "node_modules/@types/react-native": {
       "version": "0.70.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.7.tgz",
+      "integrity": "sha512-1+ANPOWc6rB3IkSnElhjv6VLlKg2dSv/OWClUyZimbLsQyBn8Js9Vtdsi3UICJ2rIQ3k2la06dkB+C92QfhKmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13966,6 +13978,31 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
@@ -16287,7 +16324,7 @@
     },
     "packages/editor": {
       "name": "react-native-image-marker-editor",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "react-native-image-marker": "file:../.."

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "build:worker": "node scripts/build-invisible-worker.mjs",
     "prepack": "bob build && node scripts/fix-esm-imports.mjs lib/module lib/typescript/module && npm run build:worker",
     "build:editor": "npm run build --workspace react-native-image-marker-editor",
+    "check:editor-api": "npm run check:api --workspace react-native-image-marker-editor",
     "verify:consumer": "npm run prepack && npm run build:editor && node scripts/verify-package-consumer.mjs",
     "check:release-notes": "node scripts/check-release-notes.mjs",
     "release": "release-it",
@@ -129,6 +130,7 @@
     "@types/jest": "^28.1.2",
     "@types/react": "~18.2.45",
     "@types/react-native": "0.70.0",
+    "@types/react-test-renderer": "^18.0.7",
     "commitlint": "^21.2.1",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "del-cli": "^5.0.0",
@@ -146,6 +148,7 @@
     "react": "18.2.0",
     "react-native": "0.73.3",
     "react-native-builder-bob": "^0.43.0",
+    "react-test-renderer": "^18.2.0",
     "release-it": "^20.2.1",
     "typescript": "^5.9.3"
   },

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0 (2026-07-29)
+
+- Stabilized the public Editor and `core-adapter` export contract while keeping
+  `react-native-image-marker@^2.0.0` as the rendering peer.
+- Added optional `testID` props with stable canvas, layer, toolbar, and action
+  identifiers for application tests and native automation.
+- Kept individual layers exposed to assistive technology instead of grouping
+  them behind one parent canvas accessibility element.
+- Added React component coverage plus iOS and Android end-to-end workflows for
+  layer creation, undo, Core preview, and original-resolution export.
+- Added a checked API contract, packed-consumer type coverage, and migration
+  notes for applications upgrading from `0.0.x`.
+- Kept the Recipe v2, controller, projection, and adapter APIs backward
+  compatible with `0.0.3`; no application code change is required.
+
 ## 0.0.3 (2026-07-29)
 
 - Added an explicit `sourceSize` coordinate space so the interactive surface,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -45,7 +45,7 @@ The main entry owns only UI and Recipe state. Import the opt-in `core-adapter`
 entry to render previews or final output through Core, or inject your own
 adapter for a server renderer.
 
-Run the repository's React Native example and choose **Editor 0.0.3**, or use
+Run the repository's React Native example and choose **Editor 0.1.0**, or use
 the [browser playground](https://image-marker.corerobin.com/playground/?workflow=editor#editor-playground)
 to exercise drag, scale, rotation, ordering, locks, undo/redo, and a real Core
 render.
@@ -54,3 +54,20 @@ Read the [integration guide](https://image-marker.corerobin.com/guides/editor/)
 or browse the
 [generated API reference](https://image-marker.corerobin.com/guides/editor/reference/)
 for controller methods, component props, adapters, state, and export types.
+
+## Migrating from 0.0.x
+
+`0.1.0` does not remove or rename any `0.0.3` API. Existing integrations can
+upgrade the package version without changing application code.
+
+- Keep passing the original decoded image dimensions as `sourceSize` to both
+  `ImageMarkerEditor` and the Core adapter for preview/export parity.
+- Custom `renderLayer` implementations continue to receive source dimensions,
+  viewport dimensions, and the projection scale.
+- The Core adapter remains opt-in through
+  `react-native-image-marker-editor/core-adapter`.
+- Optional `testID` props now expose stable canvas, layer, toolbar, and action
+  identifiers for native E2E or application component tests.
+
+The checked `api-contract.json` file records the supported main-entry and
+subpath exports so accidental public API drift fails CI.

--- a/packages/editor/api-contract.json
+++ b/packages/editor/api-contract.json
@@ -1,0 +1,56 @@
+{
+  "packageExports": [".", "./core-adapter", "./package.json"],
+  "peerDependencies": {
+    "react": ">=18",
+    "react-native": ">=0.73",
+    "react-native-image-marker": "^2.0.0"
+  },
+  "entries": {
+    ".": {
+      "source": "src/index.ts",
+      "values": [
+        "ImageMarkerEditor",
+        "ImageMarkerEditorController",
+        "ImageMarkerEditorToolbar",
+        "angle",
+        "createEditorViewportProjection",
+        "distance",
+        "fitEditorSizeWithinMax",
+        "normalizeSafeArea",
+        "projectEditorPoint",
+        "projectEditorRecipe",
+        "snapLayerPosition",
+        "unprojectEditorPoint"
+      ],
+      "types": [
+        "EditorContentCredentialsExport",
+        "EditorExportOptions",
+        "EditorExportResult",
+        "EditorInvisibleExport",
+        "EditorKeyCommand",
+        "EditorLayerRenderContext",
+        "EditorPoint",
+        "EditorRect",
+        "EditorRenderRequest",
+        "EditorSafeArea",
+        "EditorSize",
+        "EditorSnapContext",
+        "EditorSnapGuide",
+        "EditorState",
+        "EditorViewportProjection",
+        "ImageMarkerEditorProps",
+        "ImageMarkerEditorRenderAdapter",
+        "ImageMarkerEditorToolbarProps",
+        "WatermarkRecipeDefinition",
+        "WatermarkRecipeDefinitionLayer",
+        "WatermarkRecipeDocument",
+        "WatermarkRecipeInput"
+      ]
+    },
+    "./core-adapter": {
+      "source": "src/core-adapter.ts",
+      "values": ["createCoreEditorAdapter"],
+      "types": []
+    }
+  }
+}

--- a/packages/editor/jest.config.js
+++ b/packages/editor/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'react-native',
   rootDir: '../..',
-  testMatch: ['<rootDir>/packages/editor/src/__tests__/**/*.test.ts'],
+  testMatch: ['<rootDir>/packages/editor/src/__tests__/**/*.test.(ts|tsx)'],
   moduleNameMapper: {
     '^react-native-image-marker$': '<rootDir>/src/index.ts',
   },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker-editor",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Optional interactive Recipe v2 editor for react-native-image-marker",
   "license": "MIT",
   "homepage": "https://image-marker.corerobin.com/guides/editor/",
@@ -28,6 +28,7 @@
   "files": [
     "src",
     "!src/__tests__",
+    "api-contract.json",
     "lib",
     "README.md",
     "CHANGELOG.md"
@@ -59,6 +60,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.module.json && node ../../scripts/fix-esm-imports.mjs lib/module && tsc -p tsconfig.commonjs.json",
+    "check:api": "node ../../scripts/verify-editor-api-contract.mjs",
     "test": "jest --config jest.config.js --runInBand",
     "prepack": "npm run build"
   },

--- a/packages/editor/src/EditorSurface.tsx
+++ b/packages/editor/src/EditorSurface.tsx
@@ -36,6 +36,8 @@ export interface ImageMarkerEditorProps {
   controller: ImageMarkerEditorController;
   width: number;
   height: number;
+  /** Stable identifier for native E2E and application component tests. */
+  testID?: string;
   /**
    * Original background dimensions used by Recipe pixel coordinates. When
    * omitted, the viewport dimensions remain the coordinate space for backward
@@ -215,6 +217,7 @@ interface EditorLayerProps {
   snapThreshold?: number;
   size: EditorSize;
   renderLayer?: ImageMarkerEditorProps['renderLayer'];
+  testID: string;
 }
 
 function EditorLayer({
@@ -227,6 +230,7 @@ function EditorLayer({
   snapThreshold,
   size,
   renderLayer,
+  testID,
 }: EditorLayerProps) {
   const baseline = React.useRef<LayerGestureBaseline>();
   const start = React.useMemo(
@@ -331,6 +335,7 @@ function EditorLayer({
         { name: 'increment', label: 'Increase layer size' },
         { name: 'decrement', label: 'Decrease layer size' },
       ]}
+      testID={`${testID}-layer-${layer.id}`}
       onAccessibilityAction={(event) => {
         if (layer.locked) return;
         if (event.nativeEvent.actionName === 'activate') {
@@ -396,6 +401,7 @@ export function ImageMarkerEditor({
   controller,
   width,
   height,
+  testID = 'image-marker-editor',
   sourceSize,
   background,
   style,
@@ -424,8 +430,8 @@ export function ImageMarkerEditor({
 
   return (
     <View
-      accessible
-      accessibilityLabel="Image marker editor canvas"
+      accessible={false}
+      testID={`${testID}-canvas`}
       style={[styles.canvas, { width, height }, style]}
       {...({ onKeyDown: handleKeyDown } as object)}
     >
@@ -453,6 +459,7 @@ export function ImageMarkerEditor({
             sourceCanvas={sourceCanvas}
             viewportScale={projection.scale}
             viewportSize={projection.content}
+            testID={testID}
           />
         ))}
         {state.snapGuides.map((guide, index) => (
@@ -471,12 +478,15 @@ export function ImageMarkerEditor({
 export interface ImageMarkerEditorToolbarProps {
   controller: ImageMarkerEditorController;
   style?: StyleProp<ViewStyle>;
+  /** Stable identifier for native E2E and application component tests. */
+  testID?: string;
 }
 
 /** Minimal accessible toolbar; applications may replace it with their design system. */
 export function ImageMarkerEditorToolbar({
   controller,
   style,
+  testID = 'image-marker-editor-toolbar',
 }: ImageMarkerEditorToolbarProps) {
   const state = useEditorState(controller);
   const selected = state.recipe.layers.find(
@@ -484,16 +494,19 @@ export function ImageMarkerEditorToolbar({
   );
   const actions = [
     {
+      key: 'undo',
       label: 'Undo',
       disabled: !state.canUndo,
       action: () => controller.undo(),
     },
     {
+      key: 'redo',
       label: 'Redo',
       disabled: !state.canRedo,
       action: () => controller.redo(),
     },
     {
+      key: 'visibility',
       label: selected?.visible === false ? 'Show' : 'Hide',
       disabled: !selected || selected.locked,
       action: () =>
@@ -501,26 +514,33 @@ export function ImageMarkerEditorToolbar({
         controller.setLayerVisible(selected.id, selected.visible === false),
     },
     {
+      key: 'lock',
       label: selected?.locked ? 'Unlock' : 'Lock',
       disabled: !selected,
       action: () =>
         selected && controller.setLayerLocked(selected.id, !selected.locked),
     },
     {
+      key: 'delete',
       label: 'Delete',
       disabled: !selected || selected.locked,
       action: () => selected && controller.removeLayer(selected.id),
     },
   ];
   return (
-    <View accessibilityLabel="Editor actions" style={[styles.toolbar, style]}>
+    <View
+      accessibilityLabel="Editor actions"
+      style={[styles.toolbar, style]}
+      testID={testID}
+    >
       {actions.map((action) => (
         <Pressable
           accessibilityRole="button"
           accessibilityState={{ disabled: Boolean(action.disabled) }}
           disabled={Boolean(action.disabled)}
-          key={action.label}
+          key={action.key}
           onPress={action.action}
+          testID={`${testID}-${action.key}`}
           style={({ pressed }) => [
             styles.toolButton,
             pressed && styles.toolButtonPressed,

--- a/packages/editor/src/__tests__/EditorSurface.test.tsx
+++ b/packages/editor/src/__tests__/EditorSurface.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import {
+  ImageMarkerEditor,
+  ImageMarkerEditorToolbar,
+  type EditorLayerRenderContext,
+} from '../EditorSurface';
+import { ImageMarkerEditorController } from '../controller';
+
+function createController() {
+  return new ImageMarkerEditorController({
+    schemaVersion: 2,
+    layers: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'text',
+        text: 'Hello',
+        position: { X: 100, Y: 60 },
+        style: { fontSize: 40 },
+      },
+    ],
+    output: { saveFormat: 'png' },
+  });
+}
+
+describe('ImageMarkerEditor components', () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    renderer?.unmount();
+    renderer = undefined;
+  });
+
+  it('publishes stable native test identifiers and projection context', () => {
+    const controller = createController();
+    const renderLayer = jest.fn(
+      (
+        _layer: unknown,
+        _selected: boolean,
+        context: EditorLayerRenderContext
+      ) => <>{`${context.sourceSize.width}:${context.viewportSize.width}`}</>
+    );
+
+    act(() => {
+      renderer = create(
+        <ImageMarkerEditor
+          controller={controller}
+          getLayerSize={() => ({ width: 200, height: 80 })}
+          height={300}
+          renderLayer={renderLayer}
+          sourceSize={{ width: 1000, height: 500 }}
+          testID="campaign-editor"
+          width={400}
+        />
+      );
+    });
+
+    expect(
+      renderer!.root.findByProps({ testID: 'campaign-editor-canvas' }).props
+        .accessible
+    ).toBe(false);
+    expect(
+      renderer!.root.findByProps({
+        testID: 'campaign-editor-layer-title',
+      })
+    ).toBeTruthy();
+    expect(renderLayer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'title' }),
+      false,
+      expect.objectContaining({
+        sourceSize: { width: 1000, height: 500 },
+        scale: 0.4,
+      })
+    );
+  });
+
+  it('connects accessible layer and toolbar actions to controller history', () => {
+    const controller = createController();
+    controller.selectLayer('title');
+
+    act(() => {
+      renderer = create(
+        <>
+          <ImageMarkerEditor
+            controller={controller}
+            height={250}
+            testID="editor"
+            width={500}
+          />
+          <ImageMarkerEditorToolbar controller={controller} testID="toolbar" />
+        </>
+      );
+    });
+
+    const layer = renderer!.root.findByProps({
+      testID: 'editor-layer-title',
+    });
+    act(() => {
+      layer.props.onAccessibilityAction({
+        nativeEvent: { actionName: 'increment' },
+      });
+    });
+    const fontSize = controller.getState().recipe.layers[0]?.style?.fontSize;
+    expect(fontSize).toBeCloseTo(40.7);
+
+    act(() => {
+      renderer!.root
+        .findByProps({ testID: 'toolbar-visibility' })
+        .props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.visible).toBe(false);
+
+    act(() => {
+      renderer!.root.findByProps({ testID: 'toolbar-undo' }).props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.visible).toBeUndefined();
+
+    act(() => {
+      renderer!.root.findByProps({ testID: 'toolbar-lock' }).props.onPress();
+    });
+    expect(controller.getState().recipe.layers[0]?.locked).toBe(true);
+    expect(
+      renderer!.root.findByProps({ testID: 'toolbar-delete' }).props.disabled
+    ).toBe(true);
+  });
+});

--- a/scripts/verify-editor-api-contract.mjs
+++ b/scripts/verify-editor-api-contract.mjs
@@ -1,0 +1,92 @@
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const editorRoot = join(repositoryRoot, 'packages/editor');
+const contract = JSON.parse(
+  await readFile(join(editorRoot, 'api-contract.json'), 'utf8')
+);
+const manifest = JSON.parse(
+  await readFile(join(editorRoot, 'package.json'), 'utf8')
+);
+
+function assertEqual(label, actual, expected) {
+  const normalizedActual = [...actual].sort();
+  const normalizedExpected = [...expected].sort();
+  if (
+    normalizedActual.length !== normalizedExpected.length ||
+    normalizedActual.some((value, index) => value !== normalizedExpected[index])
+  ) {
+    throw new Error(
+      `${label} changed.\nExpected: ${normalizedExpected.join(
+        ', '
+      )}\nActual:   ${normalizedActual.join(', ')}`
+    );
+  }
+}
+
+assertEqual(
+  'Editor package export map',
+  Object.keys(manifest.exports ?? {}),
+  contract.packageExports
+);
+
+for (const [name, range] of Object.entries(contract.peerDependencies)) {
+  if (manifest.peerDependencies?.[name] !== range) {
+    throw new Error(
+      `Editor peer dependency ${name} must remain ${range}; received ${
+        manifest.peerDependencies?.[name] ?? 'missing'
+      }.`
+    );
+  }
+}
+
+const rootNames = Object.values(contract.entries).map(({ source }) =>
+  join(editorRoot, source)
+);
+const program = ts.createProgram(rootNames, {
+  jsx: ts.JsxEmit.ReactJSX,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  skipLibCheck: true,
+  target: ts.ScriptTarget.ESNext,
+});
+const checker = program.getTypeChecker();
+
+for (const [subpath, entry] of Object.entries(contract.entries)) {
+  const filename = join(editorRoot, entry.source);
+  const sourceFile = program.getSourceFile(filename);
+  const moduleSymbol = sourceFile && checker.getSymbolAtLocation(sourceFile);
+  if (!sourceFile || !moduleSymbol) {
+    throw new Error(`Unable to inspect Editor API source ${entry.source}.`);
+  }
+
+  const values = [];
+  const types = [];
+  for (const exported of checker.getExportsOfModule(moduleSymbol)) {
+    const target =
+      exported.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(exported)
+        : exported;
+    if (target.flags & ts.SymbolFlags.Value) {
+      values.push(exported.name);
+    } else {
+      types.push(exported.name);
+    }
+  }
+
+  assertEqual(`${subpath} runtime exports`, values, entry.values);
+  assertEqual(`${subpath} type exports`, types, entry.types);
+}
+
+await Promise.all([
+  access(join(editorRoot, 'lib/module/index.d.ts')),
+  access(join(editorRoot, 'lib/module/core-adapter.d.ts')),
+  access(join(editorRoot, 'lib/commonjs/index.js')),
+  access(join(editorRoot, 'lib/commonjs/core-adapter.js')),
+]);
+
+process.stdout.write(
+  'Verified Editor export map, peer ranges, runtime/type API contract, and build artifacts.\n'
+);

--- a/scripts/verify-package-consumer.mjs
+++ b/scripts/verify-package-consumer.mjs
@@ -137,9 +137,14 @@ try {
   type WatermarkRecipeDefinition,
 } from 'react-native-image-marker';
 import {
+  ImageMarkerEditor,
   ImageMarkerEditorController,
+  ImageMarkerEditorToolbar,
+  type ImageMarkerEditorProps,
+  type ImageMarkerEditorToolbarProps,
   type EditorRenderRequest,
 } from 'react-native-image-marker-editor';
+import { createCoreEditorAdapter } from 'react-native-image-marker-editor/core-adapter';
 import { createInvisibleWatermarkRuntime } from 'react-native-image-marker/trace-runtime';
 
 const definition: WatermarkRecipeDefinition = {
@@ -152,11 +157,27 @@ const result: Promise<MarkerResult> = Marker.createRecipe(definition).apply(
   { timeoutMs: 5_000 }
 );
 const editor = new ImageMarkerEditorController(definition);
+const editorProps: ImageMarkerEditorProps = {
+  controller: editor,
+  sourceSize: { width: 1920, height: 1080 },
+  testID: 'consumer-editor',
+  width: 360,
+  height: 240,
+};
+const toolbarProps: ImageMarkerEditorToolbarProps = {
+  controller: editor,
+  testID: 'consumer-toolbar',
+};
 const request: EditorRenderRequest = {
   recipe: editor.exportRecipe(),
   input: { backgroundImage: { src: '/source.png' } },
 };
 void result;
+void ImageMarkerEditor;
+void ImageMarkerEditorToolbar;
+void createCoreEditorAdapter;
+void editorProps;
+void toolbarProps;
 void request;
 void createInvisibleWatermarkRuntime;
 `


### PR DESCRIPTION
## Summary

- sync the reviewed Editor 0.1.0 package, examples, and native/component tests from PR #384
- add the public API contract and packed-consumer verification required for the release
- keep the historical release-branch website snapshot unchanged; the current website is deployed from master

## Validation

- npm run test:editor -- --runInBand
- npm run build:editor
- npm run check:editor-api
- npm run verify:consumer
- git diff --check origin/release/2.0...HEAD

After this merges, editor-v0.1.0 can be tagged from release/2.0 and published through trusted publishing.