### PR TITLE
fix(docs): align Editor version manifest

### DIFF
--- a/website/versions.json
+++ b/website/versions.json
@@ -30,12 +30,12 @@
     },
     {
       "id": "editor",
-      "label": "Editor 0.0.3",
+      "label": "Editor 0.1.0",
       "status": "experimental",
       "basePath": "/editor/",
       "source": "master",
-      "packageRange": "0.0.x",
-      "currentVersion": "0.0.3",
+      "packageRange": "0.1.x",
+      "currentVersion": "0.1.0",
       "peerCoreRange": "^2.0.0"
     }
   ]


### PR DESCRIPTION
## Summary

- update the version manifest from Editor 0.0.3 to 0.1.0
- align the displayed package range with the 0.1.x stabilization line
- unblock the versioned documentation deployment contract check

## Validation

- npm --prefix website run build
- git diff --check

The failed deployment was run 30437191067; its contract check compared packages/editor/package.json at 0.1.0 with the stale manifest value 0.0.3.