### PR TITLE
fix(docs): update Editor label in v1 site

### DIFF
--- a/website/src/components/VersionSelect.astro
+++ b/website/src/components/VersionSelect.astro
@@ -37,7 +37,7 @@ const v2Label = channel === 'current' ? 'v2 Current' : 'v2 Preview';
       v1.0.0 Archive
     </option>
     <option value={editorBase} selected={selected === 'editor'}>
-      Editor 0.0.x
+      Editor 0.1.0
     </option>
   </select>
 </label>

--- a/website/versions.json
+++ b/website/versions.json
@@ -30,11 +30,12 @@
     },
     {
       "id": "editor",
-      "label": "Editor 0.0.x",
+      "label": "Editor 0.1.0",
       "status": "experimental",
       "basePath": "/editor/",
       "source": "master",
-      "packageRange": "0.0.x",
+      "packageRange": "0.1.x",
+      "currentVersion": "0.1.0",
       "peerCoreRange": "^2.0.0"
     }
   ]


### PR DESCRIPTION
## Summary

- keep the protected v1 LTS site content and routes unchanged
- update its cross-version selector from the stale Editor 0.0.x label to Editor 0.1.0
- align the v1 site version manifest with the independently published Editor 0.1.x line

## Validation

- DOCS_CHANNEL=v1 DOCS_GIT_REF=release/1.x npm run docs
- 190 pages built
- 63 required pages, internal links, and custom domain verified
- git diff --check