### PR TITLE
fix(release): tolerate npm first-publish propagation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,7 +88,21 @@ jobs:
         working-directory: ${{ needs.resolve.outputs.package_path }}
         run: npm run prepack
 
+      - name: Check whether the exact version is already published
+        id: registry
+        env:
+          PACKAGE_NAME: ${{ needs.resolve.outputs.package_name }}
+          PACKAGE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          if npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version --json --prefer-online >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "$PACKAGE_NAME@$PACKAGE_VERSION is already public; continuing with verification."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish with provenance
+        if: steps.registry.outputs.published != 'true'
         working-directory: ${{ needs.resolve.outputs.package_path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -119,15 +133,21 @@ jobs:
           PACKAGE_NAME: ${{ needs.resolve.outputs.package_name }}
           PACKAGE_VERSION: ${{ needs.resolve.outputs.version }}
         run: |
-          for _ in $(seq 1 12); do
-            predicate_type="$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" dist.attestations.provenance.predicateType 2>/dev/null || true)"
+          for attempt in $(seq 1 36); do
+            predicate_type="$(
+              npm view "$PACKAGE_NAME@$PACKAGE_VERSION" \
+                dist.attestations.provenance.predicateType \
+                --prefer-online \
+                2>/dev/null || true
+            )"
             if [ "$predicate_type" = "https://slsa.dev/provenance/v1" ]; then
               echo "Verified provenance for $PACKAGE_NAME@$PACKAGE_VERSION"
               exit 0
             fi
+            echo "Registry metadata is not public yet (attempt $attempt/36)."
             sleep 5
           done
-          echo "Published package did not expose provenance metadata in time."
+          echo "Published package did not expose provenance metadata within three minutes."
           exit 1
 
       - name: Verify fresh registry consumer


### PR DESCRIPTION
## Summary
- skip `npm publish` when the exact version is already public, making release verification safely rerunnable
- extend provenance polling from one minute to three minutes for first-package registry propagation
- keep fresh registry-consumer verification mandatory

## Context
`@image-marker/node@0.1.0` published successfully with provenance, but the new package packument was not available through the public read path inside the original 60-second verification window.

## Verification
- `npm run verify:actions`
- `npm run test:ci-guards`
- `npm run test:release-routing`
- `actionlint .github/workflows/npm-publish.yml`
- `git diff --check`