### PR TITLE
fix(release): provide Node types to registry consumers

### DIFF
--- a/scripts/verify-registry-consumer.mjs
+++ b/scripts/verify-registry-consumer.mjs
@@ -49,6 +49,12 @@ try {
   if (packageName === 'react-native-image-marker-editor') {
     dependencies.push('react-native-image-marker@^2.1.0');
   }
+  if (
+    packageName === '@image-marker/node' ||
+    packageName === '@image-marker/cli'
+  ) {
+    dependencies.push('@types/node@22.15.0');
+  }
   if (packageName === '@image-marker/node') {
     dependencies.push('sharp@^0.35.3');
   }


### PR DESCRIPTION
## Summary

- install the Node.js type environment in fresh `@image-marker/node` and `@image-marker/cli` TypeScript consumer fixtures
- keep runtime dependency assertions unchanged
- unblock post-publish registry verification for both Node-only packages

## Verification

- `node --check scripts/verify-registry-consumer.mjs`
- `npm run verify:actions`
- `npm run test:ci-guards`
- `npm run test:release-routing`
- `git diff --check`

The previous failure was limited to the verification fixture: its consumer source uses `Buffer`, so a standalone TypeScript project must provide the Node type environment.