### PR TITLE
fix(release): use current registry verifier

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -150,9 +150,17 @@ jobs:
           echo "Published package did not expose provenance metadata within three minutes."
           exit 1
 
+      - name: Checkout the current registry consumer verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.resolve.outputs.branch }}
+          path: .release-verifier
+          sparse-checkout: scripts/verify-registry-consumer.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Verify fresh registry consumer
         run: >-
-          node scripts/verify-registry-consumer.mjs
+          node .release-verifier/scripts/verify-registry-consumer.mjs
           --package-name "${{ needs.resolve.outputs.package_name }}"
           --version "${{ needs.resolve.outputs.version }}"
           --channel "${{ needs.resolve.outputs.channel }}"


### PR DESCRIPTION
## Summary

- keep build and publish inputs pinned to the immutable release tag
- sparse-checkout the fresh-consumer verifier from the protected release branch
- allow already-published tags to benefit from release verification fixes without moving tags

## Verification

- `npm run verify:actions`
- `npm run test:ci-guards`
- `npm run test:release-routing`
- `actionlint .github/workflows/npm-publish.yml`
- `git diff --check`