### PR TITLE
release: promote Image Marker 2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,9 @@ jobs:
           ./gradlew assembleRelease
           mv app/build/outputs/apk/release/app-release.apk app-release-${{ github.sha }}.apk
 
+      - name: Verify Android 16 KB page-size support
+        run: npm run verify:android-page-size
+
       - name: Upload APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.1](https://github.com/JimmyDaddy/react-native-image-marker/compare/v2.1.0...v2.1.1) (2026-08-20)
+
+### Bug Fixes
+
+- **android:** support 16 KB page sizes ([475eef1](https://github.com/JimmyDaddy/react-native-image-marker/commit/475eef1c2a51150cbf546c25ba9dcf3d6d5e173e))
+- **release:** provide node types to registry consumers ([5a0567d](https://github.com/JimmyDaddy/react-native-image-marker/commit/5a0567d97e7de1c46f791dd7b87ebdd1d5f9359f))
+- **release:** tolerate npm first-publish propagation ([f7d021b](https://github.com/JimmyDaddy/react-native-image-marker/commit/f7d021b22e8397183eb776033a70cc0beb8fd048))
+- **release:** use current registry verifier ([0ab5167](https://github.com/JimmyDaddy/react-native-image-marker/commit/0ab5167fa7d4d1e7921c134d8bbd9dbb810d76d7))
+
 ## 2.1.0 (2026-07-30)
 
 ### Features

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -8,6 +8,14 @@ add_library(
 )
 
 target_compile_features(image-marker-core PRIVATE cxx_std_17)
+if(ANDROID)
+  target_link_options(
+    image-marker-core
+    PRIVATE
+    "-Wl,-z,max-page-size=16384"
+    "-Wl,-z,common-page-size=16384"
+  )
+endif()
 target_include_directories(
   image-marker-core
   PRIVATE

--- a/examples/c2pa-service/package-lock.json
+++ b/examples/c2pa-service/package-lock.json
@@ -102,9 +102,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/examples/c2pa-service/package.json
+++ b/examples/c2pa-service/package.json
@@ -23,6 +23,6 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }

--- a/expo-example/package-lock.json
+++ b/expo-example/package-lock.json
@@ -8,12 +8,12 @@
       "name": "expo-example",
       "version": "1.0.0",
       "dependencies": {
-        "@expo/metro-runtime": "~57.0.8",
-        "expo": "~57.0.9",
-        "expo-asset": "~57.0.8",
+        "@expo/metro-runtime": "~57.0.11",
+        "expo": "~57.0.14",
+        "expo-asset": "~57.0.12",
         "expo-font": "~57.0.1",
-        "expo-image-picker": "~57.0.7",
-        "expo-splash-screen": "~57.0.5",
+        "expo-image-picker": "~57.0.11",
+        "expo-splash-screen": "~57.0.7",
         "expo-status-bar": "~57.0.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -30,7 +30,7 @@
     },
     "..": {
       "name": "react-native-image-marker",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -18012,12 +18012,12 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-57.0.6.tgz",
-      "integrity": "sha512-VpMJpB/De/fb9bBFVVBiK6Ntg9lt0kAleLH9hcZz85CYRUQ3jVFVA8rNC5f8y4cp2+FiiPNFp62+kEOFI6pDiw==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-57.0.8.tgz",
+      "integrity": "sha512-7VpAu2ZMXNZI0+Kn+nD3vQBIyST89LATNkZpnp/cXh8/aj7zUXO8d/T+hOxsvhOFwR8eQO+jKXEw8tQbidiMxA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/json-file": "^11.0.1",
         "@expo/require-utils": "^57.0.4",
@@ -18030,9 +18030,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "57.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.6.tgz",
-      "integrity": "sha512-7CmKrS5Rnu8aSZyNlxH2qzA7Ls1HEa4EQvEVOAkHDKPr1e4Cg/nz7I7dUl09QDTVjMvkKYDH4Th0DuAsgqASaw==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-57.0.8.tgz",
+      "integrity": "sha512-x6lx4s/19i39/+1dMPwb9tFCc4WR843dG5Yi+C64lhKL3YHX+6oKrT2Kv72PCEalnUY+usQDkB3NrLSrYOWtDg==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^57.0.2",
@@ -18152,9 +18152,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.6.tgz",
-      "integrity": "sha512-cmC/6BOPRbdKr77Mgjwszb8aM0hY2RKBpMRCmjSdn9zIcn2FGor/ic4fHVr46cQFa1G6RDGg1GyAjRw3US4CCQ==",
+      "version": "0.20.9",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.20.9.tgz",
+      "integrity": "sha512-h+YvPyNmeAUCCqaXvftiXklA2zGyRcIPv1B8fFS0YSIgNhwcxFGh1EyLOMsvJ2aWsBViNtIJ1HIFLzNu43/r4w==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.4.2",
@@ -18213,12 +18213,12 @@
       }
     },
     "node_modules/@expo/inline-modules": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.1.4.tgz",
-      "integrity": "sha512-8bPSCm//dv8raYfrQ4x79rCX52vMw0QzmnYYl4eSOAvEbGvDPPRGGdbrhZZ7oihU+hI1sZNS5kYEgqODgFwfsw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.1.6.tgz",
+      "integrity": "sha512-5f6EiOIKsFj9zlrCBet4ZIQRPEa9dBUdQgTzpjYwdZ8Z/M8W5lqMVL9dEs4HYKvEmDnqv0dQuDkFLyRSwu/DAQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~57.0.6"
+        "@expo/config-plugins": "~57.0.8"
       }
     },
     "node_modules/@expo/json-file": {
@@ -18232,19 +18232,19 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.5.tgz",
-      "integrity": "sha512-OwiNC0Uxu67TOH7TEQ94GLa4oNzNfbbItKGdy3QMfX+hCSZv2VvjcjRo5vttMHfXCnXa9KZIu3GBS9pvtDHWhA==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-57.0.7.tgz",
+      "integrity": "sha512-Hq5xWhXJWuyH3CWh3uqDWoHtxM0XYqLs9h2OzRWImBJahCPfePOo4kmw2uTEB6qHT5T47eqO4jtDG3MRGGZCpw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.6",
+        "@expo/config": "~57.0.8",
         "chalk": "^4.1.2"
       }
     },
     "node_modules/@expo/log-box": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.2.tgz",
-      "integrity": "sha512-ZsFyfIR7YCbQAdVLzuTUmMHofZC7ZS9ywYCJNPlLc78x59cI8GwXFEIVbRjjC0uJERpNtXx/tsNNnkhexXlzMw==",
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.3.tgz",
+      "integrity": "sha512-qv/cMliNax6es07Un/4IGJIcs4PUuhTKKTrJZX/0X2YRcOT5cqm/QicibZwTIbiZWi1i8P4YBRQTfFT2B17giw==",
       "license": "MIT",
       "dependencies": {
         "@expo/dom-webview": "^57.0.1",
@@ -18281,15 +18281,15 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.7.tgz",
-      "integrity": "sha512-bVfEkg4zF1cA62OqAdYXmFOooJ6TB/I+REi7Se6Ct+PbSC+89TwSqWXnYx34L08eIs4z+1ilgbATakTZpgefmQ==",
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-57.0.9.tgz",
+      "integrity": "sha512-+lalXZdoMaKTG1uKXsi2KWO0f7H3KiWrhZzAla4EmNSkcUMRx6K1rhZuBYoaJaKIp9BHZ333KbqRPron7slKQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~57.0.6",
+        "@expo/config": "~57.0.8",
         "@expo/env": "~2.4.2",
         "@expo/json-file": "~11.0.1",
         "@expo/metro": "~56.0.0",
@@ -18334,19 +18334,19 @@
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-57.0.8.tgz",
-      "integrity": "sha512-RrdehKXNtWpnm8nNs1QFhS0IauyMKR/nSQiry6dcUJs2T5EH8gYDMcMegUt9yI41K4nO3W8tr3O0xd/GZFObXQ==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-57.0.12.tgz",
+      "integrity": "sha512-WpgjfRFh88B5tKJrbsypvyxx0MKuXMo+ru9Gbjq4Qwj7OboJmrQ+g555YCgiQD3uk3J1ThzgEU06yZOV43suGA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/log-box": "^57.0.2",
+        "@expo/log-box": "^57.0.3",
         "anser": "^1.4.9",
         "pretty-format": "^29.7.0",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@expo/log-box": "^57.0.2",
+        "@expo/log-box": "^57.0.3",
         "expo": "*",
         "react": "*",
         "react-dom": "*",
@@ -18396,19 +18396,19 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "57.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.10.tgz",
-      "integrity": "sha512-myrS5NolFAQWD8g7QuqkettnkyJx3GRl603N6rlmqAMxmO5EU7sZu4EX2EsIKkva8QtpX84B0E17PsM9xXMsTQ==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-57.0.13.tgz",
+      "integrity": "sha512-VhSySuXqOwK4fIc+9rgms7zN+c1Khj2xpuIgpVLPNyWRtpS8wB+eyV5CSohjSUBa3h+NsFdPk/VG6p0ZwlMDrg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config": "~57.0.8",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/config-types": "^57.0.2",
         "@expo/image-utils": "^0.11.4",
         "@expo/json-file": "^11.0.1",
         "@react-native/normalize-colors": "0.86.2",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~57.0.9",
+        "expo-modules-autolinking": "~57.0.10",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
@@ -18816,9 +18816,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18869,9 +18869,9 @@
       }
     },
     "node_modules/agent-cli-detector": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.4.tgz",
-      "integrity": "sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/agent-cli-detector/-/agent-cli-detector-0.1.6.tgz",
+      "integrity": "sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==",
       "license": "MIT",
       "bin": {
         "agent-cli-detector": "dist/cli.js"
@@ -19022,9 +19022,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.5.tgz",
-      "integrity": "sha512-sz9ZBTiUAlu5P9VORVNKoeAaY2qKFQRC6eQV5Y8aMkqcorvXKEv97UeCkFMLmMBEPKA+QeWImREKkX9/H21WQA==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.7.tgz",
+      "integrity": "sha512-/1RLnZTJVoTNo6nCdSv27BSA2LBzM/qEkNLznwWvztg64DhsAz7ByZIiAqdbau9FK3YqF+IV5a2ZsPXFclwq4A==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.20.5",
@@ -19073,7 +19073,7 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
-        "expo-widgets": "^57.0.7",
+        "expo-widgets": "^57.0.10",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -19116,7 +19116,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+      "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -19136,6 +19138,8 @@
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+      "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
       "license": "MIT",
       "dependencies": {
         "stream-buffers": "2.2.x"
@@ -19154,15 +19158,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -19178,7 +19182,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -19195,11 +19201,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -19245,7 +19251,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19472,12 +19480,15 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19596,7 +19607,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
+      "version": "1.5.411",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+      "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -19674,31 +19687,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.9.tgz",
-      "integrity": "sha512-NDEvnU+vjRdMbtOyDC25OSok9/E97al97pyx+bMphQgNRGAED0D7oF8ha7oGYsLE+7jFzpPADVM9S60dGbpHIA==",
+      "version": "57.0.15",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.15.tgz",
+      "integrity": "sha512-9UooISw8S8Gxo9wpsPcGkyRlf2UzNr+F26LSU2+M8iaiZ1WAjPR0I75NKFX8ETbrSgthZ2lQHgy5IU2KE/mpBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^57.0.11",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/cli": "^57.0.17",
+        "@expo/config": "~57.0.8",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/devtools": "~57.0.1",
         "@expo/dom-webview": "~57.0.1",
-        "@expo/fingerprint": "^0.20.6",
-        "@expo/local-build-cache-provider": "^57.0.5",
-        "@expo/log-box": "^57.0.2",
+        "@expo/fingerprint": "^0.20.9",
+        "@expo/local-build-cache-provider": "^57.0.7",
+        "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
+        "@expo/metro-config": "~57.0.9",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~57.0.5",
-        "expo-asset": "~57.0.8",
-        "expo-constants": "~57.0.8",
-        "expo-file-system": "~57.0.1",
+        "babel-preset-expo": "~57.0.7",
+        "expo-asset": "~57.0.13",
+        "expo-constants": "~57.0.13",
+        "expo-file-system": "~57.0.5",
         "expo-font": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
-        "expo-modules-autolinking": "~57.0.9",
-        "expo-modules-core": "~57.0.8",
+        "expo-modules-autolinking": "~57.0.10",
+        "expo-modules-core": "~57.0.12",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -19736,13 +19749,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.8.tgz",
-      "integrity": "sha512-sGocG+Wd2WcZ1KjKyB2LfUZXzrBM0VHEATGcpJKF9T3HM56M/sMbH73vv+n85u5Zr0FkJjEbV1DWhGPimCR1QQ==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-57.0.13.tgz",
+      "integrity": "sha512-RPjMcmPXRMb6UbQdTIkmSDEnQL5LKGTu7ZXatq3U67V6ldlSdQeQ9pQV7zlmk0DrbnaMEh3HYiEh2YxWLNyCzA==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.11.4",
-        "expo-constants": "~57.0.8"
+        "expo-constants": "~57.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -19751,9 +19764,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.8.tgz",
-      "integrity": "sha512-ts+B7E5076BtkblrKGy7+Sm/R2obHfTwqhmYQVYbWRtilv3+C/xNwHZhyNEnAvzM/JjKqx7UdaITUBYaeFreZw==",
+      "version": "57.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-57.0.13.tgz",
+      "integrity": "sha512-eB5AHp7kKxsVIBjTetUgj5WQSw8joI2ekzgTlcUv+Hc0x2t0jZU6IiL4DpyOT2yZQ71n0WJZCkmOKLgxlajIzg==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.4.2"
@@ -19764,9 +19777,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.1.tgz",
-      "integrity": "sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.5.tgz",
+      "integrity": "sha512-XjGrCClF0935y5wLB9qNQQUVptNEy+0OloBstXlCd+IeNXLo3uNOod6cX4N0hofIhNIrN1Al8fwfay7R0Z1a2A==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -19797,9 +19810,9 @@
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "57.0.7",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-57.0.7.tgz",
-      "integrity": "sha512-aPZis1VeeAOeWrM/VID/As7/hF/WM6egtN2AUY+ODV97oBKfAZcGHMw7MR/5BoEy3HXzR5n1ZSYMEwnHBhICvg==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-57.0.12.tgz",
+      "integrity": "sha512-BjZLioItcDNrXwp46XZDZGDEUJ16/bK0QzxPjdNijiPYpLfQLeuFYoX9yH31sosnli0UL++x4ndYQoTMsICdlw==",
       "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~57.0.1"
@@ -19819,9 +19832,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "57.0.9",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-57.0.9.tgz",
-      "integrity": "sha512-lj2nsAKMMRLXSFnGgaaQrWJ2fdSpLPc/bca6Rkiw4g8zYPn7qX4MRUJgavvzm/hBrzvMnlhXVgJtidOGuwBh+w==",
+      "version": "57.0.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-57.0.10.tgz",
+      "integrity": "sha512-jNqLswMx8QHN8VXRgud+xT+9q+J9U63CEGlx+k4V/IE9Qyt9HrKbWp+pIDma0fOquta5HBfSfsShcI+NkEpTiA==",
       "license": "MIT",
       "dependencies": {
         "@expo/require-utils": "^57.0.4",
@@ -19834,13 +19847,13 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "57.0.8",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.8.tgz",
-      "integrity": "sha512-ZUU943Oso3B8jFggC+2+LOk8oa+im66IQlleYay6WP5iexbdF2fqpgC4BcYsN4xhCkDKh7KDINSt1FlcxyRRjQ==",
+      "version": "57.0.12",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.12.tgz",
+      "integrity": "sha512-hKqCdu8+78oNKWCgM4xSeblfmD/audgNVCn6uUCJuNBS/hc4DyC0Ia1X96SSZF9w9bGTLjNS8j2b7DshiC3WJA==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.6.1",
-        "expo-modules-jsi": "~57.0.4",
+        "expo-modules-jsi": "~57.0.5",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -19855,30 +19868,30 @@
       }
     },
     "node_modules/expo-modules-jsi": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.4.tgz",
-      "integrity": "sha512-vt7FyqUqqFXiRVnBqYD7y+GSPTgeua5Ocoy0+SYt+RSHkZEA2Fyop7If3g1TYDzQObYybPRo7TG2Rle1XLaWFw==",
+      "version": "57.0.5",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.5.tgz",
+      "integrity": "sha512-NQF7MUF0j3rQHV8KJqETYA1SrJr3USvQ/AWEhODo+unMRFBDP9BKpn8+aNGGmx6fa2XLnqC2qulVw4DT6Gp13Q==",
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
       }
     },
     "node_modules/expo-server": {
-      "version": "57.0.1",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.1.tgz",
-      "integrity": "sha512-sBfVDH6dmKVHZxqUxbfkzS00PZELMZt1IpnHKxcOTMZtR/t7CtRAFrbXcisG+EyzeqHSVDacZT+1tbYfZt5D8w==",
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-57.0.3.tgz",
+      "integrity": "sha512-aK+LdKzauHSGmsOStZtyxdzv0zWssCkxTw3m4QuOhfDSJsZaMRTd9O41d8ixU/QfELTbaJ0oRNcF7JFV/7O9YQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "57.0.5",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-57.0.5.tgz",
-      "integrity": "sha512-ZN0LDXlhHRNFjXTYZDojXk8IfaoUIu7qa3hhoBTXgyj1UB/iewGlH6+M3Nvhun2lY2d/+xhwqMhv0hIRoBo09Q==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-57.0.7.tgz",
+      "integrity": "sha512-QxqfjOCTnTGnqK2BxfEtxUJOcnsJbUXO873Q342r3VkgHAG877eozsNzgYWQXcCFj/asMwx2uy9OXxBShxc5rQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/image-utils": "^0.11.4",
         "xml2js": "0.6.0"
       },
@@ -19898,36 +19911,36 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "57.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.11.tgz",
-      "integrity": "sha512-ENXCwRyL8Q9qbabUmm0L6w9kXTmdGotW7eDEEWmUDXLPux+nEzNDqw0MzWQ5K3ZsXS51QmUJZg5yETB+6SnNRg==",
+      "version": "57.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-57.0.17.tgz",
+      "integrity": "sha512-PQc7if117dNh2qe+CHdlmSWpgwhFiP9CJ7XbwNF0w4KSKxFpJ2qUjDPoAcCMW1VZg1x30mEJ907bT8G1iDIZBQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~57.0.6",
-        "@expo/config-plugins": "~57.0.6",
+        "@expo/config": "~57.0.8",
+        "@expo/config-plugins": "~57.0.8",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.4.2",
         "@expo/image-utils": "^0.11.4",
-        "@expo/inline-modules": "^0.1.4",
+        "@expo/inline-modules": "^0.1.6",
         "@expo/json-file": "^11.0.1",
-        "@expo/log-box": "^57.0.2",
+        "@expo/log-box": "^57.0.3",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~57.0.7",
+        "@expo/metro-config": "~57.0.9",
         "@expo/metro-file-map": "^57.0.1",
         "@expo/osascript": "^2.7.1",
         "@expo/package-manager": "^1.13.1",
         "@expo/plist": "^0.8.1",
-        "@expo/prebuild-config": "^57.0.10",
+        "@expo/prebuild-config": "^57.0.13",
         "@expo/require-utils": "^57.0.4",
-        "@expo/router-server": "^57.0.4",
+        "@expo/router-server": "^57.0.7",
         "@expo/schema-utils": "^57.0.2",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^2.0.0",
         "@expo/xcpretty": "^4.4.4",
         "@react-native/dev-middleware": "0.86.2",
         "accepts": "^1.3.8",
-        "agent-cli-detector": "^0.1.2",
+        "agent-cli-detector": "0.1.6",
         "arg": "^5.0.2",
         "bplist-creator": "0.1.0",
         "bplist-parser": "^0.3.1",
@@ -19937,12 +19950,12 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "dnssd-advertise": "^1.1.4",
-        "expo-server": "^57.0.1",
+        "expo-server": "^57.0.3",
         "fetch-nodeshim": "^0.4.10",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "lan-network": "^0.2.1",
-        "multitars": "^1.0.0",
+        "multitars": "^1.0.2",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
@@ -19951,6 +19964,7 @@
         "progress": "^2.0.3",
         "prompts": "^2.3.2",
         "resolve-from": "^5.0.0",
+        "sandbox-cli-detector": "^0.2.0",
         "semver": "^7.6.0",
         "send": "^0.19.0",
         "slugify": "^1.3.4",
@@ -19980,20 +19994,20 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "57.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.4.tgz",
-      "integrity": "sha512-ucqCP0hK8nZb9+S8QJYdQxNCkfRClzkKdg2RpWYDKDYgRIHyoRyxEDRgDgvbhH+q78yfY83abU8OTx8MMOrf1g==",
+      "version": "57.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-57.0.7.tgz",
+      "integrity": "sha512-QFHwt6V7UovmYA7+8BoMeKj3fh6WtkM9zksKjNAlZdcEI/hUhcW4uged6So5yc4tq+eA60kA7gIVZPKgBIZdrQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^57.0.7",
+        "@expo/metro-runtime": "^57.0.12",
         "expo": "*",
-        "expo-constants": "^57.0.7",
+        "expo-constants": "^57.0.13",
         "expo-font": "^57.0.1",
         "expo-router": "*",
-        "expo-server": "^57.0.1",
+        "expo-server": "^57.0.3",
         "react": "*",
         "react-dom": "*",
         "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
@@ -20093,9 +20107,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -20361,6 +20375,12 @@
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -20635,9 +20655,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -21089,10 +21109,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -21489,12 +21512,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -21529,15 +21552,15 @@
       "license": "MIT"
     },
     "node_modules/multitars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.0.tgz",
-      "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.2.tgz",
+      "integrity": "sha512-6GwVw5eLi9sThdtlS4PKwC7yRLaf45pYhIEzKBHdKxi+YOXGKFX8acIniH+Uh/+k9mS2lQOupTccjoe5r0/1IQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -21595,7 +21618,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -21861,15 +21886,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
@@ -21948,9 +21964,9 @@
       }
     },
     "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -21966,9 +21982,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -21985,7 +22001,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -22376,8 +22392,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sandbox-cli-detector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sandbox-cli-detector/-/sandbox-cli-detector-0.2.0.tgz",
+      "integrity": "sha512-4lyHX0ZU0AZKwjgZ1InxZAa3PNpyEb8rOQ+Zss1ReYmhNzW0Q+h1zE5nvniXN0HaAWZaZE1zgVNEirb0R7LmNg==",
+      "license": "MIT",
+      "bin": {
+        "sandbox-cli-detector": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
     "node_modules/sax": {
-      "version": "1.6.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -22566,6 +22596,8 @@
     },
     "node_modules/slugify": {
       "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -22635,6 +22667,8 @@
     },
     "node_modules/stream-buffers": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
@@ -22913,7 +22947,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -23089,6 +23125,8 @@
     },
     "node_modules/xml2js": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -23100,6 +23138,8 @@
     },
     "node_modules/xml2js/node_modules/xmlbuilder": {
       "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "license": "MIT",
       "engines": {
         "node": ">=4.0"

--- a/expo-example/package.json
+++ b/expo-example/package.json
@@ -15,12 +15,12 @@
     "expo-install": "npx expo install"
   },
   "dependencies": {
-    "@expo/metro-runtime": "~57.0.8",
-    "expo": "~57.0.9",
-    "expo-asset": "~57.0.8",
+    "@expo/metro-runtime": "~57.0.11",
+    "expo": "~57.0.14",
+    "expo-asset": "~57.0.12",
     "expo-font": "~57.0.1",
-    "expo-image-picker": "~57.0.7",
-    "expo-splash-screen": "~57.0.5",
+    "expo-image-picker": "~57.0.11",
+    "expo-splash-screen": "~57.0.7",
     "expo-status-bar": "~57.0.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "react-native-image-marker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "react-native-image-marker",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-marker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packageManager": "npm@10.9.4",
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test:ci-guards": "node --test scripts/__tests__/verify-github-actions.test.mjs scripts/__tests__/verify-size-budgets.test.mjs",
+    "test:ci-guards": "node --test scripts/__tests__/verify-android-page-size.test.mjs scripts/__tests__/verify-github-actions.test.mjs scripts/__tests__/verify-size-budgets.test.mjs",
     "test:release-routing": "node --test scripts/__tests__/release-target.test.mjs",
     "test:web": "jest src/__tests__/web-marker.test.ts src/__tests__/web-marker-api.test.ts src/__tests__/web-marker-render.test.ts src/__tests__/invisible-worker-client.test.ts --runInBand",
     "test:editor": "npm test --workspace react-native-image-marker-editor",
@@ -88,6 +88,7 @@
     "check:editor-api": "npm run check:api --workspace react-native-image-marker-editor",
     "verify:consumer": "npm run prepack && npm run build:editor && npm run build:node && npm run build:cli && node scripts/verify-package-consumer.mjs",
     "verify:actions": "node scripts/verify-github-actions.mjs",
+    "verify:android-page-size": "node scripts/verify-android-page-size.mjs android/build/intermediates/stripped_native_libs/release/out/lib/arm64-v8a/libimage-marker-core.so android/build/intermediates/stripped_native_libs/release/out/lib/armeabi-v7a/libimage-marker-core.so android/build/intermediates/stripped_native_libs/release/out/lib/x86/libimage-marker-core.so android/build/intermediates/stripped_native_libs/release/out/lib/x86_64/libimage-marker-core.so",
     "verify:size:core": "node scripts/verify-size-budgets.mjs core",
     "verify:size:editor": "node scripts/verify-size-budgets.mjs editor",
     "verify:size:cli": "node scripts/verify-size-budgets.mjs cli",

--- a/scripts/__tests__/verify-android-page-size.test.mjs
+++ b/scripts/__tests__/verify-android-page-size.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  MIN_ANDROID_PAGE_SIZE,
+  readLoadAlignments,
+  verifyAndroidPageSize,
+} from '../verify-android-page-size.mjs';
+
+function createElf({ elfClass = 2, alignments }) {
+  const is64Bit = elfClass === 2;
+  const headerSize = is64Bit ? 64 : 52;
+  const programHeaderSize = is64Bit ? 56 : 32;
+  const buffer = Buffer.alloc(
+    headerSize + programHeaderSize * alignments.length
+  );
+  Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(buffer);
+  buffer[4] = elfClass;
+  buffer[5] = 1;
+
+  if (is64Bit) {
+    buffer.writeBigUInt64LE(BigInt(headerSize), 32);
+    buffer.writeUInt16LE(programHeaderSize, 54);
+    buffer.writeUInt16LE(alignments.length, 56);
+  } else {
+    buffer.writeUInt32LE(headerSize, 28);
+    buffer.writeUInt16LE(programHeaderSize, 42);
+    buffer.writeUInt16LE(alignments.length, 44);
+  }
+
+  alignments.forEach((alignment, index) => {
+    const entryOffset = headerSize + index * programHeaderSize;
+    buffer.writeUInt32LE(1, entryOffset);
+    if (is64Bit) {
+      buffer.writeBigUInt64LE(BigInt(alignment), entryOffset + 48);
+    } else {
+      buffer.writeUInt32LE(Number(alignment), entryOffset + 28);
+    }
+  });
+  return buffer;
+}
+
+test('reads LOAD alignment from 32-bit and 64-bit Android ELF files', () => {
+  assert.deepEqual(
+    readLoadAlignments(createElf({ elfClass: 1, alignments: [16_384] })),
+    [MIN_ANDROID_PAGE_SIZE]
+  );
+  assert.deepEqual(
+    readLoadAlignments(
+      createElf({ elfClass: 2, alignments: [16_384, 65_536] })
+    ),
+    [MIN_ANDROID_PAGE_SIZE, 65_536n]
+  );
+});
+
+test('rejects a native library with 4 KB LOAD alignment', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'image-marker-page-size-')
+  );
+  const libraryPath = path.join(root, 'libimage-marker-core.so');
+  fs.writeFileSync(libraryPath, createElf({ alignments: [4_096] }));
+
+  try {
+    assert.throws(
+      () => verifyAndroidPageSize([root]),
+      /LOAD alignment 0x1000; expected at least 0x4000/
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('accepts every matching native library when all LOAD segments align', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'image-marker-page-size-')
+  );
+  for (const abi of ['arm64-v8a', 'x86_64']) {
+    const directory = path.join(root, abi);
+    fs.mkdirSync(directory);
+    fs.writeFileSync(
+      path.join(directory, 'libimage-marker-core.so'),
+      createElf({ alignments: [16_384, 16_384] })
+    );
+  }
+
+  try {
+    const results = verifyAndroidPageSize([root]);
+    assert.equal(results.length, 2);
+    assert.ok(
+      results.every(({ alignments }) =>
+        alignments.every((alignment) => alignment >= MIN_ANDROID_PAGE_SIZE)
+      )
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-android-page-size.mjs
+++ b/scripts/verify-android-page-size.mjs
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+const ELF_CLASS_32 = 1;
+const ELF_CLASS_64 = 2;
+const ELF_DATA_LITTLE_ENDIAN = 1;
+const PT_LOAD = 1;
+export const MIN_ANDROID_PAGE_SIZE = 16_384n;
+
+function assertRange(buffer, offset, length, label) {
+  if (offset < 0 || length < 0 || offset + length > buffer.length) {
+    throw new Error(`${label} is outside the ELF file.`);
+  }
+}
+
+function toSafeNumber(value, label) {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`${label} exceeds the supported file size.`);
+  }
+  return Number(value);
+}
+
+export function readLoadAlignments(buffer) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new TypeError('Expected an ELF file buffer.');
+  }
+  assertRange(buffer, 0, 16, 'ELF identification');
+  if (!buffer.subarray(0, ELF_MAGIC.length).equals(ELF_MAGIC)) {
+    throw new Error('File is not an ELF binary.');
+  }
+  if (buffer[5] !== ELF_DATA_LITTLE_ENDIAN) {
+    throw new Error('Only little-endian Android ELF binaries are supported.');
+  }
+
+  const elfClass = buffer[4];
+  let programHeaderOffset;
+  let programHeaderEntrySize;
+  let programHeaderCount;
+  let alignmentOffset;
+  let alignmentSize;
+
+  if (elfClass === ELF_CLASS_32) {
+    assertRange(buffer, 0, 52, 'ELF32 header');
+    programHeaderOffset = buffer.readUInt32LE(28);
+    programHeaderEntrySize = buffer.readUInt16LE(42);
+    programHeaderCount = buffer.readUInt16LE(44);
+    alignmentOffset = 28;
+    alignmentSize = 4;
+  } else if (elfClass === ELF_CLASS_64) {
+    assertRange(buffer, 0, 64, 'ELF64 header');
+    programHeaderOffset = toSafeNumber(
+      buffer.readBigUInt64LE(32),
+      'Program header offset'
+    );
+    programHeaderEntrySize = buffer.readUInt16LE(54);
+    programHeaderCount = buffer.readUInt16LE(56);
+    alignmentOffset = 48;
+    alignmentSize = 8;
+  } else {
+    throw new Error(`Unsupported ELF class ${String(elfClass)}.`);
+  }
+
+  if (programHeaderEntrySize < alignmentOffset + alignmentSize) {
+    throw new Error('ELF program header entry is too small.');
+  }
+
+  const alignments = [];
+  for (let index = 0; index < programHeaderCount; index += 1) {
+    const entryOffset = programHeaderOffset + index * programHeaderEntrySize;
+    assertRange(
+      buffer,
+      entryOffset,
+      programHeaderEntrySize,
+      `Program header ${index}`
+    );
+    if (buffer.readUInt32LE(entryOffset) !== PT_LOAD) {
+      continue;
+    }
+    const offset = entryOffset + alignmentOffset;
+    alignments.push(
+      alignmentSize === 8
+        ? buffer.readBigUInt64LE(offset)
+        : BigInt(buffer.readUInt32LE(offset))
+    );
+  }
+
+  if (alignments.length === 0) {
+    throw new Error('ELF binary has no loadable segments.');
+  }
+  return alignments;
+}
+
+function collectLibraries(inputPath) {
+  const resolvedPath = path.resolve(inputPath);
+  const stat = fs.statSync(resolvedPath);
+  if (stat.isFile()) {
+    return path.basename(resolvedPath) === 'libimage-marker-core.so'
+      ? [resolvedPath]
+      : [];
+  }
+  if (!stat.isDirectory()) {
+    return [];
+  }
+
+  const libraries = [];
+  for (const entry of fs.readdirSync(resolvedPath, { withFileTypes: true })) {
+    const entryPath = path.join(resolvedPath, entry.name);
+    if (entry.isDirectory()) {
+      libraries.push(...collectLibraries(entryPath));
+    } else if (entry.isFile() && entry.name === 'libimage-marker-core.so') {
+      libraries.push(entryPath);
+    }
+  }
+  return libraries;
+}
+
+export function verifyAndroidPageSize(inputPaths) {
+  if (!Array.isArray(inputPaths) || inputPaths.length === 0) {
+    throw new Error('Provide at least one Android native library path.');
+  }
+
+  const libraries = [
+    ...new Set(inputPaths.flatMap((inputPath) => collectLibraries(inputPath))),
+  ].sort();
+  if (libraries.length === 0) {
+    throw new Error('No libimage-marker-core.so files were found.');
+  }
+
+  return libraries.map((libraryPath) => {
+    const alignments = readLoadAlignments(fs.readFileSync(libraryPath));
+    const invalid = alignments.filter(
+      (alignment) => alignment < MIN_ANDROID_PAGE_SIZE
+    );
+    if (invalid.length > 0) {
+      throw new Error(
+        `${libraryPath} has LOAD alignment ${invalid
+          .map((alignment) => `0x${alignment.toString(16)}`)
+          .join(', ')}; expected at least 0x${MIN_ANDROID_PAGE_SIZE.toString(
+          16
+        )}.`
+      );
+    }
+    return { libraryPath, alignments };
+  });
+}
+
+function isMainModule() {
+  return (
+    typeof process.argv[1] === 'string' &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+  );
+}
+
+if (isMainModule()) {
+  try {
+    const results = verifyAndroidPageSize(process.argv.slice(2));
+    for (const { libraryPath, alignments } of results) {
+      process.stdout.write(
+        `Verified ${libraryPath}: ${alignments
+          .map((alignment) => `0x${alignment.toString(16)}`)
+          .join(', ')} LOAD alignment.\n`
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- promote the published 2.1.1 release from release/2.0 to master
- add Android 16 KB ELF page-size alignment for all supported ABIs
- add CI verification for native library alignment
- refresh Expo and C2PA CI fixtures required by the current dependency baseline

## Verification

- Complete CI passed on #410
- Android API 24 and 31 instrumentation tests passed
- RN 0.73 Legacy and New Architecture APK builds passed
- all four ABI libraries reported 0x4000 LOAD alignment
- npm trusted publishing and fresh registry consumer verification passed
- npm latest resolves to 2.1.1 with SLSA provenance

Closes #409.